### PR TITLE
Better output of timer content.

### DIFF
--- a/src/Panel/SqlLogPanel.php
+++ b/src/Panel/SqlLogPanel.php
@@ -92,6 +92,6 @@ class SqlLogPanel extends DebugPanel
             $count += count($logger->queries());
             $time += $logger->totalTime();
         }
-        return "{$count} - $time ms";
+        return "$count / $time ms";
     }
 }

--- a/src/Panel/SqlLogPanel.php
+++ b/src/Panel/SqlLogPanel.php
@@ -92,6 +92,9 @@ class SqlLogPanel extends DebugPanel
             $count += count($logger->queries());
             $time += $logger->totalTime();
         }
+        if (!$count) {
+            return '0';
+        }
         return "$count / $time ms";
     }
 }

--- a/src/Panel/TimerPanel.php
+++ b/src/Panel/TimerPanel.php
@@ -122,8 +122,8 @@ class TimerPanel extends DebugPanel
      */
     public function summary()
     {
-        $time = Number::precision(DebugTimer::requestTime(), 2);
+        $time = Number::precision(DebugTimer::requestTime(), 2) . ' s';
         $memory = Number::toReadableSize(DebugMemory::getPeak());
-        return "$time s - $memory";
+        return "$time / $memory";
     }
 }

--- a/tests/TestCase/Panel/SqlLogPanelTest.php
+++ b/tests/TestCase/Panel/SqlLogPanelTest.php
@@ -93,6 +93,6 @@ class SqlLogPanelTest extends TestCase
         $articles->findById(1)->first();
 
         $result = $this->panel->summary();
-        $this->assertRegExp('/\d+ - \d+ ms/', $result);
+        $this->assertRegExp('/\d+ \\/ \d+ ms/', $result);
     }
 }

--- a/tests/TestCase/Routing/Filter/DebugBarFilterTest.php
+++ b/tests/TestCase/Routing/Filter/DebugBarFilterTest.php
@@ -142,7 +142,7 @@ class DebugBarFilterTest extends TestCase
 
         $this->assertEquals('SqlLog', $result->panels[7]->panel);
         $this->assertEquals('DebugKit.sql_log_panel', $result->panels[7]->element);
-        $this->assertNotEmpty($result->panels[7]->summary);
+        $this->assertSame('0', $result->panels[7]->summary);
         $this->assertEquals('Sql Log', $result->panels[7]->title);
 
         $expected = '<html><title>test</title><body><p>some text</p>' .


### PR DESCRIPTION
Currently, the

    Timer ( 0,25 s - 9,56 MB )

output reads as range by default. If you quickly look at it the `-` dash makes you think it is some range.
Using `/` is probably a better idea:

    Timer ( 0,25 s / 9,56 MB )

Same for the SQL Log (`Sql Log ( 0 - 0 ms )`)