### PR TITLE
Remove invisible padding

### DIFF
--- a/webroot/css/debug_toolbar.css
+++ b/webroot/css/debug_toolbar.css
@@ -21,6 +21,7 @@
 	float: right;
 	list-style: none;
 	margin: 0;
+	padding: 0;
 }
 #debug-kit-toolbar .panel-tab {
 	clear: none;


### PR DESCRIPTION
The padding prevents clicks on the layer below the toolbar (in Google Chrome). 
Which in my case was the close button from dialog-window.
