### PR TITLE
Update afterFind() callback signature to be PHP5.4+ compliant with CakePHP.

### DIFF
--- a/Model/Behavior/TimedBehavior.php
+++ b/Model/Behavior/TimedBehavior.php
@@ -72,7 +72,7 @@ class TimedBehavior extends ModelBehavior {
  * @param $primary
  * @return boolean true.
  */
-	public function afterFind(Model $Model, $results, $primary) {
+	public function afterFind(Model $Model, $results, $primary = false) {
 		DebugKitDebugger::stopTimer($Model->alias . '_find');
 		return true;
 	}


### PR DESCRIPTION
See https://github.com/cakephp/cakephp/pull/1623.
