### PR TITLE
Added merge of cache config settings if found

### DIFF
--- a/Controller/Component/ToolbarComponent.php
+++ b/Controller/Component/ToolbarComponent.php
@@ -385,19 +385,18 @@ class ToolbarComponent extends Component implements CakeEventListener {
  * @return void
  */
 	protected function _createCacheConfig() {
-		if (Configure::read('Cache.disable') !== true) {
-			if (!Cache::config('debug_kit')) {
-				$cache = array(
-					'duration' => $this->cacheDuration,
-					'engine' => 'File',
-					'path' => CACHE
-				);
-				if (isset($this->settings['cache'])) {
-					$cache = array_merge($cache, $this->settings['cache']);
-				}
-				Cache::config('debug_kit', $cache);
-			}
+		if (Configure::read('Cache.disable') === true || Cache::config('debug_kit')) {
+			return;
 		}
+		$cache = array(
+		    'duration' => $this->cacheDuration,
+		    'engine' => 'File',
+		    'path' => CACHE
+		);
+		if (isset($this->settings['cache'])) {
+			$cache = array_merge($cache, $this->settings['cache']);
+		}
+		Cache::config('debug_kit', $cache);
 	}
 
 /**


### PR DESCRIPTION
This change allows you to define the cache config used by the Toolbar component somewhere like your bootstrap file. This would avoid having to do an environment check in your controller to define environment specific caching options. 
