### PR TITLE
Removed inline javascript and style code to support Content Security Policy

### DIFF
--- a/src/Controller/RequestsController.php
+++ b/src/Controller/RequestsController.php
@@ -36,6 +36,8 @@ class RequestsController extends Controller
         if (!Configure::read('debug')) {
             throw new NotFoundException();
         }
+
+        $this->response->header(['Content-Security-Policy' => "default-src 'self'; style-src 'self' fonts.googleapis.com; font-src 'self' fonts.gstatic.com"]);
     }
 
     /**

--- a/src/Controller/RequestsController.php
+++ b/src/Controller/RequestsController.php
@@ -37,7 +37,7 @@ class RequestsController extends Controller
             throw new NotFoundException();
         }
 
-        $this->response->header(['Content-Security-Policy' => "default-src 'self'; style-src 'self' fonts.googleapis.com; font-src 'self' fonts.gstatic.com"]);
+        $this->response->header(['Content-Security-Policy' => '']);
     }
 
     /**

--- a/src/Routing/Filter/DebugBarFilter.php
+++ b/src/Routing/Filter/DebugBarFilter.php
@@ -234,7 +234,6 @@ class DebugBarFilter extends DispatcherFilter
         }
         $url = Router::url('/', true);
         $script = "<script id=\"__debug_kit\" data-id=\"{$id}\" data-url=\"{$url}\" src=\"" . Router::url('/debug_kit/js/toolbar.js') . '"></script>';
-        $script .= '<link rel="stylesheet" href="' . Router::url('/debug_kit/css/iframe.css') . '"/>';
         $body = substr($body, 0, $pos) . $script . substr($body, $pos);
         $response->body($body);
     }

--- a/src/Routing/Filter/DebugBarFilter.php
+++ b/src/Routing/Filter/DebugBarFilter.php
@@ -233,7 +233,6 @@ class DebugBarFilter extends DispatcherFilter
             return;
         }
         $url = Router::url('/', true);
-        //$script = "<script>var __debug_kit_id = '${id}', __debug_kit_base_url = '${url}';</script>";
         $script = "<script id=\"__debug_kit\" data-id=\"{$id}\" data-url=\"{$url}\" src=\"" . Router::url('/debug_kit/js/toolbar.js') . '"></script>';
         $script .= '<link rel="stylesheet" href="' . Router::url('/debug_kit/css/iframe.css') . '"/>';
         $body = substr($body, 0, $pos) . $script . substr($body, $pos);

--- a/src/Routing/Filter/DebugBarFilter.php
+++ b/src/Routing/Filter/DebugBarFilter.php
@@ -233,8 +233,9 @@ class DebugBarFilter extends DispatcherFilter
             return;
         }
         $url = Router::url('/', true);
-        $script = "<script>var __debug_kit_id = '${id}', __debug_kit_base_url = '${url}';</script>";
-        $script .= '<script src="' . Router::url('/debug_kit/js/toolbar.js') . '"></script>';
+        //$script = "<script>var __debug_kit_id = '${id}', __debug_kit_base_url = '${url}';</script>";
+        $script = "<script id=\"__debug_kit\" data-id=\"{$id}\" data-url=\"{$url}\" src=\"" . Router::url('/debug_kit/js/toolbar.js') . '"></script>';
+        $script .= '<link rel="stylesheet" href="' . Router::url('/debug_kit/css/iframe.css') . '"/>';
         $body = substr($body, 0, $pos) . $script . substr($body, $pos);
         $response->body($body);
     }

--- a/src/Template/Layout/toolbar.ctp
+++ b/src/Template/Layout/toolbar.ctp
@@ -1,3 +1,6 @@
+<?php
+use Cake\Routing\Router;
+?>
 <!DOCTYPE html>
 <html>
     <head>
@@ -13,5 +16,6 @@
     </body>
     <?= $this->Html->script('DebugKit.jquery') ?>
     <?= $this->Html->script('DebugKit.toolbar-app') ?>
+    <?= $this->Html->script('DebugKit.debug_kit', ['id' => '__debug_kit', 'data-url' => json_encode($this->Url->build('/')), 'data-full-url' => Router::url('/', true)]) ?>
     <?= $this->fetch('scripts') ?>
 </html>

--- a/src/Template/Layout/toolbar.ctp
+++ b/src/Template/Layout/toolbar.ctp
@@ -1,6 +1,3 @@
-<?php
-use Cake\Routing\Router;
-?>
 <!DOCTYPE html>
 <html>
     <head>
@@ -16,6 +13,5 @@ use Cake\Routing\Router;
     </body>
     <?= $this->Html->script('DebugKit.jquery') ?>
     <?= $this->Html->script('DebugKit.toolbar-app') ?>
-    <?= $this->Html->script('DebugKit.debug_kit', ['id' => '__debug_kit', 'data-url' => json_encode($this->Url->build('/')), 'data-full-url' => Router::url('/', true)]) ?>
-    <?= $this->fetch('scripts') ?>
+    <?= $this->fetch('script') ?>
 </html>

--- a/src/Template/Requests/view.ctp
+++ b/src/Template/Requests/view.ctp
@@ -28,3 +28,4 @@ use Cake\Core\Configure;
 			['alt' => 'Debug Kit', 'title' => 'CakePHP ' . Configure::version() . ' Debug Kit']) ?>
     </li>
 </ul>
+<?php $this->Html->script('DebugKit.debug_kit', ['block' => true, 'id' => '__debug_kit', 'data-id' => $toolbar->id, 'data-url' => json_encode($this->Url->build('/')), 'data-full-url' => Router::url('/', true)]) ?>

--- a/src/Template/Requests/view.ctp
+++ b/src/Template/Requests/view.ctp
@@ -12,7 +12,7 @@ use Cake\Core\Configure;
 
 <ul id="toolbar" class="toolbar">
     <?php foreach ($toolbar->panels as $panel): ?>
-    <li class="panel" data-id="<?= $panel->id ?>" style="display: none;">
+    <li class="panel hidden" data-id="<?= $panel->id ?>">
         <span class="panel-button">
             <?= h($panel->title) ?>
         </span>
@@ -28,25 +28,3 @@ use Cake\Core\Configure;
 			['alt' => 'Debug Kit', 'title' => 'CakePHP ' . Configure::version() . ' Debug Kit']) ?>
     </li>
 </ul>
-<?php $this->start('scripts') ?>
-<script>
-var baseUrl = "<?= Router::url('/', true) ?>";
-var toolbar;
-
-$(document).ready(function() {
-    toolbar = new Toolbar({
-        button: $('#toolbar'),
-        content: $('#panel-content-container'),
-        panelButtons: $('.panel'),
-        panelClose: $('#panel-close'),
-        keyboardScope : $(document),
-        currentRequest: '<?= $toolbar->id ?>',
-        originalRequest: '<?= $toolbar->id ?>',
-        baseUrl: <?= json_encode($this->Url->build('/')) ?>
-    });
-
-    toolbar.initialize();
-
-});
-</script>
-<?php $this->end() ?>

--- a/tests/TestCase/Routing/Filter/DebugBarFilterTest.php
+++ b/tests/TestCase/Routing/Filter/DebugBarFilterTest.php
@@ -146,9 +146,8 @@ class DebugBarFilterTest extends TestCase
         $this->assertEquals('Sql Log', $result->panels[7]->title);
 
         $expected = '<html><title>test</title><body><p>some text</p>' .
-            "<script>var __debug_kit_id = '" . $result->id . "', " .
-            "__debug_kit_base_url = 'http://localhost/';</script>" .
-            '<script src="/debug_kit/js/toolbar.js"></script>' .
+            '<script id="__debug_kit" data-id="' . $result->id . '" ' .
+            'data-url="http://localhost/" src="/debug_kit/js/toolbar.js"></script>' .
             '</body>';
         $this->assertTextEquals($expected, $response->body());
     }

--- a/webroot/css/toolbar.css
+++ b/webroot/css/toolbar.css
@@ -65,6 +65,10 @@ p {
 	overflow: auto;
 }
 
+.hidden {
+    display: none;
+}
+
 /* Open close button */
 #panel-button,
 .panel {

--- a/webroot/js/debug_kit.js
+++ b/webroot/js/debug_kit.js
@@ -1,0 +1,24 @@
+var baseUrl, toolbar;
+
+var elem = document.getElementById("__debug_kit");
+if (elem) {
+    window.__debug_kit_base_url = elem.getAttribute("data-url");
+    baseUrl = elem.getAttribute("data-full-url");
+    elem = null;
+}
+
+$(document).ready(function() {
+    toolbar = new Toolbar({
+        button: $('#toolbar'),
+        content: $('#panel-content-container'),
+        panelButtons: $('.panel'),
+        panelClose: $('#panel-close'),
+        keyboardScope : $(document),
+        currentRequest: '<?= $toolbar->id ?>',
+        originalRequest: '<?= $toolbar->id ?>',
+        baseUrl: __debug_kit_base_url
+    });
+
+    toolbar.initialize();
+
+});

--- a/webroot/js/debug_kit.js
+++ b/webroot/js/debug_kit.js
@@ -2,6 +2,7 @@ var baseUrl, toolbar;
 
 var elem = document.getElementById("__debug_kit");
 if (elem) {
+    window.__debug_kit_id = elem.getAttribute("data-id");
     window.__debug_kit_base_url = elem.getAttribute("data-url");
     baseUrl = elem.getAttribute("data-full-url");
     elem = null;
@@ -14,8 +15,8 @@ $(document).ready(function() {
         panelButtons: $('.panel'),
         panelClose: $('#panel-close'),
         keyboardScope : $(document),
-        currentRequest: '<?= $toolbar->id ?>',
-        originalRequest: '<?= $toolbar->id ?>',
+        currentRequest: __debug_kit_id,
+        originalRequest: __debug_kit_id,
         baseUrl: __debug_kit_base_url
     });
 

--- a/webroot/js/toolbar.js
+++ b/webroot/js/toolbar.js
@@ -1,5 +1,4 @@
-var __debug_kit_id;
-var __debug_kit_base_url;
+var __debug_kit_id, __debug_kit_base_url;
 var elem = document.getElementById("__debug_kit");
 if (elem) {
     __debug_kit_id = elem.getAttribute("data-id");
@@ -38,7 +37,6 @@ if (elem) {
 		}
 		var body = doc.body;
 		iframe = doc.createElement('iframe');
-		//iframe.setAttribute('style', 'position: fixed; bottom: 0; right: 0; border: 0; outline: 0; overflow: hidden; z-index: 99999;');
         iframe.style.position = 'fixed';
         iframe.style.bottom = 0;
         iframe.style.right = 0;

--- a/webroot/js/toolbar.js
+++ b/webroot/js/toolbar.js
@@ -1,3 +1,12 @@
+var __debug_kit_id;
+var __debug_kit_base_url;
+var elem = document.getElementById("__debug_kit");
+if (elem) {
+    __debug_kit_id = elem.getAttribute("data-id");
+    __debug_kit_base_url = elem.getAttribute("data-url");
+    elem = null;
+}
+
 (function(win, doc) {
 	var iframe;
 	var bodyOverflow;
@@ -29,7 +38,14 @@
 		}
 		var body = doc.body;
 		iframe = doc.createElement('iframe');
-		iframe.setAttribute('style', 'position: fixed; bottom: 0; right: 0; border: 0; outline: 0; overflow: hidden; z-index: 99999;');
+		//iframe.setAttribute('style', 'position: fixed; bottom: 0; right: 0; border: 0; outline: 0; overflow: hidden; z-index: 99999;');
+        iframe.style.position = 'fixed';
+        iframe.style.bottom = 0;
+        iframe.style.right = 0;
+        iframe.style.border = 0;
+        iframe.style.outline = 0;
+        iframe.style.overflow = 'hidden';
+        iframe.style.zIndex = 99999;
 		iframe.height = 40;
 		iframe.width = 40;
 		iframe.src = __debug_kit_base_url + 'debug_kit/toolbar/' + __debug_kit_id;


### PR DESCRIPTION
Based on the issue [#7511](https://github.com/cakephp/cakephp/issues/7511) in cakephp repo, I removed inline javascript and style code and replace them with code in separated js resp. css files.
So DebugKit is (hopefully) fully supported for Content Security Policy. DebugKit also set its own Content-Security-Policy, so it should be guaranteed that everything can be loaded by DebugKit.