### PR TITLE
Better output for empty query logs.

### DIFF
--- a/View/Elements/sql_log_panel.ctp
+++ b/View/Elements/sql_log_panel.ctp
@@ -34,21 +34,29 @@ if (isset($debugKitInHistoryMode)) {
 			else:
 				$queryLog = $content[$dbName];
 			endif;
-			echo '<h5>';
-			echo __d(
-				'debug_kit',
-				'Total Time: %s ms <br />Total Queries: %s queries',
-				$queryLog['time'],
-				$queryLog['count']
-			);
-			echo '</h5>';
-			echo $this->Toolbar->table($queryLog['queries'], $headers, array('title' => 'SQL Log ' . $dbName));
+			if (empty($queryLog['queries'])):
+				if (Configure::read('debug') < 2):
+					echo ' ' . __d('debug_kit', 'No query logs when debug < 2.');
+				else:
+					echo ' ' . __d('debug_kit', 'No query logs.');
+				endif;
+			else:
+				echo '<h5>';
+				echo __d(
+					'debug_kit',
+					'Total Time: %s ms <br />Total Queries: %s queries',
+					$queryLog['time'],
+					$queryLog['count']
+				);
+				echo '</h5>';
+				echo $this->Toolbar->table($queryLog['queries'], $headers, array('title' => 'SQL Log ' . $dbName));
 			?>
 		<h4><?php echo __d('debug_kit', 'Query Explain:'); ?></h4>
 		<div id="sql-log-explain-<?php echo $dbName ?>">
 			<a id="debug-kit-explain-<?php echo $dbName ?>"> </a>
 			<p><?php echo __d('debug_kit', 'Click an "Explain" link above, to see the query explanation.'); ?></p>
 		</div>
+		<?php endif; ?>
 	</div>
 	<?php endforeach; ?>
 <?php else:


### PR DESCRIPTION
Related to #146, the SqlLog panel view didn't seem to handle cases where there are no query logs.

I think it may be better to display a message rather than the current behaviour ("Total Time: %s ms Total Queries: %s" followed by an empty table).
