### PR TITLE
Add skip for cases where DoppelGangerView class is already defined.

### DIFF
--- a/tests/cases/controllers/components/toolbar.test.php
+++ b/tests/cases/controllers/components/toolbar.test.php
@@ -131,9 +131,16 @@ class DebugToolbarTestCase extends CakeTestCase {
 /**
  * test generating a DoppelGangerView with a pluginView.
  *
+ * If $this->Controller->Toolbar->startup() has been previously called,
+ * DoppelGangerView class has already been defined.
+ *
  * @return void
  **/
 	function testPluginViewParsing() {
+		if (class_exists('DoppelGangerView')) {
+			$this->skipIf(true, 'Class DoppelGangerView already defined, skipping %s');
+			return;
+		}
 		App::import('Vendor', 'DebugKit.DebugKitDebugger');
 		$this->Controller->Toolbar->evalTest = true;
 		$this->Controller->view = 'Plugin.OtherView';


### PR DESCRIPTION
If $this->Controller->Toolbar->startup() has been previously called, from a requestAction (for example), DoppelGangerView class has already been defined and the test fails.
