### PR TITLE
Fix declaration compatibility issue

### DIFF
--- a/Model/Behavior/TimedBehavior.php
+++ b/Model/Behavior/TimedBehavior.php
@@ -96,7 +96,7 @@ class TimedBehavior extends ModelBehavior {
  * @param string $created
  * @return boolean Always true
  */
-	public function afterSave(Model $Model, $created) {
+	public function afterSave(Model $Model, $created, $options = array()) {
 		DebugKitDebugger::stopTimer($Model->alias . '_save');
 		return true;
 	}


### PR DESCRIPTION
Declaration of TimedBehavior::afterSave() should be compatible with ModelBehavior::afterSave(Model $model, $created, $options = Array)
