### PR TITLE
Properly reset TestFireCake class during tests

### DIFF
--- a/Test/Case/Lib/DebugKitDebuggerTest.php
+++ b/Test/Case/Lib/DebugKitDebuggerTest.php
@@ -36,6 +36,8 @@ class DebugKitDebuggerTest extends CakeTestCase {
 	public function setUp() {
 		parent::setUp();
 		Configure::write('log', false);
+		$this->firecake = FireCake::getInstance('TestFireCake');
+		TestFireCake::reset();
 	}
 
 /**
@@ -47,6 +49,7 @@ class DebugKitDebuggerTest extends CakeTestCase {
 		parent::tearDown();
 		Configure::write('log', true);
 		DebugKitDebugger::clearTimers();
+		TestFireCake::reset();
 	}
 
 /**
@@ -55,7 +58,6 @@ class DebugKitDebuggerTest extends CakeTestCase {
  * @return void
  */
 	public function testOutput() {
-		$firecake = FireCake::getInstance('TestFireCake');
 		Debugger::getInstance('DebugKitDebugger');
 		Debugger::addFormat('fb', array('callback' => 'DebugKitDebugger::fireError'));
 		Debugger::outputAs('fb');
@@ -64,7 +66,7 @@ class DebugKitDebuggerTest extends CakeTestCase {
 		$foo .= '';
 		restore_error_handler();
 
-		$result = $firecake->sentHeaders;
+		$result = $this->firecake->sentHeaders;
 
 		$this->assertRegExp('/GROUP_START/', $result['X-Wf-1-1-1-1']);
 		$this->assertRegExp('/ERROR/', $result['X-Wf-1-1-1-2']);

--- a/Test/Case/Lib/FireCakeTest.php
+++ b/Test/Case/Lib/FireCakeTest.php
@@ -37,6 +37,16 @@ class FireCakeTestCase extends CakeTestCase {
  */
 	public function setUp() {
 		$this->firecake = FireCake::getInstance('TestFireCake');
+		TestFireCake::reset();
+	}
+
+/**
+ * Reset the FireCake counters and headers.
+ *
+ * @return void
+ */
+	public function tearDown() {
+		TestFireCake::reset();
 	}
 
 /**
@@ -334,12 +344,4 @@ class FireCakeTestCase extends CakeTestCase {
 		$this->assertPattern('/"options"\:\{"maxObjectDepth"\:\d*,/', $json);
 	}
 
-/**
- * Reset the FireCake counters and headers.
- *
- * @return void
- */
-	public function tearDown() {
-		TestFireCake::reset();
-	}
 }

--- a/Test/Case/View/Helper/FirePhpToolbarHelperTest.php
+++ b/Test/Case/View/Helper/FirePhpToolbarHelperTest.php
@@ -27,7 +27,6 @@ App::uses('ToolbarHelper', 'DebugKit.View/Helper');
 App::uses('FirePhpToolbarHelper', 'DebugKit.View/Helper');
 
 require_once $path . 'Test' . DS . 'Case' . DS . 'TestFireCake.php';
-FireCake::getInstance('TestFireCake');
 
 /**
  * Class FirePhpToolbarHelperTestCase
@@ -54,7 +53,8 @@ class FirePhpToolbarHelperTestCase extends CakeTestCase {
 		$this->Toolbar = new ToolbarHelper($this->View, array('output' => 'DebugKit.FirePhpToolbar'));
 		$this->Toolbar->FirePhpToolbar = new FirePhpToolbarHelper($this->View);
 
-		$this->firecake = FireCake::getInstance();
+		$this->firecake = FireCake::getInstance('TestFireCake');
+		TestFireCake::reset();
 	}
 
 /**


### PR DESCRIPTION
Closes #119

https://cakephp.lighthouseapp.com/projects/42880/tickets/119-FirePHPToolbarHelper-tests-fail-by-default-when-all-DebugKit-test-are-run-together-via-cakePHP-Test-Suite
