### PR TITLE
Plugin installer dependency moved to cakephp/app

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
 		"source": "https://github.com/cakephp/debug_kit"
 	},
 	"require": {
-		"cakephp/cakephp": "3.0.*-dev",
-		"cakephp/plugin-installer": "*"
+		"cakephp/cakephp": "3.0.*-dev"
 	},
 	"require-dev": {
 		"cakephp/cakephp-codesniffer": "dev-master",


### PR DESCRIPTION
So not strictly required now in a plugin's composer file.

Would be a good idea to let some time pass after 216 is merged, so that users still have _a_ reference to the plugin installer.

Depends on https://github.com/cakephp/app/pull/216