### PR TITLE
Adding the version as title to the button

### DIFF
--- a/src/Template/Requests/view.ctp
+++ b/src/Template/Requests/view.ctp
@@ -1,5 +1,7 @@
 <?php
 use Cake\Routing\Router;
+use Cake\Core\Configure;
+
 ?>
 <div id="panel-content-container">
     <span id="panel-close" class="button-close">&times;</span>
@@ -22,7 +24,8 @@ use Cake\Routing\Router;
     </li>
     <?php endforeach; ?>
     <li id="panel-button">
-        <?= $this->Html->image('DebugKit.cake.icon.png', ['alt' => 'Debug Kit']) ?>
+        <?= $this->Html->image('DebugKit.cake.icon.png',
+			['alt' => 'Debug Kit', 'title' => 'CakePHP ' . \Cake\Core\Configure::version() . ' Debug Kit']) ?>
     </li>
 </ul>
 <?php $this->start('scripts') ?>

--- a/src/Template/Requests/view.ctp
+++ b/src/Template/Requests/view.ctp
@@ -25,7 +25,7 @@ use Cake\Core\Configure;
     <?php endforeach; ?>
     <li id="panel-button">
         <?= $this->Html->image('DebugKit.cake.icon.png',
-			['alt' => 'Debug Kit', 'title' => 'CakePHP ' . \Cake\Core\Configure::version() . ' Debug Kit']) ?>
+			['alt' => 'Debug Kit', 'title' => 'CakePHP ' . Configure::version() . ' Debug Kit']) ?>
     </li>
 </ul>
 <?php $this->start('scripts') ?>


### PR DESCRIPTION
Adding the version as title to the panel button to quickly know the current running cakephp version, showing

    CakePHP 3.0.6 Debug Kit

on hover now.
Also useful for beginners or lazy ones who quickly want to know the current version the app is running with.