### PR TITLE
Correctly set the connection when using fixtures.

### DIFF
--- a/src/Model/Table/LazyTableTrait.php
+++ b/src/Model/Table/LazyTableTrait.php
@@ -45,7 +45,7 @@ trait LazyTableTrait
             if ($class === false) {
                 throw new \RuntimeException("Unknown fixture '$name'.");
             }
-            $fixture = new $class();
+            $fixture = new $class($this->connection()->configName());
             $table = $fixture->table;
             if (in_array($table, $existing)) {
                 continue;

--- a/tests/Fixture/PanelsFixture.php
+++ b/tests/Fixture/PanelsFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class PanelsFixture extends TestFixture
 {
-
     /**
      * fields property
      *
@@ -61,4 +60,18 @@ class PanelsFixture extends TestFixture
             'content' => 'a:5:{s:6:"params";a:5:{s:6:"plugin";N;s:10:"controller";s:5:"Tasks";s:6:"action";s:3:"add";s:4:"_ext";N;s:4:"pass";a:0:{}}s:5:"query";a:0:{}s:4:"data";a:0:{}s:6:"cookie";a:2:{s:14:"toolbarDisplay";s:4:"show";s:7:"CAKEPHP";s:26:"9pk8sa2ot6pclki9f4iakio560";}s:3:"get";a:0:{}}'
         ]
     ];
+
+    /**
+     * Constructor
+     *
+     * @param string $connection The connection name to use.
+     */
+    public function __construct($connection = null)
+    {
+        if ($connection) {
+            $this->connection = $connection;
+        }
+        $this->init();
+    }
+
 }

--- a/tests/Fixture/PanelsFixture.php
+++ b/tests/Fixture/PanelsFixture.php
@@ -73,5 +73,4 @@ class PanelsFixture extends TestFixture
         }
         $this->init();
     }
-
 }

--- a/tests/Fixture/RequestsFixture.php
+++ b/tests/Fixture/RequestsFixture.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class RequestsFixture extends TestFixture
 {
-
     /**
      * fields property
      *
@@ -53,4 +52,17 @@ class RequestsFixture extends TestFixture
             'requested_at' => '2014-08-21 7:41:12'
         ]
     ];
+
+    /**
+     * Constructor
+     *
+     * @param string $connection The connection name to use.
+     */
+    public function __construct($connection = null)
+    {
+        if ($connection) {
+            $this->connection = $connection;
+        }
+        $this->init();
+    }
 }

--- a/tests/TestCase/Model/Table/RequestTableTest.php
+++ b/tests/TestCase/Model/Table/RequestTableTest.php
@@ -33,9 +33,8 @@ class RequestTableTest extends TestCase
     {
         $connection = ConnectionManager::get('test');
         $this->skipIf($connection->driver() instanceof Sqlite, 'Schema insertion/removal breaks SQLite');
-
         TableRegistry::clear();
-        
+
         $stmt = $connection->execute('DROP TABLE IF EXISTS panels');
         $stmt->closeCursor();
 


### PR DESCRIPTION
When using fixtures outside of the test harness, correctly set the active connection. This should help future proof any future connection related features that are introduced into fixtures.

Refs cakephp/cakephp#7586