### PR TITLE
skip Unserializable object for caching history

### DIFF
--- a/src/Controller/Component/ToolbarComponent.php
+++ b/src/Controller/Component/ToolbarComponent.php
@@ -462,7 +462,8 @@ class ToolbarComponent extends Component {
 				if (
 					$item instanceof Closure ||
 					$item instanceof PDO ||
-					$item instanceof SimpleXmlElement
+					$item instanceof SimpleXmlElement ||
+					$item instanceof \Cake\ORM\Query
 				) {
 					$item = 'Unserializable object - ' . get_class($item);
 				} elseif ($item instanceof Exception) {


### PR DESCRIPTION
skip Unserializable object for caching history.
To receive this error(You cannot serialize or unserialize PDO instances)
