### PR TITLE
Use dot-notation when loading plugin panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ the panel.
 ```php
 Configure::write(
 	'DebugKit.panels',
-	array_merge((array)Configure::read('DebugKit.panels'), ['MyCustomPanel'])
+	array_merge((array)Configure::read('DebugKit.panels'), ['MyPlugin.MyCustomPanel'])
 );
 ```
 


### PR DESCRIPTION
Otherwise `App::className()` can't resolve the path to the panel.