### PR TITLE
current doesn't always return first item in array, reset does

### DIFF
--- a/Lib/DebugTimer.php
+++ b/Lib/DebugTimer.php
@@ -126,7 +126,7 @@ class DebugTimer {
 
 		$times = array();
 		if (!empty(self::$_timers)) {
-			$firstTimer = current(self::$_timers);
+			$firstTimer = reset(self::$_timers);
 			$_end = $firstTimer['start'];
 		} else {
 			$_end = $now;


### PR DESCRIPTION
I've been having issues with negative "core processing" times. Turned out that the self::$_timers array pointer was not always on the first item. Using reset in stead of current solves this.
