### PR TITLE
Issue #354 fix - Fallback for unbuffered queries in VariablesPanel

### DIFF
--- a/src/Panel/VariablesPanel.php
+++ b/src/Panel/VariablesPanel.php
@@ -72,7 +72,12 @@ class VariablesPanel extends DebugPanel
 
         $walker = function (&$item) use (&$walker) {
             if ($item instanceof Query || $item instanceof ResultSet) {
-                $item = $item->toArray();
+                try {
+                    $item = $item->toArray();
+                } catch (\Cake\Database\Exception $e) {
+                    //Likely issue is unbuffered query; fall back to __debugInfo
+                    $item = array_map($walker, $item->__debugInfo());
+                }
             } elseif ($item instanceof Closure ||
                 $item instanceof PDO ||
                 $item instanceof SimpleXmlElement

--- a/tests/TestCase/Panel/VariablesPanelTest.php
+++ b/tests/TestCase/Panel/VariablesPanelTest.php
@@ -58,10 +58,13 @@ class VariablesPanelTest extends TestCase
         $requests = TableRegistry::get('Requests');
         $query = $requests->find('all');
         $result = $requests->find()->all();
+        $unbufferedQuery = $requests->find('all')->bufferResults(false);
+        $unbufferedQuery->toArray(); //toArray call would normally happen somewhere in View, usually implicitly
 
         $controller = new \StdClass();
         $controller->viewVars = [
             'query' => $query,
+            'unbufferedQuery' => $unbufferedQuery,
             'result set' => $result,
             'string' => 'yes',
             'array' => ['some' => 'key']
@@ -76,6 +79,7 @@ class VariablesPanelTest extends TestCase
             'Original value should not be mutated'
         );
         $this->assertInternalType('array', $output['content']['query']);
+        $this->assertInternalType('array', $output['content']['unbufferedQuery']);
         $this->assertInternalType('array', $output['content']['result set']);
         $this->assertEquals($controller->viewVars['string'], $output['content']['string']);
         $this->assertEquals($controller->viewVars['array'], $output['content']['array']);


### PR DESCRIPTION
Simple try/catch wrapper added as a fallback for unbuffered Query objects in VariablesPanel. Fixes issue #354