### PR TITLE
Map actions in ToolbarAccess controller

### DIFF
--- a/Controller/ToolbarAccessController.php
+++ b/Controller/ToolbarAccessController.php
@@ -67,6 +67,12 @@ class ToolbarAccessController extends DebugKitAppController {
 		}
 		$this->helpers['DebugKit.Toolbar']['cacheKey'] = $this->Toolbar->cacheKey;
 		$this->helpers['DebugKit.Toolbar']['cacheConfig'] = 'debug_kit';
+
+		if (isset($this->Auth) && method_exists($this->Auth, 'mapActions')) {
+			$this->Auth->mapActions(array(
+				'read' => array('history_state', 'sql_explain')
+			));
+		}
 	}
 
 /**


### PR DESCRIPTION
I'm using a quite customized authorize class for one of my projects here, though I figure a lot of devs will do it quite similar (guest access e.g.).

Using DebugKit's toolbar I always get a warning about unmapped actions (CrudAuth will throw that too I guess). This is intended, to make sure we don't forget to map controller actions, so maybe it won't hurt to always call mapActions() in DebugKit as well?

Please let me know what you think about this approach.
