### PR TITLE
Add required Croogo plugin files

### DIFF
--- a/Config/bootstrap.php
+++ b/Config/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+
+if (CakePlugin::loaded('Croogo')) {
+	Croogo::hookComponent('*', 'DebugKit.Toolbar');
+}

--- a/Config/plugin.json
+++ b/Config/plugin.json
@@ -1,0 +1,12 @@
+{
+ "name": "DebugKit",
+ "description": "DebugKit",
+
+ "author": "CakePHP",
+ "authorUrl": "http://cakephp.org",
+
+ "dependencies": {
+  "plugins": [
+    "extensions"
+  ]
+ }


### PR DESCRIPTION
Croogo is a CakePHP based CMS that requires these files in order to
show a plugin the admin panel.
