### PR TITLE
Make config() proxy more seamlessly.

### DIFF
--- a/src/Cache/Engine/DebugEngine.php
+++ b/src/Cache/Engine/DebugEngine.php
@@ -243,7 +243,8 @@ class DebugEngine extends CacheEngine
      * @param mixed $value The value to set.
      * @param bool $merge Whether or not configuration should be merged.
      */
-    public function config($key = null, $value = null, $merge = true) {
+    public function config($key = null, $value = null, $merge = true)
+    {
         return call_user_func_array([$this->_engine, 'config'], func_get_args());
     }
 

--- a/src/Cache/Engine/DebugEngine.php
+++ b/src/Cache/Engine/DebugEngine.php
@@ -234,6 +234,20 @@ class DebugEngine extends CacheEngine
     }
 
     /**
+     * Return the proxied configuration data.
+     *
+     * This method uses func_get_args() as not doing so confuses the
+     * proxied class.
+     *
+     * @param string $key The key to set/read.
+     * @param mixed $value The value to set.
+     * @param bool $merge Whether or not configuration should be merged.
+     */
+    public function config($key = null, $value = null, $merge = true) {
+        return call_user_func_array([$this->_engine, 'config'], func_get_args());
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function clearGroup($group)

--- a/tests/TestCase/Cache/Engine/DebugEngineTest.php
+++ b/tests/TestCase/Cache/Engine/DebugEngineTest.php
@@ -119,4 +119,40 @@ class DebugEngineTest extends TestCase
         $this->assertArrayHasKey('Cache.increment key', $result);
         $this->assertArrayHasKey('Cache.decrement key', $result);
     }
+
+    /**
+     * Test that groups proxies
+     *
+     * @return void
+     */
+    public function testGroupsProxies()
+    {
+        $engine = new DebugEngine([
+            'className' => 'File',
+            'path' => TMP,
+            'groups' => ['test', 'test2']
+        ]);
+        $engine->init();
+        $result = $engine->groups();
+        $this->assertEquals(['test', 'test2'], $result);
+    }
+
+    /**
+     * Test that config methods proxy the config data.
+     *
+     * @return void
+     */
+    public function testConfigProxies()
+    {
+        $engine = new DebugEngine([
+            'className' => 'File',
+            'path' => TMP
+        ]);
+        $engine->init();
+
+        $data = $engine->config();
+        $this->assertArrayHasKey('path', $data);
+        $this->assertArrayHasKey('isWindows', $data);
+        $this->assertArrayHasKey('prefix', $data);
+    }
 }


### PR DESCRIPTION
This makes the DebugEngine appear as if it is not there which is nice.

Refs #359