### PR TITLE
Fix history_state requestfailing

### DIFF
--- a/Controller/ToolbarAccessController.php
+++ b/Controller/ToolbarAccessController.php
@@ -88,6 +88,8 @@ class ToolbarAccessController extends DebugKitAppController {
 		$oldState = $this->Toolbar->loadState($key);
 		$this->set('toolbarState', $oldState);
 		$this->set('debugKitInHistoryMode', true);
+		$this->viewClass = null;
+		$this->layout = null;
 	}
 
 /**


### PR DESCRIPTION
When RequestHandler and parsing .json extension are enabledm history_state rendering will fail (will search for .ctp in json subdir). Setting view and layout to null in controller will keep proper response rendering no matter if RequestHandler is enabled.
