### PR TITLE
Add installer-name to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     "extra": {
         "branch-alias": {
             "dev-master": "2.2.x-dev"
-        }
+        },
+        "installer-name": "DebugKit"
     }
 }


### PR DESCRIPTION
To avoid users needing to set installer-path for this plugin.
See: https://github.com/composer/installers#custom-install-names
