### PR TITLE
Split the trace output for FireCake to make it easier to read

### DIFF
--- a/Lib/DebugKitDebugger.php
+++ b/Lib/DebugKitDebugger.php
@@ -218,7 +218,7 @@ class DebugKitDebugger extends Debugger {
 			FireCake::log($data['context'], 'Context');
 		}
 		if (isset($data['trace'])) {
-			FireCake::log($data['trace'], 'Trace');
+			FireCake::log(preg_split('/[\r\n]+/',$data['trace']), 'Trace');
 		}
 		FireCake::groupEnd();
 	}


### PR DESCRIPTION
As the title says.

I currently see stack trace in Firebug as a string without newlines. I'm not sure if newlines worked before but at least now they don't work anymore.
