### PR TITLE
Fix variables tab not showing results for queries

### DIFF
--- a/src/Panel/VariablesPanel.php
+++ b/src/Panel/VariablesPanel.php
@@ -17,6 +17,7 @@ use Cake\Database\Query;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
 use Cake\Form\Form;
+use Cake\ORM\ResultSet;
 use Cake\Utility\Hash;
 use Closure;
 use DebugKit\DebugPanel;
@@ -70,7 +71,9 @@ class VariablesPanel extends DebugPanel
         $errors = [];
 
         $walker = function (&$item) use (&$walker) {
-            if ($item instanceof Closure ||
+            if ($item instanceof Query || $item instanceof ResultSet) {
+                $item = $item->toArray();
+            } elseif ($item instanceof Closure ||
                 $item instanceof PDO ||
                 $item instanceof SimpleXmlElement
             ) {
@@ -89,9 +92,11 @@ class VariablesPanel extends DebugPanel
             }
             return $item;
         };
-        array_walk_recursive($controller->viewVars, $walker);
+        // Copy so viewVars is not mutated.
+        $vars = $controller->viewVars;
+        array_walk_recursive($vars, $walker);
 
-        foreach ($controller->viewVars as $k => $v) {
+        foreach ($vars as $k => $v) {
             // Get the validation errors for Entity
             if ($v instanceof EntityInterface) {
                 $errors[$k] = $this->_getErrors($v);
@@ -104,7 +109,7 @@ class VariablesPanel extends DebugPanel
         }
 
         $this->_data = [
-            'content' => $controller->viewVars,
+            'content' => $vars,
             'errors' => $errors
         ];
     }

--- a/src/Panel/VariablesPanel.php
+++ b/src/Panel/VariablesPanel.php
@@ -113,4 +113,17 @@ class VariablesPanel extends DebugPanel
             'errors' => $errors
         ];
     }
+
+    /**
+     * Get summary data for the variables panel.
+     *
+     * @return int
+     */
+    public function summary()
+    {
+        if (!isset($this->_data['content'])) {
+            return 0;
+        }
+        return count($this->_data['content']);
+    }
 }

--- a/tests/TestCase/Panel/VariablesPanelTest.php
+++ b/tests/TestCase/Panel/VariablesPanelTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ **/
+namespace DebugKit\Test\TestCase\Panel;
+
+use Cake\Event\Event;
+use Cake\Form\Form;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use DebugKit\Panel\VariablesPanel;
+
+/**
+ * Class VariablesPanelTest
+ *
+ */
+class VariablesPanelTest extends TestCase
+{
+    public $fixtures = ['plugin.debug_kit.panels'];
+
+    /**
+     * set up
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->panel = new VariablesPanel();
+    }
+
+    /**
+     * Teardown method.
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+        unset($this->panel);
+    }
+
+    /**
+     * test shutdown
+     *
+     * @return void
+     */
+    public function testShutdown()
+    {
+        $panels = TableRegistry::get('DebugKit.Panels');
+        $query = $panels->find('all');
+        $result = $panels->find()->all();
+
+        $controller = new \StdClass();
+        $controller->viewVars = [
+            'query' => $query,
+            'result set' => $result,
+            'string' => 'yes',
+            'array' => ['some' => 'key']
+        ];
+        $event = new Event('Controller.shutdown', $controller);
+        $this->panel->shutdown($event);
+        $output = $this->panel->data();
+
+        $this->assertInstanceOf(
+            'Cake\ORM\Query',
+            $controller->viewVars['query'],
+            'Original value should not be mutated'
+        );
+        $this->assertInternalType('array', $output['content']['query']);
+        $this->assertInternalType('array', $output['content']['result set']);
+        $this->assertEquals($controller->viewVars['string'], $output['content']['string']);
+        $this->assertEquals($controller->viewVars['array'], $output['content']['array']);
+    }
+}

--- a/tests/TestCase/Panel/VariablesPanelTest.php
+++ b/tests/TestCase/Panel/VariablesPanelTest.php
@@ -24,7 +24,7 @@ use DebugKit\Panel\VariablesPanel;
  */
 class VariablesPanelTest extends TestCase
 {
-    public $fixtures = ['plugin.debug_kit.requests'];
+    public $fixtures = ['plugin.debug_kit.requests', 'plugin.debug_kit.panels'];
 
     /**
      * set up
@@ -55,7 +55,7 @@ class VariablesPanelTest extends TestCase
      */
     public function testShutdown()
     {
-        $requests = TableRegistry::get('DebugKit.Requests');
+        $requests = TableRegistry::get('Requests');
         $query = $requests->find('all');
         $result = $requests->find()->all();
 

--- a/tests/TestCase/Panel/VariablesPanelTest.php
+++ b/tests/TestCase/Panel/VariablesPanelTest.php
@@ -24,7 +24,7 @@ use DebugKit\Panel\VariablesPanel;
  */
 class VariablesPanelTest extends TestCase
 {
-    public $fixtures = ['plugin.debug_kit.panels'];
+    public $fixtures = ['plugin.debug_kit.requests'];
 
     /**
      * set up
@@ -55,9 +55,9 @@ class VariablesPanelTest extends TestCase
      */
     public function testShutdown()
     {
-        $panels = TableRegistry::get('DebugKit.Panels');
-        $query = $panels->find('all');
-        $result = $panels->find()->all();
+        $requests = TableRegistry::get('DebugKit.Requests');
+        $query = $requests->find('all');
+        $result = $requests->find()->all();
 
         $controller = new \StdClass();
         $controller->viewVars = [


### PR DESCRIPTION
Fix the output issues related to Query and ResultSet objects. I've also added summary for the variables panel as its nice to know at a glance roughly how big of a view you might be dealing with.