### PR TITLE
Scrolling toolbar on small screen

### DIFF
--- a/webroot/css/toolbar.css
+++ b/webroot/css/toolbar.css
@@ -62,7 +62,7 @@ p {
 }
 .toolbar.open {
 	border-radius: 0;
-	overflow: scroll;
+	overflow: auto;
 }
 
 /* Open close button */

--- a/webroot/css/toolbar.css
+++ b/webroot/css/toolbar.css
@@ -62,6 +62,7 @@ p {
 }
 .toolbar.open {
 	border-radius: 0;
+	overflow: scroll;
 }
 
 /* Open close button */


### PR DESCRIPTION
In responsive design the variables tab gets lost from the toolbar when the screen is small. 
This solution is not elegant but it saves wondering "where did my tabs go" on smaller screen sizes.
Some sort of media-query driven popup or horizontal scroller would be better in the long run. Maybe that is in the works?