### PR TITLE
replaced queries on PHP_OS by stripos

### DIFF
--- a/Lib/Panel/IncludePanel.php
+++ b/Lib/Panel/IncludePanel.php
@@ -90,7 +90,7 @@ class IncludePanel extends DebugPanel {
  * @return array
  */
 	protected function _includePaths() {
-		$split = (strstr(PHP_OS, 'win')) ? ';' : ':';
+		$split = (stripos(PHP_OS, 'win') !== false) ? ';' : ':';
 		$paths = array_flip(array_merge(explode($split, get_include_path()), array(CAKE)));
 
 		unset($paths['.']);

--- a/Test/Case/Lib/DebugTimerTest.php
+++ b/Test/Case/Lib/DebugTimerTest.php
@@ -52,7 +52,7 @@ class DebugTimerTest extends CakeTestCase {
 		sleep(1);
 		$this->assertTrue(DebugTimer::stop('test2'));
 		$elapsed = DebugTimer::elapsedTime('test2');
-		$expected = strpos(PHP_OS, 'WIN') === false ? 0.999: 0.95; // Windows timer's precision is bad
+		$expected = stripos(PHP_OS, 'win') === false ? 0.999: 0.95; // Windows timer's precision is bad
 		$this->assertTrue($elapsed >= $expected);
 
 		DebugTimer::start('test3');


### PR DESCRIPTION
stripos is case insensitive.

strstr in IncludePanel.php seems to make no sense since it doesn't use the return value of strstr

strpos in DebugTimerTest.php probably works in most cases but as noted on the Stack Overflow article http://stackoverflow.com/questions/738823/possible-values-for-php-os it can also return "Windows".
