### PR TITLE
Remove AppHelper from SimpleGraphHelper since it no longer exists

### DIFF
--- a/src/View/Helper/SimpleGraphHelper.php
+++ b/src/View/Helper/SimpleGraphHelper.php
@@ -13,8 +13,7 @@
  */
 namespace DebugKit\View\Helper;
 
-use App\View\Helper\AppHelper;
-use App\View\Helper\HtmlHelper;
+use Cake\View\Helper;
 
 /**
  * Class SimpleGraphHelper
@@ -23,7 +22,7 @@ use App\View\Helper\HtmlHelper;
  *
  * @since         DebugKit 1.0
  */
-class SimpleGraphHelper extends AppHelper {
+class SimpleGraphHelper extends Helper {
 
 /**
  * Helpers


### PR DESCRIPTION
Does what it says on the tin.

SimpleGraphHelper was extending AppHelper, which was removed from Cakephp/App.
