### PR TITLE
eclipse php validation

### DIFF
--- a/views/elements/debug_toolbar.ctp
+++ b/views/elements/debug_toolbar.ctp
@@ -52,7 +52,7 @@
 				</div>
 			<?php $toolbar->panelEnd(); ?>
 			</li>
-		<?php endforeach ?>
+		<?php endforeach; ?>
 		</ul>
 	<?php endif; ?>
 </div>


### PR DESCRIPTION
The phpeclipse plugin for eclipse iDE is showing this as a sintax error.
