### PR TITLE
Transparent icon when toolbar is hidden

### DIFF
--- a/webroot/css/debug_toolbar.css
+++ b/webroot/css/debug_toolbar.css
@@ -374,3 +374,11 @@
 	content : ' Loading...';
 	font-style:italic;
 }
+
+/* Minimized mode */
+#debug-kit-toolbar.minimized {
+	opacity: 0.4;
+}
+#debug-kit-toolbar.minimized:hover {
+	opacity: inherit;
+}

--- a/webroot/js/js_debug_toolbar.js
+++ b/webroot/js/js_debug_toolbar.js
@@ -858,6 +858,13 @@ DEBUGKIT.toolbarToggle = function () {
 				Cookie.write('toolbarDisplay', display);
 			});
 			toolbarHidden = !toolbarHidden;
+
+			if (toolbarHidden) {
+				$('#debug-kit-toolbar').addClass('minimized');
+			} else {
+				$('#debug-kit-toolbar').removeClass('minimized');
+			}
+
 			return false;
 		}
 	};


### PR DESCRIPTION
![debugkit_trans](https://f.cloud.github.com/assets/2929454/943705/aff892ce-0250-11e3-9293-0e5be4da4bfd.png)

Make toolbar icon transparent when compact mode so as not to hide upper-right of the page.
It switches opaque as in the past when expanding mode.
