### PR TITLE
Added CakePlugin::load() to installation instructions

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -5,6 +5,7 @@ DebugKit provides a debugging toolbar and enhanced debugging tools for CakePHP a
 ## Installation
 
 * Clone/Copy the files in this directory into `app/Plugin/DebugKit`
+* Ensure the plugin is loaded in `app/Config/bootstrap.php` by calling `CakePlugin::load('DebugKit');`
 * Include the toolbar component in your `AppController.php`:
    * `public $components = array('DebugKit.Toolbar');`
 * Set debug mode to at least 1.


### PR DESCRIPTION
Instructions did not mention loading the plugin, which is probably helpful for new users.
