### PR TITLE
Notice if a stream is not configured instead of silently swallowing it.

### DIFF
--- a/Lib/Log/Engine/DebugKitLog.php
+++ b/Lib/Log/Engine/DebugKitLog.php
@@ -33,7 +33,7 @@ class DebugKitLog implements CakeLogInterface {
 /**
  * Makes the reverse link needed to get the logs later.
  *
- * @param $options
+ * @param array $options
  * @return \DebugKitLog
  */
 	public function __construct($options) {
@@ -43,14 +43,19 @@ class DebugKitLog implements CakeLogInterface {
 /**
  * Captures log messages in memory
  *
- * @param $type
- * @param $message
+ * @param string $type
+ * @param string $message
  * @return void
  */
 	public function write($type, $message) {
+		if (!CakeLog::stream($type)) {
+			trigger_error(__d('debug_kit', 'Logging stream %s not configured', $type));
+		}
+
 		if (!isset($this->logs[$type])) {
 			$this->logs[$type] = array();
 		}
 		$this->logs[$type][] = array(date('Y-m-d H:i:s'), $message);
 	}
+
 }


### PR DESCRIPTION
Currently, the enabled debug kit would inject its own logging engine which swallows non-configured streams.
This happens silently, so you just wonder where the logging actually went.

Example:

```
// this should just log to File in /logs/facebook_test.log
CakeLog::write('facebook_test', 'access login');
```

But it doesn't, since the Debug logger already logs and turns $logged to true.
Thus the following vital part is not executed anymore:

```
if (!$logged) {
    self::_autoConfig();
    self::stream('default')->write($type, $message);
}
```

Or is there a better way? Where you don't have to "configure" all your log streams manually?
