### PR TITLE
Broadly improved the DocBlocks and other code cleanup

### DIFF
--- a/Console/Command/BenchmarkShell.php
+++ b/Console/Command/BenchmarkShell.php
@@ -5,33 +5,32 @@
  * Provides basic benchmarking of application requests
  * functionally similar to Apache AB
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.vendors.shells
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Console.Command
  * @since         DebugKit 1.0
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
+
+App::uses('String','Utility');
 
 /**
  * Benchmark Shell Class
  *
- * @package cake
- * @subpackage cake.debug_kit.vendors.shells
+ * @package       DebugKit.Console.Command
+ * @since         DebugKit 1.0
  * @todo Print/export time detail information
  * @todo Export/graphing of data to .dot format for graphviz visualization
  * @todo Make calculated results round to leading significant digit position of std dev.
  */
-App::uses('String','Utility');
-
 class BenchmarkShell extends Shell {
 
 /**
@@ -64,6 +63,7 @@ class BenchmarkShell extends Shell {
 		}
 		$this->_results($times);
 	}
+
 /**
  * Prints calculated results
  *
@@ -125,15 +125,18 @@ class BenchmarkShell extends Shell {
 
 		return $M2 / $n;
 	}
+
 /**
  * Calculate the standard deviation.
  *
  * @param array $times Array of values
+ * @param bool $sample
  * @return float Standard deviation
  */
 	protected function _deviation($times, $sample = true) {
 		return sqrt($this->_variance($times, $sample));
 	}
+
 /**
  * Help for Benchmark shell
  *

--- a/Console/Command/WhitespaceShell.php
+++ b/Console/Command/WhitespaceShell.php
@@ -4,23 +4,28 @@
  *
  * Based on jperras' shell found at http://bin.cakephp.org/view/626544881
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.vendors.shells
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Console.Command
  * @since         DebugKit 1.3
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 App::uses('Folder', 'Utility');
 
+/**
+ * Class WhitespaceShell
+ *
+ * @package       DebugKit.Console.Command
+ * @since         DebugKit 1.3
+ */
 class WhitespaceShell extends Shell {
 
 /**
@@ -82,7 +87,7 @@ class WhitespaceShell extends Shell {
 /**
  * get the option parser
  *
- * @return void
+ * @return ConsoleOptionParser
  */
 	public function getOptionParser() {
 		$parser = parent::getOptionParser();

--- a/Controller/Component/ToolbarComponent.php
+++ b/Controller/Component/ToolbarComponent.php
@@ -1,4 +1,19 @@
 <?php
+/**
+ * DebugKit DebugToolbar Component
+ *
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Controller.Component
+ * @since         DebugKit 0.1
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
 App::uses('CakeLog', 'Log');
 App::uses('CakeLogInterface', 'Log');
 App::uses('DebugTimer', 'DebugKit.Lib');
@@ -8,19 +23,10 @@ App::uses('CakeEventManager', 'Event');
 App::uses('CakeEventListener', 'Event');
 
 /**
- * DebugKit DebugToolbar Component
+ * Class ToolbarComponent
  *
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.controllers.components
+ * @package       DebugKit.Controller.Component
  * @since         DebugKit 0.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 class ToolbarComponent extends Component implements CakeEventListener {
 
@@ -121,7 +127,9 @@ class ToolbarComponent extends Component implements CakeEventListener {
  * If debug is off the component will be disabled and not do any further time tracking
  * or load the toolbar helper.
  *
- * @return bool
+ * @param ComponentCollection $collection
+ * @param array $settings
+ * @return \ToolbarComponent
  */
 	public function __construct(ComponentCollection $collection, $settings = array()) {
 		$settings = array_merge((array)Configure::read('DebugKit'), $settings);
@@ -168,7 +176,7 @@ class ToolbarComponent extends Component implements CakeEventListener {
 /**
  * Register all the timing handlers for core events.
  *
- * @return void
+ * @return array
  */
 	public function implementedEvents() {
 		$before = function ($name) {
@@ -222,6 +230,7 @@ class ToolbarComponent extends Component implements CakeEventListener {
  * Initialize callback.
  * If automatically disabled, tell component collection about the state.
  *
+ * @param Controller $controller
  * @return bool
  */
 	public function initialize(Controller $controller) {
@@ -262,6 +271,7 @@ class ToolbarComponent extends Component implements CakeEventListener {
 /**
  * Component Startup
  *
+ * @param Controller $controller
  * @return bool
  */
 	public function startup(Controller $controller) {
@@ -281,6 +291,10 @@ class ToolbarComponent extends Component implements CakeEventListener {
 /**
  * beforeRedirect callback
  *
+ * @param Controller $controller
+ * @param $url
+ * @param null $status
+ * @param bool $exit
  * @return void
  */
 	public function beforeRedirect(Controller $controller, $url, $status = null, $exit = true) {
@@ -302,6 +316,7 @@ class ToolbarComponent extends Component implements CakeEventListener {
  *
  * Calls beforeRender on all the panels and set the aggregate to the controller.
  *
+ * @param Controller $controller
  * @return void
  */
 	public function beforeRender(Controller $controller) {
@@ -386,6 +401,7 @@ class ToolbarComponent extends Component implements CakeEventListener {
 /**
  * collects the panel contents
  *
+ * @param Controller $controller
  * @return array Array of all panel beforeRender()
  */
 	protected function _gatherVars(Controller $controller) {
@@ -418,6 +434,8 @@ class ToolbarComponent extends Component implements CakeEventListener {
 /**
  * Load Panels used in the debug toolbar
  *
+ * @param $panels
+ * @param $settings
  * @return void
  */
 	protected function _loadPanels($panels, $settings) {
@@ -441,7 +459,7 @@ class ToolbarComponent extends Component implements CakeEventListener {
 /**
  * Save the current state of the toolbar varibles to the cache file.
  *
- * @param object $controller Controller instance
+ * @param \Controller|object $controller Controller instance
  * @param array $vars Vars to save.
  * @return void
  */

--- a/Controller/DebugKitAppController.php
+++ b/Controller/DebugKitAppController.php
@@ -2,24 +2,30 @@
 /**
  * Debug Kit App Controller
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Controller
  * @since         DebugKit 0.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
+
 App::uses('Controller', 'Controller');
 App::uses('AppController', 'Controller');
 
+/**
+ * Class DebugKitAppController
+ *
+ * @package       DebugKit.Controller
+ * @since         DebugKit 0.1
+ */
 class DebugKitAppController extends AppController {
 
 }

--- a/Controller/ToolbarAccessController.php
+++ b/Controller/ToolbarAccessController.php
@@ -4,24 +4,30 @@
  *
  * Allows retrieval of information from the debugKit internals.
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.controllers
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Controller
  * @since         DebugKit 1.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
+
 App::uses('Security', 'Utility');
 App::uses('DebugKitAppController', 'DebugKit.Controller');
 
+/**
+ * Class ToolbarAccessController
+ *
+ * @package       DebugKit.Controller
+ * @since         DebugKit 1.1
+ */
 class ToolbarAccessController extends DebugKitAppController {
 
 /**
@@ -78,6 +84,7 @@ class ToolbarAccessController extends DebugKitAppController {
 /**
  * Get a stored history state from the toolbar cache.
  *
+ * @param null $key
  * @return void
  */
 	public function history_state($key = null) {
@@ -114,5 +121,4 @@ class ToolbarAccessController extends DebugKitAppController {
 		$result = $this->ToolbarAccess->explainQuery($this->request->data['log']['ds'], $this->request->data['log']['sql']);
 		$this->set(compact('result'));
 	}
-
 }

--- a/Lib/DebugKitDebugger.php
+++ b/Lib/DebugKitDebugger.php
@@ -1,34 +1,39 @@
 <?php
 /**
- * DebugKit Debugger class. Extends and enhances core
- * debugger. Adds benchmarking and timing functionality.
+ * DebugKit Debugger class.
  *
- * PHP versions 5
+ * Extends and enhances core debugger.
+ * Adds benchmarking and timing functionality.
+ *
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.vendors
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Lib
  * @since         DebugKit 0.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
+
 App::uses('Debugger', 'Utility');
 App::uses('FireCake', 'DebugKit.Lib');
 App::uses('DebugTimer', 'DebugKit.Lib');
 App::uses('DebugMemory', 'DebugKit.Lib');
 
 /**
- * Debug Kit Temporary Debugger Class
+ * DebugKit Temporary Debugger Class
  *
  * Provides the future features that are planned. Yet not implemented in the 1.2 code base
  *
  * This file will not be needed in future version of CakePHP.
+ *
+ * @package       DebugKit.Lib
+ * @since         DebugKit 0.1
  */
 class DebugKitDebugger extends Debugger {
 
@@ -69,6 +74,7 @@ class DebugKitDebugger extends Debugger {
 		}
 		echo '</tbody></table>';
 	}
+
 /**
  * Start an benchmarking timer.
  *
@@ -200,7 +206,7 @@ class DebugKitDebugger extends Debugger {
  * @deprecated Use DebugMemory::clear() instead.
  */
 	public static function clearMemoryPoints() {
-		return DebugMemory::clear();
+		DebugMemory::clear();
 	}
 
 /**
@@ -223,9 +229,7 @@ class DebugKitDebugger extends Debugger {
 		}
 		FireCake::groupEnd();
 	}
-
 }
-
 
 DebugKitDebugger::getInstance('DebugKitDebugger');
 Debugger::addFormat('fb', array('callback' => 'DebugKitDebugger::fireError'));

--- a/Lib/DebugMemory.php
+++ b/Lib/DebugMemory.php
@@ -2,23 +2,29 @@
 /**
  * Contains methods for Profiling memory usage.
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.Lib
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Lib
  * @since         DebugKit 2.0
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 App::uses('Debugger', 'Utility');
 
+/**
+ * Class DebugMemory
+ *
+ * @package       DebugKit.Lib
+ * @since         DebugKit 2.0
+ */
 class DebugMemory {
 
 /**
@@ -49,7 +55,7 @@ class DebugMemory {
 /**
  * Stores a memory point in the internal tracker.
  * Takes a optional message name which can be used to identify the memory point.
- * If no message is supplied a debug_backtrace will be done to identifty the memory point.
+ * If no message is supplied a debug_backtrace will be done to identify the memory point.
  *
  * @param string $message Message to identify this memory point.
  * @return boolean
@@ -94,5 +100,4 @@ class DebugMemory {
 	public static function clear() {
 		self::$_points = array();
 	}
-
 }

--- a/Lib/DebugPanel.php
+++ b/Lib/DebugPanel.php
@@ -4,16 +4,26 @@
  *
  * Base class for debug panels.
  *
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * PHP 5
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Lib
  * @since         DebugKit 0.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+/**
+ * Class DebugPanel
+ *
+ * @package       DebugKit.Lib
+ * @since         DebugKit 0.1
  */
 class DebugPanel {
 
@@ -54,6 +64,9 @@ class DebugPanel {
  */
 	public $elementName = null;
 
+/**
+ * Empty constructor
+ */
 	public function __construct() {
 	}
 
@@ -62,7 +75,7 @@ class DebugPanel {
  *
  * Pull information from the controller / request
  *
- * @param object $controller Controller reference.
+ * @param \Controller|object $controller Controller reference.
  * @return void
  */
 	public function startup(Controller $controller) {
@@ -71,10 +84,9 @@ class DebugPanel {
 /**
  * Prepare output vars before Controller Rendering.
  *
- * @param object $controller Controller reference.
+ * @param \Controller|object $controller Controller reference.
  * @return void
  */
 	public function beforeRender(Controller $controller) {
 	}
-
 }

--- a/Lib/DebugTimer.php
+++ b/Lib/DebugTimer.php
@@ -1,25 +1,30 @@
 <?php
 /**
- * Contains methods for Profiling and creating
- * timers.
+ * Contains methods for Profiling and creating timers.
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.lib
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Lib
  * @since         DebugKit 0.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 App::uses('Debugger', 'Utility');
 
+/**
+ * Class DebugTimer
+ *
+ * @package       DebugKit.Lib
+ * @since         DebugKit 0.1
+ */
 class DebugTimer {
 
 /**
@@ -34,7 +39,7 @@ class DebugTimer {
  *
  * @param string $name The name of the timer to start.
  * @param string $message A message for your timer
- * @return bool true
+ * @return bool Always true
  */
 	public static function start($name = null, $message = null) {
 		$start = microtime(true);

--- a/Lib/FireCake.php
+++ b/Lib/FireCake.php
@@ -3,35 +3,47 @@
  * FirePHP Class for CakePHP
  *
  * Provides most of the functionality offered by FirePHPCore
- * Interoperates with FirePHP extension for firefox
+ * Interoperates with FirePHP extension for Firefox
  *
  * For more information see: http://www.firephp.org/
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.views.helpers
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Lib
  * @since         DebugKit 0.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 App::uses('Debugger', 'Utility');
 
 if (!function_exists('firecake')) {
 
+	/**
+	 * Procedural version of FireCake::log()
+	 *
+	 * @param $message
+	 * @param null $label
+	 */
 	function firecake($message, $label = null) {
 		FireCake::fb($message, $label, 'log');
 	}
 
 }
 
+/**
+ * Class FireCake
+ *
+ * @package       DebugKit.Lib
+ * @since         DebugKit 0.1
+ */
 class FireCake {
 
 /**
@@ -72,6 +84,11 @@ class FireCake {
 		'groupEnd' => 'GROUP_END',
 	);
 
+/**
+ * Version number for X-Wf-1-Plugin-1 HTML header
+ *
+ * @var string
+ */
 	protected $_version = '0.2.1';
 
 /**
@@ -106,7 +123,7 @@ class FireCake {
  * get Instance of the singleton
  *
  * @param string $class Class instance to store in the singleton. Used with subclasses and Tests.
- * @return void
+ * @return FireCake
  */
 	public static function getInstance($class = null) {
 		static $instance = array();
@@ -231,8 +248,8 @@ class FireCake {
 /**
  * Convenience wrapper for TABLE messages
  *
- * @param string $message Message to log
  * @param string $label Label for message (optional)
+ * @param string $message Message to log
  * @return void
  */
 	public static function table($label, $message) {
@@ -242,8 +259,8 @@ class FireCake {
 /**
  * Convenience wrapper for DUMP messages
  *
- * @param string $message Message to log
  * @param string $label Unique label for message
+ * @param string $message Message to log
  * @return void
  */
 	public static function dump($label, $message) {
@@ -275,7 +292,7 @@ class FireCake {
  * Convenience wrapper for GROUPEND messages
  * Closes a group block
  *
- * @param string $label Label for group (optional)
+ * @internal param string $label Label for group (optional)
  * @return void
  */
 	public static function groupEnd() {
@@ -291,7 +308,7 @@ class FireCake {
  * fb($message, $label, $type) - Send a message with a custom label and type.
  *
  * @param mixed $message Message to output. For other parameters see usage above.
- * @return void
+ * @return boolean Success
  */
 	public static function fb($message) {
 		$_this = FireCake::getInstance();
@@ -408,6 +425,7 @@ class FireCake {
  * Parse a debug backtrace
  *
  * @param array $trace Debug backtrace output
+ * @param $messageName
  * @return array
  */
 	protected static function _parseTrace($trace, $messageName) {
@@ -457,7 +475,7 @@ class FireCake {
  * @param mixed $object Object or variable to encode to string.
  * @param int $objectDepth Current Depth in object chains.
  * @param int $arrayDepth Current Depth in array chains.
- * @return void
+ * @return string|Object
  */
 	public static function stringEncode($object, $objectDepth = 1, $arrayDepth = 1) {
 		$_this = FireCake::getInstance();
@@ -501,7 +519,8 @@ class FireCake {
  * Encode an object into JSON
  *
  * @param mixed $object Object or array to json encode
- * @param boolean $doIt
+ * @param bool $skipEncode
+ * @internal param bool $doIt
  * @static
  * @return string
  */
@@ -516,10 +535,11 @@ class FireCake {
 /**
  * Send Headers - write headers.
  *
+ * @param $name
+ * @param $value
  * @return void
- **/
+ */
 	protected function _sendHeader($name, $value) {
 		header($name . ': ' . $value);
 	}
-
 }

--- a/Lib/Log/Engine/DebugKitLogListener.php
+++ b/Lib/Log/Engine/DebugKitLogListener.php
@@ -2,17 +2,39 @@
 /**
  * A CakeLog listener which saves having to munge files or other configured loggers.
  *
- * @package debug_kit.components
+ * PHP 5
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Lib.Log.Engine
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
+/**
+ * Class DebugKitLogListener
+ *
+ * @package       DebugKit.Lib.Log.Engine
+ */
 class DebugKitLogListener implements CakeLogInterface {
 
+/**
+ * logs
+ *
+ * @var array
+ */
 	public $logs = array();
 
 /**
  * Makes the reverse link needed to get the logs later.
  *
- * @return void
+ * @param $options
+ * @return \DebugKitLogListener
  */
 	public function __construct($options) {
 		$options['panel']->logger = $this;
@@ -21,6 +43,8 @@ class DebugKitLogListener implements CakeLogInterface {
 /**
  * Captures log messages in memory
  *
+ * @param $type
+ * @param $message
  * @return void
  */
 	public function write($type, $message) {
@@ -29,5 +53,4 @@ class DebugKitLogListener implements CakeLogInterface {
 		}
 		$this->logs[$type][] = array(date('Y-m-d H:i:s'), $message);
 	}
-
 }

--- a/Lib/Panel/EnvironmentPanel.php
+++ b/Lib/Panel/EnvironmentPanel.php
@@ -1,19 +1,37 @@
 <?php
-
-App::uses ('DebugPanel', 'DebugKit.Lib');
-
 /**
  * Environment Panel
  *
  * Provides information about your PHP and CakePHP environment to assist with debugging.
  *
- * @package       cake.debug_kit.panels
+ * PHP 5
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Lib.Panel
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ *
+ */
+
+App::uses ('DebugPanel', 'DebugKit.Lib');
+
+/**
+ * Class EnvironmentPanel
+ *
+ * @package       DebugKit.Lib.Panel
  */
 class EnvironmentPanel extends DebugPanel {
 
 /**
  * beforeRender - Get necessary data about environment to pass back to controller
  *
+ * @param Controller $controller
  * @return array
  */
 	public function beforeRender(Controller $controller) {
@@ -64,5 +82,4 @@ class EnvironmentPanel extends DebugPanel {
 
 		return $return;
 	}
-
 }

--- a/Lib/Panel/HistoryPanel.php
+++ b/Lib/Panel/HistoryPanel.php
@@ -1,12 +1,30 @@
 <?php
-App::uses('DebugPanel', 'DebugKit.Lib');
 /**
  * History Panel
  *
  * Provides debug information on previous requests.
  *
- * @package       cake.debug_kit.panels
+ * PHP 5
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Lib.Panel
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
+
+App::uses('DebugPanel', 'DebugKit.Lib');
+
+/**
+ * Class HistoryPanel
+ *
+ * @package       DebugKit.Lib.Panel
+ */
 class HistoryPanel extends DebugPanel {
 
 /**
@@ -20,8 +38,8 @@ class HistoryPanel extends DebugPanel {
  * Constructor
  *
  * @param array $settings Array of settings.
- * @return void
- **/
+ * @return \HistoryPanel
+ */
 	public function __construct($settings) {
 		if (isset($settings['history'])) {
 			$this->history = $settings['history'];
@@ -31,8 +49,9 @@ class HistoryPanel extends DebugPanel {
 /**
  * beforeRender callback function
  *
+ * @param Controller $controller
  * @return array contents for panel
- **/
+ */
 	public function beforeRender(Controller $controller) {
 		$cacheKey = $controller->Toolbar->cacheKey;
 		$toolbarHistory = Cache::read($cacheKey, 'debug_kit');

--- a/Lib/Panel/IncludePanel.php
+++ b/Lib/Panel/IncludePanel.php
@@ -1,21 +1,44 @@
 <?php
-App::uses('DebugPanel', 'DebugKit.Lib');
-
 /**
  * Include Panel
  *
  * Provides a list of included files for the current request
  *
- * @package       cake.debug_kit.panels
+ * PHP 5
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Lib.Panel
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
+
+App::uses('DebugPanel', 'DebugKit.Lib');
+
+/**
+ * Class IncludePanel
+ *
+ * @package       DebugKit.Lib.Panel
+ */
 class IncludePanel extends DebugPanel {
 
 /**
  * The list of plugins within the application
+ *
  * @var <type>
  */
 	protected $_pluginPaths = array();
 
+/**
+ * File Types
+ *
+ * @var array
+ */
 	protected $_fileTypes = array(
 		'Cache', 'Config', 'Configure', 'Console', 'Component', 'Controller',
 		'Behavior', 'Datasource', 'Model', 'Plugin', 'Test', 'View', 'Utility',
@@ -37,7 +60,7 @@ class IncludePanel extends DebugPanel {
  * Get a list of files that were included and split them out into the various parts of the app
  *
  * @param Controller $controller
- * @return void
+ * @return array
  */
 	public function beforeRender(Controller $controller) {
 		$return = array('core' => array(), 'app' => array(), 'plugins' => array());

--- a/Lib/Panel/LogPanel.php
+++ b/Lib/Panel/LogPanel.php
@@ -1,17 +1,34 @@
 <?php
-App::uses('DebugPanel', 'DebugKit.Lib');
-
 /**
  * Log Panel - Reads log entries made this request.
  *
- * @package       cake.debug_kit.panels
+ * PHP 5
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Lib.Panel
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+App::uses('DebugPanel', 'DebugKit.Lib');
+
+/**
+ * Class LogPanel
+ *
+ * @package       DebugKit.Lib.Panel
  */
 class LogPanel extends DebugPanel {
 
 /**
  * Constructor - sets up the log listener.
  *
- * @return void
+ * @return \LogPanel
  */
 	public function __construct() {
 		parent::__construct();
@@ -30,11 +47,11 @@ class LogPanel extends DebugPanel {
 /**
  * beforeRender Callback
  *
+ * @param Controller $controller
  * @return array
  */
 	public function beforeRender(Controller $controller) {
 		$logger = $this->logger;
 		return $logger;
 	}
-
 }

--- a/Lib/Panel/RequestPanel.php
+++ b/Lib/Panel/RequestPanel.php
@@ -1,20 +1,38 @@
 <?php
-App::uses('DebugPanel', 'DebugKit.Lib');
-
 /**
  * Request Panel
  *
  * Provides debug information on the Current request params.
  *
- * @package       cake.debug_kit.panels
+ * PHP 5
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Lib.Panel
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
+
+App::uses('DebugPanel', 'DebugKit.Lib');
+
+/**
+ * Class RequestPanel
+ *
+ * @package       DebugKit.Lib.Panel
+ */
 class RequestPanel extends DebugPanel {
 
 /**
  * beforeRender callback - grabs request params
  *
+ * @param Controller $controller
  * @return array
- **/
+ */
 	public function beforeRender(Controller $controller) {
 		$out = array();
 		$out['params'] = $controller->request->params;

--- a/Lib/Panel/SessionPanel.php
+++ b/Lib/Panel/SessionPanel.php
@@ -1,19 +1,36 @@
 <?php
-App::uses('DebugPanel', 'DebugKit.Lib');
-
 /**
  * Session Panel
  *
  * Provides debug information on the Session contents.
  *
- * @package       cake.debug_kit.panels
+ * PHP 5
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Lib.Panel
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+App::uses('DebugPanel', 'DebugKit.Lib');
+
+/**
+ * Class SessionPanel
+ *
+ * @package       DebugKit.Lib.Panel
  */
 class SessionPanel extends DebugPanel {
 
 /**
  * beforeRender callback
  *
- * @param object $controller
+ * @param \Controller|object $controller
  * @return array
  */
 	public function beforeRender(Controller $controller) {

--- a/Lib/Panel/SqlLogPanel.php
+++ b/Lib/Panel/SqlLogPanel.php
@@ -1,12 +1,29 @@
 <?php
-App::uses('DebugPanel', 'DebugKit.Lib');
-
 /**
  * SqlLog Panel
  *
  * Provides debug information on the SQL logs and provides links to an ajax explain interface.
  *
- * @package       cake.debug_kit.panels
+ * PHP 5
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Lib.Panel
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+App::uses('DebugPanel', 'DebugKit.Lib');
+
+/**
+ * Class SqlLogPanel
+ *
+ * @package       DebugKit.Lib.Panel
  */
 class SqlLogPanel extends DebugPanel {
 
@@ -21,8 +38,8 @@ class SqlLogPanel extends DebugPanel {
 /**
  * Gets the connection names that should have logs + dumps generated.
  *
- * @param string $controller
- * @return void
+ * @param \Controller|string $controller
+ * @return array
  */
 	public function beforeRender(Controller $controller) {
 		if (!class_exists('ConnectionManager')) {

--- a/Lib/Panel/TimerPanel.php
+++ b/Lib/Panel/TimerPanel.php
@@ -1,18 +1,36 @@
 <?php
-App::uses('DebugPanel', 'DebugKit.Lib');
-
 /**
  * Timer Panel
  *
  * Provides debug information on all timers used in a request.
  *
- * @package       cake.debug_kit.panels
+ * PHP 5
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Lib.Panel
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+App::uses('DebugPanel', 'DebugKit.Lib');
+
+/**
+ * Class TimerPanel
+ *
+ * @package       DebugKit.Lib.Panel
  */
 class TimerPanel extends DebugPanel {
 
 /**
  * startup - add in necessary helpers
  *
+ * @param Controller $controller
  * @return void
  */
 	public function startup(Controller $controller) {

--- a/Lib/Panel/VariablesPanel.php
+++ b/Lib/Panel/VariablesPanel.php
@@ -1,22 +1,39 @@
 <?php
-App::uses('DebugPanel', 'DebugKit.Lib');
-
 /**
  * Variables Panel
  *
  * Provides debug information on the View variables.
  *
- * @package       cake.debug_kit.panels
+ * PHP 5
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Lib.Panel
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+App::uses('DebugPanel', 'DebugKit.Lib');
+
+/**
+ * Class VariablesPanel
+ *
+ * @package       DebugKit.Lib.Panel
  */
 class VariablesPanel extends DebugPanel {
 
 /**
  * beforeRender callback
  *
+ * @param Controller $controller
  * @return array
  */
 	public function beforeRender(Controller $controller) {
 		return array_merge($controller->viewVars, array('$request->data' => $controller->request->data));
 	}
-
 }

--- a/Model/Behavior/TimedBehavior.php
+++ b/Model/Behavior/TimedBehavior.php
@@ -2,23 +2,29 @@
 /**
  * DebugKit TimedBehavior
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.models.behaviors
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Model.Behavior
  * @since         DebugKit 1.3
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 App::uses('DebugKitDebugger', 'DebugKit.Lib');
 
+/**
+ * Class TimedBehavior
+ *
+ * @package       DebugKit.Model.Behavior
+ * @since         DebugKit 1.3
+ */
 class TimedBehavior extends ModelBehavior {
 
 /**
@@ -38,7 +44,7 @@ class TimedBehavior extends ModelBehavior {
 /**
  * Setup the behavior and import required classes.
  *
- * @param object $Model Model using the behavior
+ * @param \Model|object $Model Model using the behavior
  * @param array $settings Settings to override for model.
  * @return void
  */
@@ -67,6 +73,7 @@ class TimedBehavior extends ModelBehavior {
  *
  * @param Model $Model
  * @param array $results Array of results
+ * @param $primary
  * @return boolean true.
  */
 	public function afterFind(Model $Model, $results, $primary) {
@@ -89,9 +96,9 @@ class TimedBehavior extends ModelBehavior {
 /**
  * afterSave, stop the timer started from a save.
  *
- * @param string $Model
+ * @param \Model $Model
  * @param string $created
- * @return void
+ * @return boolean Always true
  */
 	public function afterSave(Model $Model, $created) {
 		DebugKitDebugger::stopTimer($Model->alias . '_save');

--- a/Model/DebugKitAppModel.php
+++ b/Model/DebugKitAppModel.php
@@ -2,24 +2,29 @@
 /**
  * Debug Kit App Model
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Model
  * @since         DebugKit 0.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
 
 App::uses('AppModel', 'Model');
 
+/**
+ * Class DebugKitAppModel
+ *
+ * @package       DebugKit.Model
+ * @since         DebugKit 0.1
+ */
 class DebugKitAppModel extends AppModel {
 
 }

--- a/Model/ToolbarAccess.php
+++ b/Model/ToolbarAccess.php
@@ -4,23 +4,29 @@
  *
  * Contains logic for accessing DebugKit specific information.
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.controllers
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Model
  * @since         DebugKit 1.3
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
+
 App::uses('ConnectionManager', 'Model');
 
+/**
+ * Class ToolbarAccess
+ *
+ * @package       DebugKit.Model
+ * @since         DebugKit 1.3
+ */
 class ToolbarAccess extends Object {
 
 /**

--- a/Test/Case/AllDebugKitTest.php
+++ b/Test/Case/AllDebugKitTest.php
@@ -1,36 +1,34 @@
 <?php
-
-require_once dirname(__FILE__) . DS . 'DebugkitGroupTestCase.php';
-
 /**
- * View Group Test for debugkit
+ * View Group Test for DebugKit
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.tests.groups
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Test.Case
  * @since         DebugKit 1.0
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
+
+require_once dirname(__FILE__) . DS . 'DebugkitGroupTestCase.php';
 
 /**
  * DebugKitViewTestSuite class
  *
- * @package       cake
- * @subpackage    cake.tests.cases
+ * @package       DebugKit.Test.Case
+ * @since         DebugKit 1.0
  */
 class AllDebugKitTest extends DebugkitGroupTestCase {
 
 /**
- *
+ * Assemble Test Suite
  *
  * @return PHPUnit_Framework_TestSuite the instance of PHPUnit_Framework_TestSuite
  */

--- a/Test/Case/AllDebugKitViewTest.php
+++ b/Test/Case/AllDebugKitViewTest.php
@@ -1,36 +1,34 @@
 <?php
-
-require_once dirname(__FILE__) . DS . 'DebugkitGroupTestCase.php';
-
 /**
- * View Group Test for debugkit
+ * View Group Test for DebugKit
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.tests.groups
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Test.Case
  * @since         DebugKit 1.0
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
+
+require_once dirname(__FILE__) . DS . 'DebugkitGroupTestCase.php';
 
 /**
  * DebugKitViewTestSuite class
  *
- * @package       cake
- * @subpackage    cake.tests.cases
+ * @package       DebugKit.Test.Case
+ * @since         DebugKit 1.0
  */
 class AllDebugKitViewTest extends DebugkitGroupTestCase {
 
 /**
- *
+ * Assemble Test Suite
  *
  * @return PHPUnit_Framework_TestSuite the instance of PHPUnit_Framework_TestSuite
  */

--- a/Test/Case/AllDebugKitWithoutViewTest.php
+++ b/Test/Case/AllDebugKitWithoutViewTest.php
@@ -1,36 +1,34 @@
 <?php
-
-require_once dirname(__FILE__) . DS . 'DebugkitGroupTestCase.php';
-
 /**
- * View Group Test for debugkit
+ * View Group Test for DebugKit
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.tests.groups
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Test.Case
  * @since         DebugKit 1.0
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
+
+require_once dirname(__FILE__) . DS . 'DebugkitGroupTestCase.php';
+
 /**
  * DebugKitViewTestSuite class
  *
- * @package       cake
- * @subpackage    cake.tests.cases
+ * @package       DebugKit.Test.Case
+ * @since         DebugKit 1.0
  */
-
 class AllDebugKitWithoutViewTest extends DebugkitGroupTestCase {
 
 /**
- *
+ * Assemble Test Suite
  *
  * @return PHPUnit_Framework_TestSuite the instance of PHPUnit_Framework_TestSuite
  */

--- a/Test/Case/AllTestsTest.php
+++ b/Test/Case/AllTestsTest.php
@@ -1,35 +1,34 @@
 <?php
-
-require_once dirname(__FILE__) . DS . 'DebugkitGroupTestCase.php';
-
 /**
  * AllTestsTest For DebugKit
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.tests.groups
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Test.Case
  * @since         DebugKit 1.0
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
+
+require_once dirname(__FILE__) . DS . 'DebugkitGroupTestCase.php';
+
 /**
  * AllTestsTest class
  *
- * @package       cake
- * @subpackage    cake.tests.cases
+ * @package       DebugKit.Test.Case
+ * @since         DebugKit 1.0
  */
-
 class AllTestsTest extends DebugkitGroupTestCase {
 
 /**
+ * Assemble Test Suite
  *
  * @return PHPUnit_Framework_TestSuite the instance of PHPUnit_Framework_TestSuite
  */

--- a/Test/Case/Controller/Component/ToolbarComponentTest.php
+++ b/Test/Case/Controller/Component/ToolbarComponentTest.php
@@ -2,21 +2,21 @@
 /**
  * DebugToolbar Test
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.tests.controllers.components
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Test.Case.Controller.Component
  * @since         DebugKit 2.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 App::uses('Router', 'Routing');
 App::uses('Controller', 'Controller');
 App::uses('AppController', 'Controller');
@@ -25,22 +25,34 @@ App::uses('ToolbarComponent', 'DebugKit.Controller/Component');
 App::uses('DebugMemory', 'DebugKit.Lib');
 App::uses('DebugTimer', 'DebugKit.Lib');
 
+/**
+ * Class TestToolbarComponent
+ *
+ * @package       DebugKit.Test.Case.Controller.Component
+ * @since         DebugKit 2.1
+ */
 class TestToolbarComponent extends ToolbarComponent {
 
+	/**
+	 * Load Panels of Toolbar
+	 *
+	 * @param $panels
+	 * @param array $settings
+	 */
 	public function loadPanels($panels, $settings = array()) {
 		$this->_loadPanels($panels, $settings);
 	}
-
 }
-
 
 /**
  * DebugKitToolbarComponentTestCase Test case
+ *
+ * @package       DebugKit.Test.Case.Controller.Component
  */
 class DebugKitToolbarComponentTestCase extends CakeTestCase {
 
 /**
- * fixtures.
+ * fixtures
  *
  * @var array
  */
@@ -103,9 +115,11 @@ class DebugKitToolbarComponentTestCase extends CakeTestCase {
 		}
 		Router::reload();
 	}
+
 /**
  * loading test controller
  *
+ * @param array $settings
  * @return Controller
  */
 	protected function _loadController($settings = array()) {
@@ -512,5 +526,4 @@ class DebugKitToolbarComponentTestCase extends CakeTestCase {
 		$result = $this->Controller->requestAction('/debug_kit_test/request_action_render', array('return'));
 		$this->assertEquals($result, 'I have been rendered.');
 	}
-
 }

--- a/Test/Case/DebugkitGroupTestCase.php
+++ b/Test/Case/DebugkitGroupTestCase.php
@@ -1,12 +1,43 @@
 <?php
+/**
+ * DebugKit Group Test Case
+ *
+ * PHP 5
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Test.Case
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ **/
 
-class DebugkitGroupTestCase extends PHPUnit_Framework_TestSuite {
+/**
+ * Class DebugKitGroupTestCase
+ *
+ * @package       DebugKit.Test.Case
+ */
+class DebugKitGroupTestCase extends PHPUnit_Framework_TestSuite {
 
+/**
+ * Constructor
+ */
 	public function __construct() {
 		$label = Inflector::humanize(Inflector::underscore(get_class($this)));
 		parent::__construct($label);
 	}
 
+/**
+ * Get Test Files
+ *
+ * @param null $directory
+ * @param null $excludes
+ * @return array
+ */
 	public static function getTestFiles($directory = null, $excludes = null) {
 		if (is_array($directory)) {
 			$files = array();
@@ -38,7 +69,6 @@ class DebugkitGroupTestCase extends PHPUnit_Framework_TestSuite {
 					!preg_match('|^All.+?\.php$|', basename($file)) &&
 					($excludes === null || !in_array($file, $excludes))
 				) {
-
 					$files[] = $file;
 				}
 			}
@@ -48,5 +78,4 @@ class DebugkitGroupTestCase extends PHPUnit_Framework_TestSuite {
 
 		return $files;
 	}
-
 }

--- a/Test/Case/Lib/DebugKitDebuggerTest.php
+++ b/Test/Case/Lib/DebugKitDebuggerTest.php
@@ -2,29 +2,29 @@
 /**
  * DebugKit Debugger Test Case File
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.tests.vendors
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Test.Case.Lib
  * @since         debug_kit 0.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
+
 App::uses('DebugKitDebugger', 'DebugKit.Lib');
 require_once CakePlugin::path('DebugKit') . 'Test' . DS . 'Case' . DS . 'TestFireCake.php';
 
 /**
  * Test case for the DebugKitDebugger
  *
- * @package       debug_kit.tests
- * @subpackage    debug_kit.tests.cases.vendors
+ * @package       DebugKit.Test.Case.Lib
+ * @since         debug_kit 0.1
  */
 class DebugKitDebuggerTest extends CakeTestCase {
 
@@ -73,5 +73,4 @@ class DebugKitDebuggerTest extends CakeTestCase {
 		Debugger::getInstance('Debugger');
 		Debugger::outputAs('html');
 	}
-
 }

--- a/Test/Case/Lib/DebugMemoryTest.php
+++ b/Test/Case/Lib/DebugMemoryTest.php
@@ -1,6 +1,28 @@
 <?php
+/**
+ * DebugKit Debug Memory Test Cases
+ *
+ * PHP 5
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Test.Case.Lib
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ **/
+
 App::uses('DebugMemory', 'DebugKit.Lib');
 
+/**
+ * Class DebugMemoryTest
+ *
+ * @package       DebugKit.Test.Case.Lib
+ */
 class DebugMemoryTest extends CakeTestCase {
 
 /**

--- a/Test/Case/Lib/DebugTimerTest.php
+++ b/Test/Case/Lib/DebugTimerTest.php
@@ -1,24 +1,30 @@
 <?php
 /**
- * DebugTimer Test Case File
+ * DebugTimer Test Case
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.Test.Case.Lib
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Test.Case.Lib
  * @since         debug_kit 2.0
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 App::uses('DebugTimer', 'DebugKit.Lib');
 
+/**
+ * Class DebugTimerTest
+ *
+ * @package       DebugKit.Test.Case.Lib
+ * @since         debug_kit 2.0
+ */
 class DebugTimerTest extends CakeTestCase {
 
 /**

--- a/Test/Case/Lib/FireCakeTest.php
+++ b/Test/Case/Lib/FireCakeTest.php
@@ -1,29 +1,30 @@
 <?php
 /**
- * CakeFirePHP test case
+ * CakeFirePHP Test Case
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.tests.vendors
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Test.Case.Lib
  * @since         DebugKit 0.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
+
 App::uses('FireCake', 'DebugKit.Lib');
 require_once CakePlugin::path('DebugKit') . 'Test' . DS . 'Case' . DS . 'TestFireCake.php';
 
 /**
  * Test Case For FireCake
  *
- * @package debug_kit.tests
+ * @package       DebugKit.Test.Case.Lib
+ * @since         DebugKit 0.1
  */
 class FireCakeTestCase extends CakeTestCase {
 
@@ -39,7 +40,7 @@ class FireCakeTestCase extends CakeTestCase {
 	}
 
 /**
- * test getInstance cheat.
+ * Test getInstance cheat.
  *
  * If this fails the rest of the test is going to fail too.
  *
@@ -54,7 +55,7 @@ class FireCakeTestCase extends CakeTestCase {
 	}
 
 /**
- * testsetoption
+ * Test setOptions
  *
  * @return void
  */
@@ -64,7 +65,7 @@ class FireCakeTestCase extends CakeTestCase {
 	}
 
 /**
- * test Log()
+ * Test Log()
  *
  * @return void
  */
@@ -82,7 +83,7 @@ class FireCakeTestCase extends CakeTestCase {
 	}
 
 /**
- * test info()
+ * Test info()
  *
  * @return void
  */
@@ -100,7 +101,7 @@ class FireCakeTestCase extends CakeTestCase {
 	}
 
 /**
- * test info()
+ * Test info()
  *
  * @return void
  */
@@ -118,7 +119,7 @@ class FireCakeTestCase extends CakeTestCase {
 	}
 
 /**
- * test error()
+ * Test error()
  *
  * @return void
  */
@@ -136,7 +137,7 @@ class FireCakeTestCase extends CakeTestCase {
 	}
 
 /**
- * test dump()
+ * Test dump()
  *
  * @return void
  */
@@ -147,7 +148,7 @@ class FireCakeTestCase extends CakeTestCase {
 	}
 
 /**
- * test table() generation
+ * Test table() generation
  *
  * @return void
  */
@@ -162,7 +163,7 @@ class FireCakeTestCase extends CakeTestCase {
 	}
 
 /**
- * testStringEncoding
+ * TestStringEncoding
  *
  * @return void
  */
@@ -178,7 +179,7 @@ class FireCakeTestCase extends CakeTestCase {
 	}
 
 /**
- * test object encoding
+ * Test object encoding
  *
  * @return void
  */
@@ -192,7 +193,7 @@ class FireCakeTestCase extends CakeTestCase {
 	}
 
 /**
- * test trace()
+ * Test trace()
  *
  * @return void
  */
@@ -207,7 +208,7 @@ class FireCakeTestCase extends CakeTestCase {
 	}
 
 /**
- * test enabling and disabling of FireCake output
+ * Test enabling and disabling of FireCake output
  *
  * @return void
  */
@@ -222,7 +223,7 @@ class FireCakeTestCase extends CakeTestCase {
 	}
 
 /**
- * test correct line continuation markers on multi line headers.
+ * Test correct line continuation markers on multi line headers.
  *
  * @return void
  */
@@ -238,7 +239,7 @@ class FireCakeTestCase extends CakeTestCase {
 	}
 
 /**
- * test inclusion of line numbers
+ * Test inclusion of line numbers
  *
  * @return void
  */
@@ -251,7 +252,7 @@ class FireCakeTestCase extends CakeTestCase {
 	}
 
 /**
- * test Group messages
+ * Test Group messages
  *
  * @return void
  */
@@ -266,7 +267,7 @@ class FireCakeTestCase extends CakeTestCase {
 	}
 
 /**
- * test fb() parameter parsing
+ * Test fb() parameter parsing
  *
  * @return void
  */
@@ -299,7 +300,7 @@ class FireCakeTestCase extends CakeTestCase {
 	}
 
 /**
- * testClientExtensionDetection.
+ * Test DetectClientExtension.
  *
  * @return void
  */
@@ -317,7 +318,7 @@ class FireCakeTestCase extends CakeTestCase {
 	}
 
 /**
- * test of Non Native JSON encoding.
+ * Test of Non Native JSON encoding.
  *
  * @return void
  */
@@ -334,7 +335,7 @@ class FireCakeTestCase extends CakeTestCase {
 	}
 
 /**
- * reset the FireCake counters and headers.
+ * Reset the FireCake counters and headers.
  *
  * @return void
  */

--- a/Test/Case/Lib/Panel/LogPanelTest.php
+++ b/Test/Case/Lib/Panel/LogPanelTest.php
@@ -1,7 +1,29 @@
 <?php
+/**
+ * DebugKit Log Panel Test Cases
+ *
+ * PHP 5
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Test.Case.Lib.Panel
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ **/
+
 App::uses('LogPanel', 'DebugKit.Lib/Panel');
 App::uses('Controller', 'Controller');
 
+/**
+ * Class LogPanelTest
+ *
+ * @package       DebugKit.Test.Case.Lib.Panel
+ */
 class LogPanelTest extends CakeTestCase {
 
 /**
@@ -40,5 +62,4 @@ class LogPanelTest extends CakeTestCase {
 		$this->assertTrue(isset($result->logs));
 		$this->assertCount(1, $result->logs['error']);
 	}
-
 }

--- a/Test/Case/Lib/Panel/SqlLogPanelTest.php
+++ b/Test/Case/Lib/Panel/SqlLogPanelTest.php
@@ -1,22 +1,28 @@
 <?php
+/**
+ * SqlLogPanelTest
+ *
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Test.Case.Lib.Panel
+ * @since         DebugKit 2.1
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
 App::uses('SqlLogPanel', 'DebugKit.Lib/Panel');
 App::uses('Model', 'Model');
 App::uses('Controller', 'Controller');
 
 /**
- * SqlLogPanelTest
+ * Class SqlLogPanelTest
  *
- * Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.tests.controllers.components
+ * @package       DebugKit.Test.Case.Lib.Panel
  * @since         DebugKit 2.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 class SqlLogPanelTest extends CakeTestCase {
 

--- a/Test/Case/Model/Behavior/TimedBehaviorTest.php
+++ b/Test/Case/Model/Behavior/TimedBehaviorTest.php
@@ -1,30 +1,41 @@
 <?php
 /**
- * DebugKit TimedBehavior test case
+ * DebugKit TimedBehavior Test Case
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.models.behaviors
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Test.Case.Model.Behavior
  * @since         DebugKit 1.3
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 App::uses('DebugKitDebugger', 'DebugKit.Lib');
 
+/**
+ * Class TimedBehaviorTestCase
+ *
+ * @package       DebugKit.Test.Case.Model.Behavior
+ * @since         DebugKit 1.3
+ */
 class TimedBehaviorTestCase extends CakeTestCase {
 
+/**
+ * Fixtures
+ *
+ * @var array
+ */
 	public $fixtures = array('core.article');
 
 /**
- * startTest callback
+ * Start Test callback
  *
  * @return void
  */
@@ -35,7 +46,7 @@ class TimedBehaviorTestCase extends CakeTestCase {
 	}
 
 /**
- * end a test
+ * End a test
  *
  * @return void
  */
@@ -47,7 +58,7 @@ class TimedBehaviorTestCase extends CakeTestCase {
 	}
 
 /**
- * test find timers
+ * Test find timers
  *
  * @return void
  */
@@ -65,7 +76,7 @@ class TimedBehaviorTestCase extends CakeTestCase {
 	}
 
 /**
- * test save timers
+ * Test save timers
  *
  * @return void
  */

--- a/Test/Case/Model/ToolbarAccessTest.php
+++ b/Test/Case/Model/ToolbarAccessTest.php
@@ -2,27 +2,28 @@
 /**
  * DebugKit ToolbarAccess Model Test case
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.controllers
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Test.Case.Model
  * @since         DebugKit 1.3
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
+
 App::uses('ToolbarAccess', 'DebugKit.Model');
 
 /**
  * Test case for ToolbarAccess model
  *
- * @package debug_kit
+ * @package       DebugKit.Test.Case.Model
+ * @since         DebugKit 1.3
  */
 class ToolbarAccessTestCase extends CakeTestCase {
 

--- a/Test/Case/TestFireCake.php
+++ b/Test/Case/TestFireCake.php
@@ -2,47 +2,60 @@
 /**
  * Common test objects used in DebugKit tests
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.tests
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Test.Case
  * @since         DebugKit 0.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
-/**
- * TestFireCake class allows for testing of FireCake
- *
- * @package debug_kit.tests.
- */
 
 App::uses('FireCake', 'DebugKit.Lib');
 
+/**
+ * TestFireCake class allows for testing of FireCake
+ *
+ * @package       DebugKit.Test.Case
+ * @since         DebugKit 0.1
+ */
 class TestFireCake extends FireCake {
 
+/**
+ * Headers that were sent
+ *
+ * @var array
+ */
 	public $sentHeaders = array();
 
+/**
+ * Send header
+ *
+ * @param $name
+ * @param $value
+ */
 	protected function _sendHeader($name, $value) {
 		$_this = FireCake::getInstance();
 		$_this->sentHeaders[$name] = $value;
 	}
+
 /**
- * skip client detection as headers are not being sent.
+ * Skip client detection as headers are not being sent.
  *
- * @return void
+ * @return boolean Always true
  */
 	public static function detectClientExtension() {
 		return true;
 	}
+
 /**
- * Reset the fireCake
+ * Reset FireCake
  *
  * @return void
  **/
@@ -52,5 +65,3 @@ class TestFireCake extends FireCake {
 		$_this->_messageIndex = 1;
 	}
 }
-
-

--- a/Test/Case/View/Helper/FirePhpToolbarHelperTest.php
+++ b/Test/Case/View/Helper/FirePhpToolbarHelperTest.php
@@ -2,21 +2,21 @@
 /**
  * Toolbar Abstract Helper Test Case
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.tests.views.helpers
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Test.Case.View.Helper
  * @since         DebugKit 0.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
+
 $path = CakePlugin::path('DebugKit');
 
 App::uses('View', 'View');
@@ -25,10 +25,16 @@ App::uses('CakeResponse', 'Network');
 App::uses('Router', 'Routing');
 App::uses('ToolbarHelper', 'DebugKit.View/Helper');
 App::uses('FirePhpToolbarHelper', 'DebugKit.View/Helper');
-require_once $path . 'Test' . DS . 'Case' . DS . 'TestFireCake.php';
 
+require_once $path . 'Test' . DS . 'Case' . DS . 'TestFireCake.php';
 FireCake::getInstance('TestFireCake');
 
+/**
+ * Class FirePhpToolbarHelperTestCase
+ *
+ * @package       DebugKit.Test.Case.View.Helper
+ * @since         DebugKit 0.1
+ */
 class FirePhpToolbarHelperTestCase extends CakeTestCase {
 
 /**
@@ -50,8 +56,9 @@ class FirePhpToolbarHelperTestCase extends CakeTestCase {
 
 		$this->firecake = FireCake::getInstance();
 	}
+
 /**
- * start test - switch view paths
+ * Start test - switch view paths
  *
  * @return void
  **/
@@ -65,7 +72,7 @@ class FirePhpToolbarHelperTestCase extends CakeTestCase {
 	}
 
 /**
- * endTest()
+ * End Test
  *
  * @return void
  */
@@ -74,7 +81,7 @@ class FirePhpToolbarHelperTestCase extends CakeTestCase {
 	}
 
 /**
- * tearDown
+ * TearDown
  *
  * @return void
  */
@@ -86,7 +93,7 @@ class FirePhpToolbarHelperTestCase extends CakeTestCase {
 	}
 
 /**
- * test neat array (dump)creation
+ * Test neat array (dump)creation
  *
  * @return void
  */
@@ -96,8 +103,9 @@ class FirePhpToolbarHelperTestCase extends CakeTestCase {
 		$this->assertTrue(isset($result['X-Wf-1-1-1-1']));
 		$this->assertPattern('/\[1,2,3\]/', $result['X-Wf-1-1-1-1']);
 	}
+
 /**
- * testAfterlayout element rendering
+ * Test afterlayout element rendering
  *
  * @return void
  */
@@ -122,6 +130,7 @@ class FirePhpToolbarHelperTestCase extends CakeTestCase {
 		$result = $this->firecake->sentHeaders;
 		$this->assertTrue(is_array($result));
 	}
+
 /**
  * test starting a panel
  *
@@ -132,6 +141,7 @@ class FirePhpToolbarHelperTestCase extends CakeTestCase {
 		$result = $this->firecake->sentHeaders;
 		$this->assertPattern('/GROUP_START.+My Panel/', $result['X-Wf-1-1-1-1']);
 	}
+
 /**
  * test ending a panel
  *
@@ -142,5 +152,4 @@ class FirePhpToolbarHelperTestCase extends CakeTestCase {
 		$result = $this->firecake->sentHeaders;
 		$this->assertPattern('/GROUP_END/', $result['X-Wf-1-1-1-1']);
 	}
-
 }

--- a/Test/Case/View/Helper/HtmlToolbarHelperTest.php
+++ b/Test/Case/View/Helper/HtmlToolbarHelperTest.php
@@ -2,21 +2,21 @@
 /**
  * Toolbar HTML Helper Test Case
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.tests.views.helpers
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Test.Case.View.Helper
  * @since         DebugKit 0.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
+
 App::uses('View', 'View');
 App::uses('Controller', 'Controller');
 App::uses('Router', 'Routing');
@@ -26,8 +26,17 @@ App::uses('HtmlToolbarHelper', 'DebugKit.View/Helper');
 App::uses('HtmlHelper', 'View/Helper');
 App::uses('FormHelper', 'View/Helper');
 
+/**
+ * Class HtmlToolbarHelperTestCase
+ *
+ * @package       DebugKit.Test.Case.View.Helper
+ * @since         DebugKit 0.1
+ */
 class HtmlToolbarHelperTestCase extends CakeTestCase {
 
+/**
+ * Setup Test Case
+ */
 	public static function setupBeforeClass() {
 		App::build(array(
 			'View' => array(
@@ -38,12 +47,15 @@ class HtmlToolbarHelperTestCase extends CakeTestCase {
 		), true);
 	}
 
+/**
+ * Tear Down Test Case
+ */
 	public static function tearDownAfterClass() {
 		App::build();
 	}
 
 /**
- * setUp
+ * Setup
  *
  * @return void
  **/
@@ -64,7 +76,7 @@ class HtmlToolbarHelperTestCase extends CakeTestCase {
 	}
 
 /**
- * tearDown
+ * Tear Down
  *
  * @return void
  */
@@ -74,7 +86,7 @@ class HtmlToolbarHelperTestCase extends CakeTestCase {
 	}
 
 /**
- * test Neat Array formatting
+ * Test Neat Array formatting
  *
  * @return void
  **/
@@ -295,6 +307,7 @@ class HtmlToolbarHelperTestCase extends CakeTestCase {
 		);
 		$this->assertTags($result, $expected);
 	}
+
 /**
  * Test Table generation
  *
@@ -320,6 +333,7 @@ class HtmlToolbarHelperTestCase extends CakeTestCase {
 		);
 		$this->assertTags($result, $expected);
 	}
+
 /**
  * test starting a panel
  *
@@ -334,6 +348,7 @@ class HtmlToolbarHelperTestCase extends CakeTestCase {
 		);
 		$this->assertTags($result, $expected);
 	}
+
 /**
  * test ending a panel
  *

--- a/Test/Case/View/Helper/ToolbarHelperTest.php
+++ b/Test/Case/View/Helper/ToolbarHelperTest.php
@@ -2,31 +2,47 @@
 /**
  * Toolbar facade tests.
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.tests.views.helpers
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Test.Case.View.Helper
  * @since         DebugKit 0.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
+
 App::uses('View', 'View');
 App::uses('Controller', 'Controller');
 App::uses('Helper', 'View');
 App::uses('ToolbarHelper', 'DebugKit.View/Helper');
 
+/**
+ * Class MockBackendHelper
+ *
+ * @package       DebugKit.Test.Case.View.Helper
+ * @since         DebugKit 0.1
+ */
 class MockBackendHelper extends Helper {
 }
 
+/**
+ * Class ToolbarHelperTestCase
+ *
+ * @package       DebugKit.Test.Case.View.Helper
+ */
 class ToolbarHelperTestCase extends CakeTestCase {
 
+/**
+ * Fixtures
+ *
+ * @var array
+ */
 	public $fixtures = array('core.post');
 
 /**
@@ -70,6 +86,7 @@ class ToolbarHelperTestCase extends CakeTestCase {
 		$result = $this->Toolbar->writeCache('test', array('stuff', 'to', 'cache'));
 		$this->assertTrue($result);
 	}
+
 /**
  * Ensure that the cache writing only affects the
  * top most level of the history stack. As this is where the current request is stored.
@@ -90,6 +107,7 @@ class ToolbarHelperTestCase extends CakeTestCase {
 		$result = $this->Toolbar->readCache('test', 1);
 		$this->assertEquals($result, array('second', 'values'));
 	}
+
 /**
  * test cache reading for views
  *
@@ -108,6 +126,7 @@ class ToolbarHelperTestCase extends CakeTestCase {
 		$result = $this->Toolbar->readCache('test');
 		$this->assertEquals($result, array('new', 'stuff'), 'Cache value is wrong %s');
 	}
+
 /**
  * Test that reading/writing doesn't work with no cache config.
  *
@@ -122,6 +141,7 @@ class ToolbarHelperTestCase extends CakeTestCase {
 		$result = $this->Toolbar->readCache('test');
 		$this->assertFalse($result, 'Reading cache succeeded with no cache config %s');
 	}
+
 /**
  * ensure that getQueryLogs works and writes to the cache so the history panel will
  * work.

--- a/Test/test_app/Controller/DebugKitTestController.php
+++ b/Test/test_app/Controller/DebugKitTestController.php
@@ -1,37 +1,65 @@
 <?php
 /**
- * DebugKitTestController
+ * DebugKit TestController of test_app
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.tests.test_app
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Test.TestApp.Controller
  * @since         DebugKit 0.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
+
+/**
+ * Class DebugKitTestController
+ *
+ * @package       DebugKit.Test.TestApp.Controller
+ * @since         DebugKit 0.1
+ */
 class DebugKitTestController extends Controller {
 
+/**
+ * Mame of the Controller
+ *
+ * @var string
+ */
 	public $name = 'DebugKitTest';
 
+/**
+ * Uses no Models
+ *
+ * @var array
+ */
 	public $uses = array();
 
+/**
+ * Uses only DebugKit Toolbar Component
+ *
+ * @var array
+ */
 	public $components = array('DebugKit.Toolbar');
 
+/**
+ * Return Request Action Value
+ *
+ * @return string
+ */
 	public function request_action_return() {
 		$this->autoRender = false;
 		return 'I am some value from requestAction.';
 	}
 
+/**
+ * Render Request Action
+ */
 	public function request_action_render() {
 		$this->set('test', 'I have been rendered.');
 	}
-
 }

--- a/Test/test_app/Lib/Panel/TestPanel.php
+++ b/Test/test_app/Lib/Panel/TestPanel.php
@@ -1,24 +1,35 @@
 <?php
 /**
- * Test Panel 
+ * Test Panel of test_app
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.tests.test_app
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Test.TestApp.Lib.Panel
  * @since         DebugKit 0.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+/**
+ * Class TestPanel
+ *
+ * @package       DebugKit.Test.TestApp.Lib.Panel
+ * @since         DebugKit 0.1
  */
 class TestPanel extends DebugPanel {
 
+/**
+ * Startup
+ *
+ * @param Controller $controller
+ */
 	public function startup(Controller $controller) {
 		$controller->testPanel = true;
 	}

--- a/Test/test_app/Plugin/DebugkitTestPlugin/Lib/Panel/PluginTestPanel.php
+++ b/Test/test_app/Plugin/DebugkitTestPlugin/Lib/Panel/PluginTestPanel.php
@@ -1,4 +1,25 @@
 <?php
+/**
+ * Test Panel of test_app
+ *
+ * PHP 5
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Test.TestApp.Lib.Plugin.DebugKitTestPlugin.Lib.Panel
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
 
+/**
+ * Class PluginTestPanel
+ *
+ * @package       DebugKit.Test.TestApp.Lib.Plugin.DebugKitTestPlugin.Lib.Panel
+ */
 class PluginTestPanel extends DebugPanel {
 }

--- a/Test/test_app/View/DebugKitTest/request_action_render.ctp
+++ b/Test/test_app/View/DebugKitTest/request_action_render.ctp
@@ -1,1 +1,19 @@
+<?php
+/**
+ * Request Action Render template
+ *
+ * PHP 5
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.Test.TestApp.View.DebugKitTest
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+?>
 <?php echo $test; ?>

--- a/View/Elements/debug_toolbar.ctp
+++ b/View/Elements/debug_toolbar.ctp
@@ -4,20 +4,19 @@
  *
  * Renders all of the other panel elements.
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.views.elements
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.View.Elements
  * @since         DebugKit 0.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
 ?>
 <div id="debug-kit-toolbar">

--- a/View/Elements/environment_panel.ctp
+++ b/View/Elements/environment_panel.ctp
@@ -1,3 +1,23 @@
+<?php
+/**
+ * Environment Panel Element
+ *
+ * Shows information about the current app environment
+ *
+ * PHP 5
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.View.Elements
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+?>
 <h2><?php echo __d('debug_kit', 'App Constants'); ?></h2>
 <?php
 	if (!empty($content['app'])) {

--- a/View/Elements/history_panel.ctp
+++ b/View/Elements/history_panel.ctp
@@ -2,20 +2,19 @@
 /**
  * View Variables Panel Element
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.views.elements
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.View.Elements
  * @since         DebugKit 1.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
 ?>
 <h2> <?php echo __d('debug_kit', 'Request History'); ?></h2>

--- a/View/Elements/include_panel.ctp
+++ b/View/Elements/include_panel.ctp
@@ -2,20 +2,19 @@
 /**
  * Included Files Element
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.views.elements
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.View.Elements
  * @since         DebugKit 2.0
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
 ?>
 <h2> <?php echo __d('debug_kit', 'Included Files'); ?></h2>

--- a/View/Elements/log_panel.ctp
+++ b/View/Elements/log_panel.ctp
@@ -2,20 +2,19 @@
 /**
  * Log Panel Element
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.views.elements
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.View.Elements
  * @since         DebugKit 0.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
 ?>
 <h2><?php echo __d('debug_kit', 'Logs') ?></h2>

--- a/View/Elements/request_panel.ctp
+++ b/View/Elements/request_panel.ctp
@@ -2,20 +2,19 @@
 /**
  * Request Panel Element
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.views.elements
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.View.Elements
  * @since         DebugKit 0.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
 ?>
 <h2> <?php echo __d('debug_kit', 'Request'); ?></h2>

--- a/View/Elements/session_panel.ctp
+++ b/View/Elements/session_panel.ctp
@@ -2,20 +2,19 @@
 /**
  * Session Panel Element
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.views.elements
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.View.Elements
  * @since         DebugKit 1.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
 ?>
 <h2><?php echo __d('debug_kit', 'Session'); ?></h2>

--- a/View/Elements/sqllog_panel.ctp
+++ b/View/Elements/sqllog_panel.ctp
@@ -2,21 +2,21 @@
 /**
  * SQL Log Panel Element
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.views.elements
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.View.Elements
  * @since         DebugKit 0.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 $headers = array('Query', 'Affected', 'Num. rows', 'Took (ms)', 'Actions');
 if (isset($debugKitInHistoryMode)) {
 	$content = $this->Toolbar->readCache('sql_log', $this->request->params['pass'][0]);

--- a/View/Elements/timer_panel.ctp
+++ b/View/Elements/timer_panel.ctp
@@ -2,20 +2,19 @@
 /**
  * Timer Panel Element
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.views.elements
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.View.Elements
  * @since         DebugKit 0.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
 
 $this->Number = $this->Helpers->load('Number');

--- a/View/Elements/variables_panel.ctp
+++ b/View/Elements/variables_panel.ctp
@@ -2,20 +2,19 @@
 /**
  * View Variables Panel Element
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.views.elements
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.View.Elements
  * @since         DebugKit 0.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
 ?>
 <h2> <?php echo __d('debug_kit', 'View Variables'); ?></h2>

--- a/View/Helper/DebugTimerHelper.php
+++ b/View/Helper/DebugTimerHelper.php
@@ -1,27 +1,33 @@
 <?php
-App::uses('DebugTimer', 'DebugKit.Lib');
-App::uses('DebugMemory', 'DebugKit.Lib');
-App::uses('Helper', 'View');
-
 /**
  * Debug TimerHelper
  *
  * Tracks time and memory usage while rendering view.
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.View.Helper
  * @since         DebugKit 2.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
+
+App::uses('DebugTimer', 'DebugKit.Lib');
+App::uses('DebugMemory', 'DebugKit.Lib');
+App::uses('Helper', 'View');
+
+/**
+ * Class DebugTimerHelper
+ *
+ * @package       DebugKit.View.Helper
+ */
 class DebugTimerHelper extends Helper {
 
 /**
@@ -36,7 +42,7 @@ class DebugTimerHelper extends Helper {
  * Constructor
  *
  * @param View $View
- * @para array $array
+ * @param array $settings
  */
 	public function __construct(View $View, $settings = array()) {
 		parent::__construct($View, $settings);
@@ -66,7 +72,7 @@ class DebugTimerHelper extends Helper {
  * Stops the timer point before rendering a file.
  *
  * @param string $viewFile The view being rendered
- * @param string $contents The contents of the view.
+ * @param string $content The contents of the view.
  */
 	public function afterRenderFile($viewFile, $content) {
 		if ($this->_renderComplete) {
@@ -86,5 +92,4 @@ class DebugTimerHelper extends Helper {
 		DebugMemory::record(__d('debug_kit', 'View render complete'));
 		$this->_renderComplete = true;
 	}
-
 }

--- a/View/Helper/FirePhpToolbarHelper.php
+++ b/View/Helper/FirePhpToolbarHelper.php
@@ -4,24 +4,29 @@
  *
  * Injects the toolbar elements into non-HTML layouts via FireCake.
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.views.helpers
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.View.Helper
  * @since         DebugKit 0.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
+
 App::uses('ToolbarHelper', 'DebugKit.View/Helper');
 App::uses('FireCake', 'DebugKit.Lib');
 
+/**
+ * Class FirePhpToolbarHelper
+ *
+ * @package       DebugKit.View.Helper
+ */
 class FirePhpToolbarHelper extends ToolbarHelper {
 
 /**
@@ -87,6 +92,8 @@ class FirePhpToolbarHelper extends ToolbarHelper {
 /**
  * Start a panel which is a 'Group' in FirePHP
  *
+ * @param $title
+ * @param $anchor
  * @return void
  */
 	public function panelStart($title, $anchor) {

--- a/View/Helper/HtmlToolbarHelper.php
+++ b/View/Helper/HtmlToolbarHelper.php
@@ -5,24 +5,30 @@
  * Injects the toolbar elements into HTML layouts.
  * Contains helper methods for
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.views.helpers
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.View.Helper
  * @since         DebugKit 0.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
+
 App::uses('ToolbarHelper', 'DebugKit.View/Helper');
 App::uses('Security', 'Utility');
 
+/**
+ * Class HtmlToolbarHelper
+ *
+ * @package       DebugKit.View.Helper
+ * @since         DebugKit 0.1
+ */
 class HtmlToolbarHelper extends ToolbarHelper {
 
 /**
@@ -45,6 +51,7 @@ class HtmlToolbarHelper extends ToolbarHelper {
  * @param mixed $values Array to make pretty.
  * @param int $openDepth Depth to add open class
  * @param int $currentDepth current depth.
+ * @param bool $doubleEncode
  * @return string
  */
 	public function makeNeatArray($values, $openDepth = 0, $currentDepth = 0, $doubleEncode = false) {
@@ -107,9 +114,11 @@ class HtmlToolbarHelper extends ToolbarHelper {
 
 /**
  * Start a panel.
- * make a link and anchor.
+ * Make a link and anchor.
  *
- * @return void
+ * @param $title
+ * @param $anchor
+ * @return string
  */
 	public function panelStart($title, $anchor) {
 		$link = $this->Html->link($title, '#' . $anchor);
@@ -134,7 +143,7 @@ class HtmlToolbarHelper extends ToolbarHelper {
 	}
 
 /**
- * send method
+ * Send method
  *
  * @return void
  */
@@ -167,6 +176,7 @@ class HtmlToolbarHelper extends ToolbarHelper {
  * Generates a SQL explain link for a given query
  *
  * @param string $sql SQL query string you want an explain link for.
+ * @param $connection
  * @return string Rendered Html link or '' if the query is not a select/describe
  */
 	public function explainLink($sql, $connection) {

--- a/View/Helper/SimpleGraphHelper.php
+++ b/View/Helper/SimpleGraphHelper.php
@@ -4,24 +4,30 @@
  *
  * Allows creation and display of extremely simple graphing elements
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.views.helpers
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.View.Helper
  * @since         DebugKit 1.0
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
+
 App::uses('AppHelper', 'View/Helper');
 App::uses('HtmlHelper', 'View/Helper');
 
+/**
+ * Class SimpleGraphHelper
+ *
+ * @package       DebugKit.View.Helper
+ * @since         DebugKit 1.0
+ */
 class SimpleGraphHelper extends AppHelper {
 
 /**
@@ -54,7 +60,7 @@ class SimpleGraphHelper extends AppHelper {
  *
  * @param $value Value to be graphed
  * @param $offset how much indentation
- * @param $options Graph options
+ * @param array|\Graph $options Graph options
  * @return string Html graph
  */
 	public function bar($value, $offset, $options = array()) {

--- a/View/Helper/TidyHelper.php
+++ b/View/Helper/TidyHelper.php
@@ -1,30 +1,31 @@
 <?php
-App::uses('File', 'Utility');
-
 /**
- * Tidy helper - passes html through tidy on the command line, and reports markup errors
+ * Tidy Helper
  *
- * PHP version 4 and 5
+ * Passes html through tidy on the command line, and reports markup errors
  *
- * Copyright (c) 2009, Andy Dawson
+ * PHP 5
+ *
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) 2009, Andy Dawson
- * @link          www.ad7six.com
- * @package       debug_kit
- * @subpackage    debug_kit.views.helpers
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.View.Helper
  * @since         v 1.0 (22-Jun-2009)
- * @license       http://www.opensource.org/licenses/mit-license.php The MIT License
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
+App::uses('File', 'Utility');
 
 /**
  * TidyHelper class
  *
  * @uses          AppHelper
- * @package       debug_kit
- * @subpackage    debug_kit.views.helpers
+ * @package       DebugKit.View.Helper
+ * @since         v 1.0 (22-Jun-2009)
  */
 class TidyHelper extends AppHelper {
 
@@ -57,7 +58,7 @@ class TidyHelper extends AppHelper {
 		$errors = $this->tidyErrors($html, $out);
 
 		if (!$errors) {
-			return;
+			return array();
 		}
 		$result = array('Error' => array(), 'Warning' => array(), 'Misc' => array());
 		$errors = explode("\n", $errors);
@@ -146,7 +147,7 @@ class TidyHelper extends AppHelper {
 		$File->delete();
 
 		if (!file_exists($errors)) {
-			return;
+			return '';
 		}
 		$Error = new File($errors);
 		$errors = $Error->read();
@@ -159,7 +160,7 @@ class TidyHelper extends AppHelper {
  *
  * @param mixed $cmd
  * @param mixed $out null
- * @return void
+ * @return boolean True if successful
  * @access protected
  */
 	protected function _exec($cmd, &$out = null) {
@@ -179,5 +180,4 @@ class TidyHelper extends AppHelper {
 		}
 		return $_out ? $_out : true;
 	}
-
 }

--- a/View/Helper/ToolbarHelper.php
+++ b/View/Helper/ToolbarHelper.php
@@ -1,27 +1,35 @@
 <?php
 /**
- * Abstract Toolbar helper. Provides Base methods for content
- * specific debug toolbar helpers. Acts as a facade for other toolbars helpers as well.
+ * Abstract Toolbar helper.
  *
- * PHP versions 5
+ * Provides Base methods for content specific debug toolbar helpers.
+ * Acts as a facade for other toolbars helpers as well.
+ *
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.views.helpers
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.View.Helper
  * @since         DebugKit 0.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
+
 App::uses('DebugKitDebugger', 'DebugKit.Lib');
 App::uses('AppHelper', 'View/Helper');
 App::uses('ConnectionManager', 'Model');
 
+/**
+ * Class ToolbarHelper
+ *
+ * @package       DebugKit.View.Helper
+ * @since         DebugKit 0.1
+ */
 class ToolbarHelper extends AppHelper {
 
 /**
@@ -41,8 +49,9 @@ class ToolbarHelper extends AppHelper {
 /**
  * Construct the helper and make the backend helper.
  *
- * @param string $options
- * @return void
+ * @param $View
+ * @param array|string $options
+ * @return \ToolbarHelper
  */
 	public function __construct($View, $options = array()) {
 		$this->_myName = strtolower(get_class($this));
@@ -100,7 +109,7 @@ class ToolbarHelper extends AppHelper {
  *
  * @param string $method
  * @param mixed $params
- * @return void
+ * @return mixed|void
  */
 	public function __call($method, $params) {
 		if (method_exists($this->{$this->_backEndClassName}, $method)) {
@@ -116,7 +125,7 @@ class ToolbarHelper extends AppHelper {
  *
  * @param string $name Name of the panel you are replacing.
  * @param string $content Content to write to the panel.
- * @return boolean Sucess of write.
+ * @return boolean Success of write.
  */
 	public function writeCache($name, $content) {
 		if (!$this->_cacheEnabled) {
@@ -131,6 +140,7 @@ class ToolbarHelper extends AppHelper {
  * Read the toolbar
  *
  * @param string $name Name of the panel you want cached data for
+ * @param int $index
  * @return mixed Boolean false on failure, array of data otherwise.
  */
 	public function readCache($name, $index = 0) {

--- a/View/ToolbarAccess/history_state.ctp
+++ b/View/ToolbarAccess/history_state.ctp
@@ -2,21 +2,21 @@
 /**
  * Toolbar history state view.
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.views.helpers
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.View.ToolbarAccess
  * @since         DebugKit 1.0
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  **/
+
 $panels = array();
 foreach ($toolbarState as $panelName => $panel) {
 	$panels[$panelName] = $this->element($panel['elementName'], array(

--- a/webroot/js/js_debug_toolbar.js
+++ b/webroot/js/js_debug_toolbar.js
@@ -7,17 +7,16 @@
  *
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org
- * @package       debug_kit
- * @subpackage    debug_kit.views.helpers
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       DebugKit.webroot.js
  * @since         DebugKit 0.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 var DEBUGKIT = function () {
 	var undef;


### PR DESCRIPTION
Now every php file has a header comment block with all the CakePHP standard stuff
Synced PHP version annotations
Fixed @license tag, url comes first
Removed all @subpackage, replaced by only @package
Fixed @package tags to reflect directory structure
Whitespace and other minor code cleanup
Fixed many @param and @return tags
Now phpDocumentator doesn't complain anything
Copied @since tags from file comment block to class, now appears in api docs, too
