### PR TITLE
Fixed an issue with AssetCompress+DebugKit integration

### DIFF
--- a/controllers/components/toolbar.php
+++ b/controllers/components/toolbar.php
@@ -203,6 +203,9 @@ class ToolbarComponent extends Object {
  * @return void
  **/
 	function beforeRender(&$controller) {
+		if (!class_exists('DebugKitDebugger')) {
+			return null;
+		}
 		DebugKitDebugger::stopTimer('controllerAction');
 		$vars = $this->_gatherVars($controller);
 		$this->_saveState($controller, $vars);


### PR DESCRIPTION
In cases where the following code is in use:

<pre><code><?php class AppController extends Controller {
    public function __construct() {
        if (Configure::read('debug')) {
            $this->components[] = 'DebugKit.Toolbar';
        }
        parent::__construct();
    }
}</code></pre>


AssetCompress throws a wobbly with the following error message:

<pre><code>
Fatal error: Class 'DebugKitDebugger' not found in /Users/jose/Sites/work/test/app/plugins/debug_kit/controllers/components/toolbar.php on line 206

Call Stack:
    0.0007     634848   1. {main}() /Users/jose/Sites/work/test/app/webroot/index.php:0
    0.0918    1604856   2. Dispatcher->dispatch() /Users/jose/Sites/work/test/app/webroot/index.php:83
    0.2000    1788136   3. Dispatcher->_invoke() /Users/jose/Sites/work/test/cake/dispatcher.php:171
    0.2365    2596568   4. call_user_func_array() /Users/jose/Sites/work/test/cake/dispatcher.php:204
    0.2365    2596952   5. CssFilesController->get() /Users/jose/Sites/work/test/cake/dispatcher.php:0
    0.2497    2608336   6. Controller->render() /Users/jose/Sites/work/test/app/plugins/asset_compress/controllers/css_files_controller.php:62
    0.2497    2608560   7. Component->triggerCallback() /Users/jose/Sites/work/test/cake/libs/controller/controller.php:864
    0.2498    2608608   8. ToolbarComponent->beforeRender() /Users/jose/Sites/work/test/cake/libs/controller/component.php:186
</code></pre>


Moving `DebugKit.Toolbar` to the array of components as is normally done fixes the issue. I'm not quite able to ascertain why this error exists, but it at least has to do with the overriding of `startupProcess()` in the `AssetCompressAppController`.

With the check in my pull request, this issue is obviated, and DebugKit plays nicely with AssetCompress.
