### PR TITLE
3.0 - update `Cake\Error\NotFoundException`

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ expected to have a filename of `src/Panel/MyCustomPanel.php`.
 ```php
 namespace App\Panel;
 
-use Cake\DebugKit\DebugPanel;
+use DebugKit\DebugPanel;
 
 /**
  * My Custom Panel

--- a/src/Controller/PanelsController.php
+++ b/src/Controller/PanelsController.php
@@ -13,8 +13,8 @@ namespace DebugKit\Controller;
 
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
-use Cake\Error\NotFoundException;
 use Cake\Event\Event;
+use Cake\Network\Exception\NotFoundException;
 
 /**
  * Provides access to panel data.

--- a/src/Controller/RequestsController.php
+++ b/src/Controller/RequestsController.php
@@ -13,8 +13,8 @@ namespace DebugKit\Controller;
 
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
-use Cake\Error\NotFoundException;
 use Cake\Event\Event;
+use Cake\Network\Exception\NotFoundException;
 
 /**
  * Provides access to panel data.

--- a/src/Controller/ToolbarController.php
+++ b/src/Controller/ToolbarController.php
@@ -14,8 +14,8 @@ namespace DebugKit\Controller;
 use Cake\Cache\Cache;
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
-use Cake\Error\NotFoundException;
 use Cake\Event\Event;
+use Cake\Network\Exception\NotFoundException;
 
 /**
  * Provides utility features need by the toolbar.

--- a/src/Panel/IncludePanel.php
+++ b/src/Panel/IncludePanel.php
@@ -14,8 +14,8 @@ namespace DebugKit\Panel;
 
 use Cake\Controller\Controller;
 use Cake\Core\Plugin;
-use DebugKit\DebugPanel;
 use Cake\Event\Event;
+use DebugKit\DebugPanel;
 
 /**
  * Provides a list of included files for the current request

--- a/src/Panel/LogPanel.php
+++ b/src/Panel/LogPanel.php
@@ -13,9 +13,9 @@
 namespace DebugKit\Panel;
 
 use Cake\Controller\Controller;
-use DebugKit\DebugPanel;
 use Cake\Event\Event;
 use Cake\Log\Log;
+use DebugKit\DebugPanel;
 
 /**
  * Log Panel - Reads log entries made this request.

--- a/src/Panel/PanelRegistry.php
+++ b/src/Panel/PanelRegistry.php
@@ -12,9 +12,9 @@
 namespace DebugKit\Panel;
 
 use Cake\Core\App;
+use Cake\Core\ObjectRegistry;
 use Cake\Event\EventManager;
 use Cake\Event\EventManagerTrait;
-use Cake\Core\ObjectRegistry;
 
 /**
  * Registry object for panels.

--- a/src/Panel/RequestPanel.php
+++ b/src/Panel/RequestPanel.php
@@ -13,9 +13,9 @@
 namespace DebugKit\Panel;
 
 use Cake\Controller\Controller;
-use DebugKit\DebugPanel;
 use Cake\Event\Event;
 use Cake\Routing\Router;
+use DebugKit\DebugPanel;
 
 /**
  * Provides debug information on the Current request params.

--- a/src/Panel/SessionPanel.php
+++ b/src/Panel/SessionPanel.php
@@ -13,8 +13,8 @@
 namespace DebugKit\Panel;
 
 use Cake\Controller\Controller;
-use DebugKit\DebugPanel;
 use Cake\Event\Event;
+use DebugKit\DebugPanel;
 
 /**
  * Provides debug information on the Session contents.

--- a/src/Panel/VariablesPanel.php
+++ b/src/Panel/VariablesPanel.php
@@ -13,9 +13,9 @@
 namespace DebugKit\Panel;
 
 use Cake\Controller\Controller;
-use DebugKit\DebugPanel;
 use Cake\Event\Event;
 use Cake\Database\Query;
+use DebugKit\DebugPanel;
 
 /**
  * Provides debug information on the View variables.

--- a/src/Routing/Filter/DebugBarFilter.php
+++ b/src/Routing/Filter/DebugBarFilter.php
@@ -11,8 +11,6 @@
  */
 namespace DebugKit\Routing\Filter;
 
-use DebugKit\Panel\DebugPanel;
-use DebugKit\Panel\PanelRegistry;
 use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
@@ -21,6 +19,8 @@ use Cake\ORM\TableRegistry;
 use Cake\Routing\DispatcherFilter;
 use Cake\Routing\Router;
 use Cake\Utility\String;
+use DebugKit\Panel\DebugPanel;
+use DebugKit\Panel\PanelRegistry;
 
 /**
  * Toolbar injector filter.

--- a/src/View/Helper/TidyHelper.php
+++ b/src/View/Helper/TidyHelper.php
@@ -13,9 +13,9 @@
 namespace DebugKit\View\Helper;
 
 use Cake\Core\Configure;
-use Cake\Log\Log;
 use Cake\Error\Debugger;
 use Cake\Filesystem\File;
+use Cake\Log\Log;
 
 /**
  * TidyHelper class

--- a/src/View/Helper/ToolbarHelper.php
+++ b/src/View/Helper/ToolbarHelper.php
@@ -14,8 +14,8 @@
 namespace DebugKit\View\Helper;
 
 use Cake\Datasource\ConnectionManager;
-use Cake\Event\Event;
 use Cake\Cache\Cache;
+use Cake\Event\Event;
 use Cake\View\Helper;
 use DebugKit\DebugKitDebugger;
 

--- a/tests/TestCase/Database/Log/DebugLogTest.php
+++ b/tests/TestCase/Database/Log/DebugLogTest.php
@@ -13,8 +13,8 @@
 namespace DebugKit\Test\TestCase\Database\Log;
 
 use Cake\Database\Log\LoggedQuery;
-use DebugKit\Database\Log\DebugLog;
 use Cake\TestSuite\TestCase;
+use DebugKit\Database\Log\DebugLog;
 
 /**
  * DebugLog test case

--- a/tests/TestCase/DebugTimerTest.php
+++ b/tests/TestCase/DebugTimerTest.php
@@ -13,8 +13,8 @@
  */
 namespace DebugKit\Test\TestCase;
 
-use Cake\TestSuite\TestCase;
 use Cake\Error\Debugger;
+use Cake\TestSuite\TestCase;
 use DebugKit\DebugTimer;
 
 /**

--- a/tests/TestCase/Panel/CachePanelTest.php
+++ b/tests/TestCase/Panel/CachePanelTest.php
@@ -12,8 +12,8 @@
  **/
 namespace DebugKit\Test\TestCase\Panel;
 
-use Cake\Event\Event;
 use Cake\Cache\Cache;
+use Cake\Event\Event;
 use Cake\TestSuite\TestCase;
 use DebugKit\Panel\CachePanel;
 


### PR DESCRIPTION
following today's previous PR : 
- update `Cake\Error\NotFoundException` to `Cake\Network\Exception\NotFoundException`
- sort namespaces by alphabetic order
