### PR TITLE
Format SQL queries so they are easier to read.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
 		"source": "https://github.com/cakephp/debug_kit"
 	},
 	"require": {
-		"cakephp/cakephp": "3.0.*"
+		"cakephp/cakephp": "3.0.*",
+		"jdorn/sql-formatter": "~1.2"
 	},
 	"require-dev": {
 		"cakephp/cakephp-codesniffer": "dev-master",

--- a/src/Template/Element/sql_log_panel.ctp
+++ b/src/Template/Element/sql_log_panel.ctp
@@ -16,6 +16,13 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 $noOutput = true;
+
+// Configure sqlformatter colours.
+SqlFormatter::$quote_attributes = 'style="color: #004d40;"';
+SqlFormatter::$backtick_quote_attributes = 'style="color: #26a69a;"';
+SqlFormatter::$number_attributes = 'style="color: #ec407a;"';
+SqlFormatter::$word_attributes = 'style="color: #9c27b0;"';
+SqlFormatter::$pre_attributes = 'style="color: #222; background-color: transparent;"';
 ?>
 
 <?php if (!empty($tables)): ?>
@@ -63,7 +70,7 @@ $noOutput = true;
             <tbody>
                 <?php foreach ($queries as $query): ?>
                 <tr>
-                    <td><pre><?= SqlFormatter::format($query['query'], false) ?></pre></td>
+                    <td><?= SqlFormatter::format($query['query']) ?></td>
                     <td><?= h($query['rows']) ?></td>
                     <td><?= h($query['took']) ?></td>
                 </tr>

--- a/src/Template/Element/sql_log_panel.ctp
+++ b/src/Template/Element/sql_log_panel.ctp
@@ -63,7 +63,7 @@ $noOutput = true;
             <tbody>
                 <?php foreach ($queries as $query): ?>
                 <tr>
-                    <td><?= h($query['query']) ?></td>
+                    <td><pre><?= SqlFormatter::format($query['query'], false) ?></pre></td>
                     <td><?= h($query['rows']) ?></td>
                     <td><?= h($query['took']) ?></td>
                 </tr>


### PR DESCRIPTION
Use a library to format SQL queries into a more readable formatting.

:notebook: This does not include syntax highlighting.

Refs #349