### PR TITLE
js_debug_toolbar.js activatePanel use show()

### DIFF
--- a/webroot/js/js_debug_toolbar.js
+++ b/webroot/js/js_debug_toolbar.js
@@ -748,7 +748,7 @@ DEBUGKIT.toolbar = function () {
 			if (this.panels[id] !== undefined && !this.panels[id].active) {
 				var panel = this.panels[id];
 				if (panel.content.length > 0) {
-					panel.content.css('display', 'block');
+					panel.content.show();
 				}
 
 				var contentHeight = panel.content.find('.panel-content-data').height() + 70;


### PR DESCRIPTION
Changed `js_debug_toolbar.js` `activatePanel()` to jQuery `show()`

Rationale: This makes sense because `deactivatePanel()` is using jQuery `hide()`

Justification: If you're going to use hide, you should toggle with show. -- If you aren't going to use show, you shouldn't use hide.

Discovery: This was found because on a project show/hide were over-ridden to set/remove classes vs. simply altering the display property....