### PR TITLE
Alternate background color for debug tables

### DIFF
--- a/src/Template/Element/cache_panel.ctp
+++ b/src/Template/Element/cache_panel.ctp
@@ -22,13 +22,16 @@
         <span class="inline-message"></span>
         <table cellspacing="0" cellpadding="0" class="debug-table">
             <thead>
-                <tr><th><?= __d('debug_kit', 'Metric') ?></th><th><?= __d('debug_kit', 'Total') ?></th></tr>
+                <tr>
+                    <th><?= __d('debug_kit', 'Metric') ?></th>
+                    <th><?= __d('debug_kit', 'Total') ?></th>
+                </tr>
             </thead>
             <tbody>
             <?php foreach ($counters as $key => $val): ?>
                 <tr>
-                <td><?= h($key) ?></td>
-                <td class="right-text"><?= $val ?></td>
+                    <td><?= h($key) ?></td>
+                    <td class="right-text"><?= $val ?></td>
                 </tr>
             <?php endforeach; ?>
             </tbody>

--- a/src/Template/Element/environment_panel.ctp
+++ b/src/Template/Element/environment_panel.ctp
@@ -16,67 +16,105 @@
  */
 use Cake\Utility\Inflector;
 ?>
-<?php
-    if (!empty($app)) {
-        $cakeRows = array();
-        foreach ($app as $key => $val) {
-            $cakeRows[] = array(
-                h($key),
-                h($val)
-            );
-        }
-        $headers = array('Constant', 'Value');
-        echo $this->Toolbar->table($cakeRows, $headers);
-    } else {
-        echo "No application environment available.";
-    } ?>
+
+<h2><?= __d('debug_kit', 'Application Constants') ?></h2>
+
+<?php if (!empty($app)): ?>
+<table cellspacing="0" cellpadding="0" class="debug-table">
+    <thead>
+        <tr>
+            <th>Constant</th>
+            <th>Value</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($app as $key => $val): ?>
+        <tr>
+            <td><?= h($key) ?></td>
+            <td><?= h($val) ?></td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+<?php else: ?>
+<div class="warning">
+    <?= __d('debug_kit', 'No application environment available.'); ?>
+</div>
+<?php endif; ?>
 
 <h2><?= __d('debug_kit', 'CakePHP Constants') ?></h2>
-<?php
-    if (!empty($cake)) {
-        $cakeRows = array();
-        foreach ($cake as $key => $val) {
-            $cakeRows[] = array(
-                h($key),
-                h($val)
-            );
-        }
-        $headers = array('Constant', 'Value');
-        echo $this->Toolbar->table($cakeRows, $headers);
-    } else {
-        echo "CakePHP environment unavailable.";
-    } ?>
+
+<?php if (!empty($cake)): ?>
+<table cellspacing="0" cellpadding="0" class="debug-table">
+    <thead>
+        <tr>
+            <th>Constant</th>
+            <th>Value</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($cake as $key => $val): ?>
+        <tr>
+            <td><?= h($key) ?></td>
+            <td><?= h($val) ?></td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+<?php else: ?>
+<div class="warning">
+    <?= __d('debug_kit', 'CakePHP environment unavailable.'); ?>
+</div>
+<?php endif; ?>
 
 <h2><?= __d('debug_kit', 'PHP Environment') ?></h2>
-<?php
-    $headers = array('Environment Variable', 'Value');
 
-    if (!empty($php)) {
-        $phpRows = array();
-        foreach ($php as $key => $val) {
-            $phpRows[] = array(
-                h($key),
-                h($val)
-            );
-        }
-        echo $this->Toolbar->table($phpRows, $headers);
-    } else {
-        echo "PHP environment unavailable.";
-    }
+<?php if (!empty($php)): ?>
+<table cellspacing="0" cellpadding="0" class="debug-table">
+    <thead>
+        <tr>
+            <th>Environment Variable</th>
+            <th>Value</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($php as $key => $val): ?>
+        <tr>
+            <td><?= h($key) ?></td>
+            <td><?= h($val) ?></td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+<?php else: ?>
+<div class="warning">
+    <?= __d('debug_kit', 'PHP environment unavailable.'); ?>
+</div>
+<?php endif; ?>
 
-    if (isset($hidef)) {
-        echo '<h2>' . __d('debug_kit', 'Hidef Environment') . '</h2>';
-        if (!empty($hidef)) {
-            $cakeRows = array();
-            foreach ($hidef as $key => $val) {
-                $cakeRows[] = array(
-                    h($key),
-                    h($val)
-                );
-            }
-            $headers = array('Constant', 'Value');
-            echo $this->Toolbar->table($cakeRows, $headers);
-        } else {
-            echo "No Hidef environment available.";
-        }
-    }
+<?php if (isset($hidef)): ?>
+    <h2><?= __d('debug_kit', 'Hidef Environment') ?></h2>
+
+    <?php if (!empty($hidef)): ?>
+    <table cellspacing="0" cellpadding="0" class="debug-table">
+        <thead>
+            <tr>
+                <th>Constant</th>
+                <th>Value</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($hidef as $key => $val): ?>
+            <tr>
+                <td><?= h($key) ?></td>
+                <td><?= h($val) ?></td>
+            </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+    <?php else: ?>
+    <div class="warning">
+        <?= __d('debug_kit', 'No Hidef environment available.'); ?>
+    </div>
+    <?php endif; ?>
+<?php endif; ?>

--- a/src/Template/Element/log_panel.ctp
+++ b/src/Template/Element/log_panel.ctp
@@ -20,13 +20,16 @@ use DebugKit\Log\DebugKitLog;
         <h3><?= __d('debug_kit', '{0} Messages', h(ucfirst($logName))) ?> </h3>
         <table cellspacing="0" cellpadding="0" class="debug-table">
             <thead>
-                <tr><th><?= __d('debug_kit', 'Time') ?></th><th><?= __d('debug_kit', 'Message') ?></th></tr>
+                <tr>
+                    <th><?= __d('debug_kit', 'Time') ?></th>
+                    <th><?= __d('debug_kit', 'Message') ?></th>
+                </tr>
             </thead>
             <tbody>
             <?php foreach ($logs as $log): ?>
                 <tr>
-                <td width="200" class="code"><?= $log[0] ?></td>
-                <td><?= h($log[1]) ?></td>
+                    <td width="200" class="code"><?= $log[0] ?></td>
+                    <td><?= h($log[1]) ?></td>
                 </tr>
             <?php endforeach; ?>
             </tbody>

--- a/src/Template/Element/sql_log_panel.ctp
+++ b/src/Template/Element/sql_log_panel.ctp
@@ -52,21 +52,24 @@ $noOutput = true;
         ?>
         </h5>
 
-        <?php $sqlLogRows = [];
-            foreach ($queries as $query) {
-                $sqlLogRows[] = [
-                    h($query['query']),
-                    h($query['rows']),
-                    h($query['took']),
-                ];
-            }
-            $headers = [
-                __d('debug_kit', 'Query'),
-                __d('debug_kit', 'Num rows'),
-                __d('debug_kit', 'Took (ms)'),
-            ];
-            echo $this->Toolbar->table($sqlLogRows, $headers);
-        ?>
+        <table cellspacing="0" cellpadding="0">
+            <thead>
+                <tr>
+                    <th><?= __d('debug_kit', 'Query') ?></th>
+                    <th><?= __d('debug_kit', 'Query') ?></th>
+                    <th><?= __d('debug_kit', 'Took (ms)') ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($queries as $query): ?>
+                <tr>
+                    <td><?= h($query['query']) ?></td>
+                    <td><?= h($query['rows']) ?></td>
+                    <td><?= h($query['took']) ?></td>
+                </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
     </div>
     <?php endforeach; ?>
 <?php endif; ?>

--- a/src/Template/Element/timer_panel.ctp
+++ b/src/Template/Element/timer_panel.ctp
@@ -21,14 +21,17 @@
 
     <table cellspacing="0" cellpadding="0">
         <thead>
-            <tr><th><?= __d('debug_kit', 'Message') ?></th><th><?= __d('debug_kit', 'Memory Use') ?></th></tr>
+            <tr>
+                <th><?= __d('debug_kit', 'Message') ?></th>
+                <th><?= __d('debug_kit', 'Memory Use') ?></th>
+            </tr>
         </thead>
         <tbody>
         <?php foreach ($memory as $key => $value): ?>
-        <tr>
-            <td><?= h($key) ?></td>
-            <td class="right-text"><?= $this->Number->toReadableSize($value) ?></td>
-        </tr>
+            <tr>
+                <td><?= h($key) ?></td>
+                <td class="right-text"><?= $this->Number->toReadableSize($value) ?></td>
+            </tr>
         <?php endforeach; ?>
         </tbody>
     </table>
@@ -69,17 +72,19 @@
         ?>
         <tr>
             <td>
-            <?= h($indent . $timeInfo['message']) ?>
+                <?= h($indent . $timeInfo['message']) ?>
             </td>
             <td class="right-text"><?= $this->Number->precision($timeInfo['time'] * 1000, 2) ?></td>
-            <td><?= $this->SimpleGraph->bar(
-                $timeInfo['time'] * 1000,
-                $timeInfo['start'] * 1000,
-                array(
-                    'max' => $maxTime * 1000,
-                    'requestTime' => $requestTime * 1000,
-                )
-            ) ?></td>
+            <td>
+                <?= $this->SimpleGraph->bar(
+                    $timeInfo['time'] * 1000,
+                    $timeInfo['start'] * 1000,
+                    array(
+                        'max' => $maxTime * 1000,
+                        'requestTime' => $requestTime * 1000,
+                    )
+                ) ?>
+            </td>
             <?php
             $i++;
         endforeach;

--- a/src/View/Helper/ToolbarHelper.php
+++ b/src/View/Helper/ToolbarHelper.php
@@ -123,22 +123,4 @@ class ToolbarHelper extends Helper
         $out .= '</ul>';
         return $out;
     }
-
-    /**
-     * Create a table.
-     *
-     * @param array $rows Rows to make.
-     * @param array $headers Optional header row.
-     * @return string
-     */
-    public function table($rows, $headers = array())
-    {
-        $out = '<table class="debug-table">';
-        if (!empty($headers)) {
-            $out .= $this->Html->tableHeaders($headers);
-        }
-        $out .= $this->Html->tableCells($rows);
-        $out .= '</table>';
-        return $out;
-    }
 }

--- a/tests/TestCase/View/Helper/ToolbarHelperTest.php
+++ b/tests/TestCase/View/Helper/ToolbarHelperTest.php
@@ -317,29 +317,4 @@ class ToolbarHelperTest extends TestCase
         );
         $this->assertTags($result, $expected);
     }
-
-    /**
-     * Test Table generation
-     *
-     * @return void
-     */
-    public function testTable()
-    {
-        $rows = array(
-            array(1, 2),
-            array(3, 4),
-        );
-        $result = $this->Toolbar->table($rows);
-        $expected = array(
-            'table' => array('class' => 'debug-table'),
-            '<tr',
-            '<td', '1', '/td',
-            '<td', '2', '/td', '/tr',
-            '<tr',
-            '<td', '3', '/td',
-            '<td', '4', '/td', '/tr',
-            '/table'
-        );
-        $this->assertTags($result, $expected);
-    }
 }

--- a/webroot/css/toolbar.css
+++ b/webroot/css/toolbar.css
@@ -212,6 +212,9 @@ table th {
 	font-weight: bold;
 	line-height: 16px;
 }
+table tbody tr:nth-child(odd) {
+    background-color: #f9f9f9;
+}
 
 .debug-table td {
 	font-family: Monaco, Consolas, mono-space;

--- a/webroot/css/toolbar.css
+++ b/webroot/css/toolbar.css
@@ -224,7 +224,7 @@ table th {
 }
 .debug-table td:nth-child(n+2) {
 	word-wrap: break-word;
-	word-break: break-word; // Not standard for webkit
+	word-break: break-word; /* Not standard for webkit */
 }
 
 .list {


### PR DESCRIPTION
Hi guys,

I added alternative style for odd rows to improve debug tables usability.

I had to rewrite the environments and SQL log tables to avoid some CSS problems due to the DOM (no thead/tbody tags). I hope it's not a problem that I removed the use of the HTML helper to construct those tables, I think it's more readable/flexible this way and more consistant regarding the tables from the others panels.