### PR TITLE
Fix rendering artifact

### DIFF
--- a/webroot/css/toolbar.css
+++ b/webroot/css/toolbar.css
@@ -7,6 +7,7 @@ body {
 	padding: 0;
 	margin: 0;
 	font-family: Helvetica, Arial, sans-serif;
+	overflow: hidden;
 }
 
 /**


### PR DESCRIPTION
Fixes the icon being overlaid by scrollbars upon first load (when "minimised") in Chrome.
![debugkit rendering-artifact](https://cloud.githubusercontent.com/assets/5319760/4101495/682ac7a0-30ee-11e4-852b-872a221c1d2b.png)
