### PR TITLE
Don't loop infinitely with cyclic references.

### DIFF
--- a/Test/Case/View/Helper/HtmlToolbarHelperTest.php
+++ b/Test/Case/View/Helper/HtmlToolbarHelperTest.php
@@ -127,6 +127,37 @@ class HtmlToolbarHelperTestCase extends CakeTestCase {
 	}
 
 /**
+ * Test that cyclic references can be printed.
+ *
+ * @return void
+ */
+	public function testMakeNeatArrayCyclicObjects() {
+		$a = new StdClass;
+		$b = new StdClass;
+		$a->child = $b;
+		$b->parent = $a;
+
+		$in = array('obj' => $a);
+		$result = $this->Toolbar->makeNeatArray($in);
+		$expected = array(
+			array('ul' => array('class' => 'neat-array depth-0')),
+			'<li', '<strong', 'obj', '/strong', '(object)',
+			array('ul' => array('class' => 'neat-array depth-1')),
+			'<li', '<strong', 'child', '/strong', '(object)',
+			array('ul' => array('class' => 'neat-array depth-2')),
+			'<li', '<strong', 'parent', '/strong',
+			'(object) - recursion',
+			'/li',
+			'/ul',
+			'/li',
+			'/ul',
+			'/li',
+			'/ul'
+		);
+		$this->assertTags($result, $expected);
+	}
+
+/**
  * Test Neat Array formatting
  *
  * @return void

--- a/View/Helper/HtmlToolbarHelper.php
+++ b/View/Helper/HtmlToolbarHelper.php
@@ -50,6 +50,10 @@ class HtmlToolbarHelper extends ToolbarHelper {
  * @return string
  */
 	public function makeNeatArray($values, $openDepth = 0, $currentDepth = 0, $doubleEncode = false) {
+		static $printedObjects = null;
+		if ($currentDepth === 0) {
+			$printedObjects = new SplObjectStorage();
+		}
 		$className = "neat-array depth-$currentDepth";
 		if ($openDepth > $currentDepth) {
 			$className .= ' expanded';
@@ -90,12 +94,22 @@ class HtmlToolbarHelper extends ToolbarHelper {
 				$value = 'function';
 			}
 
+			$isObject = is_object($value);
+			if ($isObject && $printedObjects->contains($value)) {
+				$isObject = false;
+				$value = ' - recursion';
+			}
+
+			if ($isObject) {
+				$printedObjects->attach($value);
+			}
+
 			if (
 				(
 				$value instanceof ArrayAccess ||
 				$value instanceof Iterator ||
 				is_array($value) ||
-				is_object($value)
+				$isObject
 				) && !empty($value)
 			) {
 				$out .= $this->makeNeatArray($value, $openDepth, $nextDepth, $doubleEncode);


### PR DESCRIPTION
Object chains can easily contain cycles, printing those values to HTML should not recurse infinitely.

Refs #135
