### PR TITLE
Pin dependencies for DebugKit.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		"source": "https://github.com/cakephp/debug_kit"
 	},
 	"require": {
-		"cakephp/cakephp": "~3.0"
+		"cakephp/cakephp": "3.0.*"
 	},
 	"require-dev": {
 		"cakephp/cakephp-codesniffer": "dev-master",


### PR DESCRIPTION
This avoids deprecation warnings when people use 3.1.x.