### PR TITLE
Add request method to history panel.

### DIFF
--- a/src/Routing/Filter/DebugBarFilter.php
+++ b/src/Routing/Filter/DebugBarFilter.php
@@ -142,6 +142,7 @@ class DebugBarFilter extends DispatcherFilter {
 		$data = [
 			'url' => $request->here(),
 			'content_type' => $response->type(),
+			'method' => $request->method(),
 			'status_code' => $response->statusCode(),
 			'requested_at' => $request->env('REQUEST_TIME'),
 			'panels' => []

--- a/src/Template/Element/history_panel.ctp
+++ b/src/Template/Element/history_panel.ctp
@@ -30,8 +30,9 @@ use Cake\Routing\Router;
 			<li>
 				<a class="history-link" data-request="<?= $request->id ?>" href="<?= $this->Url->build($url) ?>">
 					<span class="history-time"><?= h($request->requested_at) ?></span>
-					<span class="history-code"><?= h($request->status_code) ?></span>
-					<span class="history-type"><?= h($request->content_type) ?></span>
+					<span class="history-bubble"><?= h($request->method) ?></span>
+					<span class="history-bubble"><?= h($request->status_code) ?></span>
+					<span class="history-bubble"><?= h($request->content_type) ?></span>
 					<span class="history-url"><?= h($request->url) ?></span>
 				</a>
 			</li>

--- a/tests/Fixture/RequestFixture.php
+++ b/tests/Fixture/RequestFixture.php
@@ -31,6 +31,7 @@ class RequestFixture extends TestFixture {
 		'url' => ['type' => 'string', 'null' => false],
 		'content_type' => ['type' => 'string'],
 		'status_code' => ['type' => 'integer'],
+		'method' => ['type' => 'string'],
 		'requested_at' => ['type' => 'datetime', 'null' => false],
 		'_constraints' => [
 			'primary' => ['type' => 'primary', 'columns' => ['id']],

--- a/tests/TestCase/Routing/Filter/DebugBarFilterTest.php
+++ b/tests/TestCase/Routing/Filter/DebugBarFilterTest.php
@@ -89,7 +89,10 @@ class DebugBarFilterTest extends TestCase {
  * @return void
  */
 	public function testAfterDispatchSavesData() {
-		$request = new Request(['url' => '/articles']);
+		$request = new Request([
+			'url' => '/articles',
+			'environment' => ['REQUEST_METHOD' => 'GET']
+		]);
 		$response = new Response([
 			'statusCode' => 200,
 			'type' => 'text/html',
@@ -108,6 +111,7 @@ class DebugBarFilterTest extends TestCase {
 			->contain('Panels')
 			->first();
 
+		$this->assertEquals('GET', $result->method);
 		$this->assertEquals('/articles', $result->url);
 		$this->assertNotEmpty($result->requested_at);
 		$this->assertNotEmpty('text/html', $result->content_type);

--- a/webroot/css/toolbar.css
+++ b/webroot/css/toolbar.css
@@ -325,14 +325,9 @@ table th {
 	padding: 6px;
 }
 
-.history-type,
-.history-code,
-.history-time {
+.history-bubble {
 	font-size: 12px;
 	line-height: 14px;
-}
-.history-type,
-.history-code {
 	display: inline-block;
 	background: #eee;
 	padding: 2px;


### PR DESCRIPTION
Display a request's HTTP method in the history output. It looks like:

![screen shot 2014-09-12 at 7 52 07 pm](https://cloud.githubusercontent.com/assets/24086/4258687/e25d9672-3ad7-11e4-9e33-ef22adc0681e.png)
