### PR TITLE
Catch exceptions when serializing panel data.

### DIFF
--- a/src/Routing/Filter/DebugBarFilter.php
+++ b/src/Routing/Filter/DebugBarFilter.php
@@ -181,12 +181,19 @@ class DebugBarFilter extends DispatcherFilter {
 
 		foreach ($this->_registry->loaded() as $name) {
 			$panel = $this->_registry->{$name};
+			try {
+				$content = serialize($panel->data());
+			} catch (\Exception $e) {
+				$content = serialize([
+					'error' => $e->getMessage(),
+				]);
+			}
 			$row->panels[] = $requests->Panels->newEntity([
 				'panel' => $name,
 				'element' => $panel->elementName(),
 				'title' => $panel->title(),
 				'summary' => $panel->summary(),
-				'content' => serialize($panel->data())
+				'content' => $content,
 			]);
 		}
 		$row = $requests->save($row);

--- a/src/Template/Element/variables_panel.ctp
+++ b/src/Template/Element/variables_panel.ctp
@@ -11,7 +11,13 @@
  * @since         DebugKit 0.1
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-echo $this->Toolbar->makeNeatArray($content);
+if (isset($error)):
+	printf('<p class="warning">%s</p>', $error);
+endif;
+
+if (!empty($content)):
+	echo $this->Toolbar->makeNeatArray($content);
+endif;
 
 if (!empty($errors)):
 	echo '<h4>Validation errors</h4>';


### PR DESCRIPTION
There are many places that PDO or other non-serializable objects could be hiding in application data. While we can try to filter out known bad things, there is always a risk of objects containing non-serializable objects in private/protected properties. In these situations we can only catch the exception and nerf the panel.

Refs cakephp/cakephp#5358
