### PR TITLE
3.0 add collapse from entire bar

### DIFF
--- a/src/Template/Requests/view.ctp
+++ b/src/Template/Requests/view.ctp
@@ -8,7 +8,7 @@ use Cake\Routing\Router;
 	</div>
 </div>
 
-<ul class="toolbar">
+<ul id="toolbar" class="toolbar">
 	<li id="panel-button">
 		<?= $this->Html->image('DebugKit.cake.icon.png', ['alt' => 'Debug Kit']) ?>
 	</li>
@@ -31,7 +31,7 @@ var baseUrl = "<?= Router::url('/', true); ?>";
 
 $(document).ready(function() {
 	var toolbar = new Toolbar({
-		button: $('#panel-button'),
+		button: $('#toolbar'),
 		content: $('#panel-content-container'),
 		panelButtons: $('.panel'),
 		panelClose: $('#panel-close')
@@ -43,6 +43,7 @@ $(document).ready(function() {
 
 	toolbar.panelButtons.on('click', function(e) {
 		e.preventDefault();
+		e.stopPropagation();
 		var id = $(this).data('id');
 		var samePanel = toolbar.currentPanel() === id;
 


### PR DESCRIPTION
With this modification it allow to use the empty space of the toolbar to collapse it.
![capture](https://cloud.githubusercontent.com/assets/4977112/4116722/8df897c8-3288-11e4-8c05-11bdf0684fcd.PNG)

I think that it can be quite convenient if you just want to toogle the toolbar quickly to see to timers or log displayed in the toolbar.

I didn't add the `cursor:pointer` for the whole toolbar is it show exactly where the buttons are but I can also update this if you feel that it's needed
