### PR TITLE
Update debug_toolbar.ctp

### DIFF
--- a/View/Elements/debug_toolbar.ctp
+++ b/View/Elements/debug_toolbar.ctp
@@ -25,7 +25,7 @@
 		<ul id="panel-tabs">
 			<li class="panel-tab icon">
 				<a href="#hide" id="hide-toolbar">
-					<?php echo $this->Html->image('/debug_kit/img/cake.icon.png', array('alt' => 'CakePHP')); ?>
+					<?php echo $this->Html->image('cake.icon.png', array('alt' => 'CakePHP', 'plugin' => 'DebugKit')); ?>
 				</a>
 			</li>
 		<?php foreach ($debugToolbarPanels as $panelName => $panelInfo): ?>


### PR DESCRIPTION
The reference to the image now takes into account the plugin option for correctly referencing the image location
