### PR TITLE
3.0 update timer bar creation

### DIFF
--- a/src/Template/Element/timer_panel.ctp
+++ b/src/Template/Element/timer_panel.ctp
@@ -75,8 +75,8 @@ $this->addHelper('DebugKit.SimpleGraph');
 			</td>
 			<td class="right-text"><?= $this->Number->precision($timeInfo['time'] * 1000, 2) ?></td>
 			<td><?= $this->SimpleGraph->bar(
-				$this->Number->precision($timeInfo['time'] * 1000, 2),
-				$this->Number->precision($timeInfo['start'] * 1000, 2),
+				$timeInfo['time'] * 1000,
+				$timeInfo['start'] * 1000,
 				array(
 					'max' => $maxTime * 1000,
 					'requestTime' => $requestTime * 1000,


### PR DESCRIPTION
the `Cake\Utility\Number::precision()` doesn't return float anymore but string in 3.0
This causes that if a time value is over 1000ms, with the locale formating the conversion string to int in the `bar()` function will return 1 instead of 1000 (as the number is send to the function as a string like `1,834.24` in us or '1 834,24' in france).
Screenshot before the modification: 
![capture1](https://cloud.githubusercontent.com/assets/4977112/4131083/72f21d0a-3341-11e4-87b2-0fd18afc7d47.PNG)

after : 
![capture2](https://cloud.githubusercontent.com/assets/4977112/4131085/812a2106-3341-11e4-81c8-d3c12c4c474b.PNG)
