### PR TITLE
Bugfix to avoid HTML breakage. Keys must also be h() escaped on output.

### DIFF
--- a/View/Helper/HtmlToolbarHelper.php
+++ b/View/Helper/HtmlToolbarHelper.php
@@ -71,7 +71,7 @@ class HtmlToolbarHelper extends ToolbarHelper {
 			$values[] = '(empty)';
 		}
 		foreach ($values as $key => $value) {
-			$out .= '<li><strong>' . $key . '</strong>';
+			$out .= '<li><strong>' . h($key, $doubleEncode) . '</strong>';
 			if (is_array($value) && count($value) > 0) {
 				$out .= '(array)';
 			} elseif (is_object($value)) {


### PR DESCRIPTION
Without that we had totally broken pages because some keys contained mismatched HTML tags that didnt close again. Keys should also be escaped on output.