### PR TITLE
Fix toolbar

### DIFF
--- a/webroot/js/toolbar-app.js
+++ b/webroot/js/toolbar-app.js
@@ -223,6 +223,7 @@ Toolbar.prototype = {
 
 	initialize: function() {
 		this.windowOrigin();
+		this.mouseListener();
 		this.keyboardListener();
 		this.loadState();
 	}


### PR DESCRIPTION
#280 (32cc439b87d14c9f8293704ba554066684bcadd2) removed the call to `mouseListener()` in the toolbar initialisation (Probably accidently). This has the rather major side effect of completely breaking the toolbar as it no longer listens to `click` events.
