### PR TITLE
Fix for PHP Notice

### DIFF
--- a/Lib/Panel/EnvironmentPanel.php
+++ b/Lib/Panel/EnvironmentPanel.php
@@ -23,8 +23,8 @@ class EnvironmentPanel extends DebugPanel {
 
 		// PHP Data
 		$phpVer = phpversion();
-		unset($return['php']['argv']);
 		$return['php'] = array_merge(array('PHP_VERSION' => $phpVer), $_SERVER);
+		unset($return['php']['argv']);
 
 		// CakePHP Data
 		$return['cake'] = array(


### PR DESCRIPTION
This is a fix for a PHP notice found by Ceeram.  Seems to be limited to 5.3.3-7+squeeze9 as I cannot replicate on my end.  Details in the comments.

https://github.com/cakephp/debug_kit/commit/3735a59c3c063a9be76ecb9cb862bfe9fcafb5cc#commitcomment-1632691
