### PR TITLE
Remove deprecated property "layout". Add beforeRender handler to assign layout

### DIFF
--- a/src/Controller/PanelsController.php
+++ b/src/Controller/PanelsController.php
@@ -31,13 +31,6 @@ class PanelsController extends Controller
     public $components = ['RequestHandler', 'Cookie'];
 
     /**
-     * Layout property.
-     *
-     * @var string
-     */
-    public $layout = 'DebugKit.panel';
-
-    /**
      * Before filter handler.
      *
      * @param \Cake\Event\Event $event The event.
@@ -50,6 +43,17 @@ class PanelsController extends Controller
         if (!Configure::read('debug')) {
             throw new NotFoundException();
         }
+    }
+
+    /**
+     * Before render handler.
+     *
+     * @param \Cake\Event\Event $event The event.
+     * @return void
+     */
+    public function beforeRender(Event $event)
+    {
+        $this->viewBuilder()->layout('DebugKit.panel');
     }
 
     /**

--- a/src/Controller/RequestsController.php
+++ b/src/Controller/RequestsController.php
@@ -23,8 +23,6 @@ use Cake\Network\Exception\NotFoundException;
 class RequestsController extends Controller
 {
 
-    public $layout = 'DebugKit.toolbar';
-
     /**
      * Before filter handler.
      *
@@ -38,6 +36,17 @@ class RequestsController extends Controller
         if (!Configure::read('debug')) {
             throw new NotFoundException();
         }
+    }
+
+    /**
+     * Before render handler.
+     *
+     * @param \Cake\Event\Event $event The event.
+     * @return void
+     */
+    public function beforeRender(Event $event)
+    {
+        $this->viewBuilder()->layout('DebugKit.toolbar');
     }
 
     /**


### PR DESCRIPTION
After 3.1 changes, DebugKit was throwing some deprecated notices.