### PR TITLE
wrong sqlPanel id prevents explain sql link from working

### DIFF
--- a/webroot/js/js_debug_toolbar.js
+++ b/webroot/js/js_debug_toolbar.js
@@ -97,7 +97,7 @@ DEBUGKIT.sqlLog = function () {
 
 	return {
 		init : function () {
-			var sqlPanel = $('#sqllog-tab');
+			var sqlPanel = $('#sql_log-tab');
 			var buttons = sqlPanel.find('input');
 
 			// Button handling code for explain links.


### PR DESCRIPTION
Without the fix, it performs the default html POST resulting in a new page.
