### PR TITLE
Remove problematic CSS that hides tabs.

### DIFF
--- a/webroot/css/debug_toolbar.css
+++ b/webroot/css/debug_toolbar.css
@@ -66,15 +66,10 @@
 	padding: 4px;
 }
 #debug-kit-toolbar .panel-tab a.edit-value {
-		float: none;
-		display: inline;
+	float: none;
+	display: inline;
 }
 
-/* Hovering over link shows tab, useful for no js  */
-#debug-kit-toolbar .panel-tab a:hover + .panel-content,
-#debug-kit-toolbar .panel-tab a + .panel-content:hover {
-	display: block;
-}
 #debug-kit-toolbar .panel-tab.icon a {
 	border-radius: 8px 0 0 8px;
 }


### PR DESCRIPTION
Some very old CSS was attempting to handle the 'no js' case, which I think is no longer a situation we should worry about. By removing these rules the tabs do not gain auto-hide/show behaviour which was the root of #367