### PR TITLE
SQLLogger has an WARNING if using blowfish

### DIFF
--- a/View/Helper/HtmlToolbarHelper.php
+++ b/View/Helper/HtmlToolbarHelper.php
@@ -180,7 +180,7 @@ class HtmlToolbarHelper extends ToolbarHelper {
 		if (!preg_match('/^[\s()]*SELECT/i', $sql)) {
 			return '';
 		}
-		$hash = Security::hash($sql . $connection, null, true);
+		$hash = Security::hash($sql . $connection);
 		$url = array(
 			'plugin' => 'debug_kit',
 			'controller' => 'toolbar_access',


### PR DESCRIPTION
passing `true` as salt for blowfish causes an E_USER_WARNING error
