### PR TITLE
Moved routes to config/routes.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ php composer.phar require --dev cakephp/debug_kit "~3.0"
 
 * [Load the plugin](http://book.cakephp.org/3.0/en/plugins.html#loading-a-plugin)
 ```php
-Plugin::load('DebugKit', ['bootstrap' => true]);
+Plugin::load('DebugKit', ['bootstrap' => true, 'routes' => true]);
 ```
 * Set `'debug' => true,` in `config/app.php`.
 

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -15,7 +15,6 @@ use Cake\Datasource\ConnectionManager;
 use Cake\Event\EventManager;
 use Cake\Log\Log;
 use Cake\Routing\DispatcherFactory;
-use Cake\Routing\Router;
 use DebugKit\Routing\Filter\DebugBarFilter;
 
 $debugBar = new DebugBarFilter(EventManager::instance(), (array)Configure::read('DebugKit'));
@@ -42,27 +41,6 @@ if (!$hasDebugKitConfig) {
         'quoteIdentifiers' => false,
     ]);
 }
-
-Router::plugin('DebugKit', function ($routes) {
-    $routes->extensions('json');
-    $routes->connect(
-        '/toolbar/clear_cache',
-        ['controller' => 'Toolbar', 'action' => 'clearCache']
-    );
-    $routes->connect(
-        '/toolbar/*',
-        ['controller' => 'Requests', 'action' => 'view']
-    );
-    $routes->connect(
-        '/panels/view/*',
-        ['controller' => 'Panels', 'action' => 'view']
-    );
-    $routes->connect(
-        '/panels/*',
-        ['controller' => 'Panels', 'action' => 'index']
-    );
-});
-
 
 // Setup toolbar
 $debugBar->setup();

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -11,6 +11,7 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 use Cake\Core\Configure;
+use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
 use Cake\Event\EventManager;
 use Cake\Log\Log;
@@ -40,6 +41,10 @@ if (!$hasDebugKitConfig) {
         'cacheMetadata' => true,
         'quoteIdentifiers' => false,
     ]);
+}
+
+if (Plugin::routes('DebugKit') === false) {
+    require __DIR__ . DS . 'routes.php';
 }
 
 // Setup toolbar

--- a/config/routes.php
+++ b/config/routes.php
@@ -20,6 +20,3 @@ Router::plugin('DebugKit', function ($routes) {
         ['controller' => 'Panels', 'action' => 'index']
     );
 });
-
-
-

--- a/config/routes.php
+++ b/config/routes.php
@@ -1,0 +1,25 @@
+<?php
+use Cake\Routing\Router;
+
+Router::plugin('DebugKit', function ($routes) {
+    $routes->extensions('json');
+    $routes->connect(
+        '/toolbar/clear_cache',
+        ['controller' => 'Toolbar', 'action' => 'clearCache']
+    );
+    $routes->connect(
+        '/toolbar/*',
+        ['controller' => 'Requests', 'action' => 'view']
+    );
+    $routes->connect(
+        '/panels/view/*',
+        ['controller' => 'Panels', 'action' => 'view']
+    );
+    $routes->connect(
+        '/panels/*',
+        ['controller' => 'Panels', 'action' => 'index']
+    );
+});
+
+
+


### PR DESCRIPTION
This little quirk caused a bit of pain lately when I was reloading routes and debug kit wen't into an infinite XHR loop. This allows us to reload the plugin's routes after `Router::reload()` without having to reload all bootstrap setup. The only current downside I can see to loading bootstrap again when needing the routes is that the dispatcher filter is added again. But, in the future, any additional changes to bootstrap could cause problems.

This is more of an RFC I think, because it will cause "breaking" changes in existing applications, which could be more headache than it's worth. The app skel should be updated as well as the docs.

Thoughts on this?