### PR TITLE
Update HtmlToolbarHelper to use ‘sha1’ for the explain_sql hash

### DIFF
--- a/Controller/ToolbarAccessController.php
+++ b/Controller/ToolbarAccessController.php
@@ -108,7 +108,7 @@ class ToolbarAccessController extends DebugKitAppController {
 		) {
 			throw new BadRequestException('Invalid parameters');
 		}
-		$hash = Security::hash($this->request->data['log']['sql'] . $this->request->data['log']['ds'], null, true);
+		$hash = Security::hash($this->request->data['log']['sql'] . $this->request->data['log']['ds'], 'sha1', true);
 		if ($hash !== $this->request->data['log']['hash']) {
 			throw new BadRequestException('Invalid parameters');
 		}


### PR DESCRIPTION
- In pull https://github.com/cakephp/debug_kit/pull/46 the View/Helper/HtmlToolbarHelper was updated to use ‘sha1’ for the explain_sql hash, but the controller is still using the system default.  If the system default is something other than ‘sha1’ the call will fall because the hashes will not match.  I've just updated ToolbarAccessController to use 'sha1' when evaluating the hash in explain_sql()
