### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Ensure `require` is present in `composer.json`. This will install the plugin int
 
 ```
 {
+    "extra": {
+	"installer-paths": {
+	    "app/Plugin/DebugKit": ["cakephp/debug_kit"]
+        }
+    },
     "require": {
         "cakephp/debug_kit": "2.2.*"
     }


### PR DESCRIPTION
Adding the installer-path in composer.json allow DebugKit to run the same way than the manual install.
