### PR TITLE
Fixed warnings in views when using a non-SQL datasource (REST)

### DIFF
--- a/controllers/components/toolbar.php
+++ b/controllers/components/toolbar.php
@@ -552,16 +552,12 @@ class SqlLogPanel extends DebugPanel {
 		$dbConfigs = ConnectionManager::sourceList();
 		foreach ($dbConfigs as $configName) {
 			$db =& ConnectionManager::getDataSource($configName);
-			if (!isset($db->config['driver'])) {
+			if (!isset($db->config['driver']) || !$db->isInterfaceSupported('getLog')) {
 				return false;
 			}
 			$driver = $db->config['driver'];
-			$explain = false;
 			$isExplainable = ($driver === 'mysql' || $driver === 'mysqli' || $driver === 'postgres');
-			if ($isExplainable && $db->isInterfaceSupported('getLog')) {
-				$explain = true;
-			}
-			$connections[$configName] = $explain;
+			$connections[$configName] = $isExplainable;
 		}
 		return array('connections' => $connections, 'threshold' => $this->slowRate);
 	}

--- a/views/helpers/toolbar.php
+++ b/views/helpers/toolbar.php
@@ -141,7 +141,9 @@ class ToolbarHelper extends AppHelper {
 		$options += array('explain' => false, 'cache' => true, 'threshold' => 20);
 		App::import('Model', 'ConnectionManager');
 		$db =& ConnectionManager::getDataSource($connection);
-		
+		if (!$db->isInterfaceSupported('getLog')) {
+			return false;
+		}
 		$out = array();
 		$log = $db->getLog();
 		foreach ($log['log'] as $i => $query) {


### PR DESCRIPTION
Hi, I was using a REST datasource and I noticed some warnings in the sql panel (invalid argument for foreach, or similar). To resolve this, I added in the toolbar component and helper an if to check if the datasource support the getLog method. This was already done in other places, but not in the helper.

Thanks.
