### PR TITLE
Handle form instances specifically.

### DIFF
--- a/src/Panel/VariablesPanel.php
+++ b/src/Panel/VariablesPanel.php
@@ -73,6 +73,13 @@ class VariablesPanel extends DebugPanel
             if ($item instanceof Query) {
                 $item = $item->all();
             }
+            // Handle forms specifically until they implement __debugInfo
+            if ($item instanceof Form) {
+                $item = [
+                    'form class' => get_class($item),
+                    'errors' => $item->errors()
+                ];
+            }
             if ($item instanceof Closure ||
                 $item instanceof PDO ||
                 $item instanceof SimpleXmlElement
@@ -87,6 +94,9 @@ class VariablesPanel extends DebugPanel
                     $item->getFile(),
                     $item->getLine()
                 );
+            }
+            if (is_object($item) && method_exists($item, '__debugInfo')) {
+                $item = $item->__debugInfo();
             }
             return $item;
         });


### PR DESCRIPTION
Forms can contain validators which can contain closures. This chain breaks DebugKit. For now we'll hack around forms, but I'd like to add `__debugInfo` to Form, and Validator so we can not have specific hacks.

Refs cakephp/cakephp#6504