### PR TITLE
Replaced javascript inclusion with plugin syntax

### DIFF
--- a/Controller/Component/ToolbarComponent.php
+++ b/Controller/Component/ToolbarComponent.php
@@ -83,8 +83,8 @@ class ToolbarComponent extends Component implements CakeEventListener {
  * @var array
  */
 	public $javascript = array(
-		'jquery' => '/debug_kit/js/jquery',
-		'libs' => '/debug_kit/js/js_debug_toolbar'
+		'jquery' => 'DebugKit.jquery',
+		'libs' => 'DebugKit.js_debug_toolbar'
 	);
 
 /**


### PR DESCRIPTION
For more consistency I used the plugin syntax for the inclusion of both javascript files, because a few lines down it is used for the CSS.
The outputted html stays the same.
