### PR TITLE
Fix toolbar failing under IE

### DIFF
--- a/webroot/js/toolbar-app.js
+++ b/webroot/js/toolbar-app.js
@@ -214,8 +214,15 @@ Toolbar.prototype = {
 		});
 	},
 
+	windowOrigin : function() {
+		// IE does not have access to window.location.origin
+		if (!window.location.origin) {
+			window.location.origin = window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port: '');
+		}
+	},
+
 	initialize: function() {
-		this.mouseListener();
+		this.windowOrigin();
 		this.keyboardListener();
 		this.loadState();
 	}


### PR DESCRIPTION
Internet Explorer does not have access to window.location.origin.  This fixes any access to that property when using IE.
