### PR TITLE
3.0 fill error array only if From actually has errors

### DIFF
--- a/src/Panel/VariablesPanel.php
+++ b/src/Panel/VariablesPanel.php
@@ -97,7 +97,10 @@ class VariablesPanel extends DebugPanel
             if ($v instanceof EntityInterface) {
                 $errors[$k] = $this->_getErrors($v);
             } elseif ($v instanceof Form) {
-                $errors[$k] = $v->errors();
+                $formError = $v->errors();
+                if (!empty($formError)) {
+                    $errors[$k] = $formError;
+                }
             }
         }
 


### PR DESCRIPTION
to avoid the empty validation error array to be display in  the variable panel.

Sorry I shouldn't omit that in my previous PR.
