### PR TITLE
Fix failing test when debug = 1

### DIFF
--- a/Test/Case/View/Helper/ToolbarHelperTest.php
+++ b/Test/Case/View/Helper/ToolbarHelperTest.php
@@ -146,6 +146,10 @@ class ToolbarHelperTestCase extends CakeTestCase {
  * @return void
  */
 	public function testGetQueryLogs() {
+		if (Configure::read('debug') < 2) {
+			$this->markTestSkipped('Can\'t test query logging when debug < 2');
+		}
+
 		$model = new CakeTestModel(array('table' => 'posts', 'alias' => 'Post'));
 		$model->find('all');
 		$model->find('first');


### PR DESCRIPTION
Noticed this when trying to reproduce #145:

Assertions don't pass because core dbosources only return query logs when debug > 1.
