### PR TITLE
Missing Helper class when throw Exception

### DIFF
--- a/View/Helper/DebugTimerHelper.php
+++ b/View/Helper/DebugTimerHelper.php
@@ -1,6 +1,7 @@
 <?php
 App::uses('DebugTimer', 'DebugKit.Lib');
 App::uses('DebugMemory', 'DebugKit.Lib');
+App::uses('Helper', 'View');
 
 /**
  * Debug TimerHelper


### PR DESCRIPTION
I have throw new Exception in beforeFilter and the error about missing the class Helper has came..

I have just added App::uses for this class.
