### PR TITLE
Periodically clear out old data.

### DIFF
--- a/src/Model/Table/RequestsTable.php
+++ b/src/Model/Table/RequestsTable.php
@@ -65,4 +65,32 @@ class RequestsTable extends Table
         return $query->order(['Requests.requested_at' => 'DESC'])
             ->limit(10);
     }
+
+    /**
+     * Garbage collect old request data.
+     *
+     * Delete request data that is older than 2 weeks old.
+     * This method will only trigger periodically.
+     *
+     * @return void
+     */
+    public function gc()
+    {
+        if (time() % 100 !== 0) {
+            return;
+        }
+        $query = $this->query()
+            ->delete()
+            ->where(['requested_at <=' => new \DateTime('-2 weeks')]);
+        $statement = $query->execute();
+        $statement->closeCursor();
+
+        $existing = $this->find()->select(['id']);
+
+        $query = $this->Panels->query()
+            ->delete()
+            ->where(['request_id NOT IN' => $existing]);
+        $statement = $query->execute();
+        $statement->closeCursor();
+    }
 }

--- a/src/Routing/Filter/DebugBarFilter.php
+++ b/src/Routing/Filter/DebugBarFilter.php
@@ -184,6 +184,8 @@ class DebugBarFilter extends DispatcherFilter
             'panels' => []
         ];
         $requests = TableRegistry::get('DebugKit.Requests');
+        $requests->gc();
+
         $row = $requests->newEntity($data);
         $row->isNew(true);
 


### PR DESCRIPTION
To combat gigantic debugkit databases, we can periodically clear out old data. There may be situations where we end up clearing out all but the most recent request, but I think that's acceptable. If a person hasn't interacted with an app in 2+ weeks, they are unlikely to remember what they last did.