### PR TITLE
HtmlToolbarHelper::makeNeatArray should treat Iterator instances as Array

### DIFF
--- a/View/Helper/HtmlToolbarHelper.php
+++ b/View/Helper/HtmlToolbarHelper.php
@@ -83,7 +83,7 @@ class HtmlToolbarHelper extends ToolbarHelper {
 				$value = 'function';
 			}
 
-			if (($value instanceof ArrayAccess || is_array($value)) && !empty($value)) {
+			if (($value instanceof ArrayAccess || $value instanceof Iterator || is_array($value)) && !empty($value)) {
 				$out .= $this->makeNeatArray($value, $openDepth, $nextDepth, $doubleEncode);
 			} else {
 				$out .= h($value, $doubleEncode);


### PR DESCRIPTION
HtmlToolbarHelper::makeNeatArray should treat Iterator instances as Array
