### PR TITLE
Removing unnecessary calls to addHelper

### DIFF
--- a/src/Template/Element/timer_panel.ctp
+++ b/src/Template/Element/timer_panel.ctp
@@ -11,8 +11,6 @@
  * @since         DebugKit 0.1
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-$this->addHelper('Number');
-$this->addHelper('DebugKit.SimpleGraph');
 ?>
 <section>
 	<h3><?= __d('debug_kit', 'Memory') ?></h3>


### PR DESCRIPTION
Helper in Core and inside the same plugin are lazy loaded, there is no
need to load them manually. This also removes the deprecation warning
for addHelper
