### PR TITLE
Add pdo-sqlite extension as requirement in composer.json.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
 	},
 	"require": {
 		"php": ">=5.4.19",
+		"ext-pdo-sqlite": "*",
 		"cakephp/plugin-installer": "dev-master"
 	},
 	"require-dev": {


### PR DESCRIPTION
Refs cakephp/cakephp#4478

Not entirely sure if this is a good idea though. Currently at least you can complete app installation and then just comment out the plugin load statement in bootstrap.
