### PR TITLE
Use z-index to put panel on top of all DOM elements

### DIFF
--- a/webroot/js/toolbar.js
+++ b/webroot/js/toolbar.js
@@ -25,7 +25,7 @@
 		}
 		var body = doc.getElementsByTagName('body');
 		iframe = doc.createElement('iframe');
-		iframe.setAttribute('style', 'position: fixed; bottom: 0; right: 0; border: 0; outline: 0; overflow: hidden; z-index: 9999999999;');
+		iframe.setAttribute('style', 'position: fixed; bottom: 0; right: 0; border: 0; outline: 0; overflow: hidden; z-index: 99999;');
 		iframe.height = 40;
 		iframe.width = 40;
 		iframe.src = __debug_kit_base_url + 'debug_kit/toolbar/view/' + __debug_kit_id;


### PR DESCRIPTION
Without z-index attribute, there can be cases when panel is below DOM elements and can not show correctly.
