### PR TITLE
Add summary count to Include Panel.

### DIFF
--- a/src/Panel/IncludePanel.php
+++ b/src/Panel/IncludePanel.php
@@ -15,6 +15,7 @@ namespace DebugKit\Panel;
 use Cake\Controller\Controller;
 use Cake\Core\Plugin;
 use Cake\Event\Event;
+use Cake\Utility\Hash;
 use DebugKit\DebugPanel;
 
 /**
@@ -55,10 +56,9 @@ class IncludePanel extends DebugPanel
     /**
      * Get a list of files that were included and split them out into the various parts of the app
      *
-     * @param Controller $controller The controller.
      * @return array
      */
-    protected function _prepare(Controller $controller)
+    protected function _prepare()
     {
         $return = ['core' => [], 'app' => [], 'plugins' => []];
 
@@ -182,6 +182,20 @@ class IncludePanel extends DebugPanel
      */
     public function shutdown(Event $event)
     {
-        $this->_data = $this->_prepare($event->subject());
+        $this->_data = $this->_prepare();
+    }
+
+    /**
+     * Get the number of files included in this request.
+     *
+     * @return string
+     */
+    public function summary()
+    {
+        $data = $this->_data;
+        if (empty($data)) {
+            $data = $this->_prepare();
+        }
+        return count(Hash::flatten($data));
     }
 }

--- a/tests/TestCase/Panel/IncludePanelTest.php
+++ b/tests/TestCase/Panel/IncludePanelTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ **/
+namespace DebugKit\Test\TestCase\Panel;
+
+use Cake\Event\Event;
+use Cake\Log\Log;
+use Cake\TestSuite\TestCase;
+use DebugKit\Panel\IncludePanel;
+
+/**
+ * Class IncludePanelTest
+ *
+ */
+class IncludePanelTest extends TestCase
+{
+
+    /**
+     * set up
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->panel = new IncludePanel();
+    }
+
+    /**
+     * test shutdown
+     *
+     * @return void
+     */
+    public function testShutdown()
+    {
+        $result = $this->panel->shutdown(new Event('Controller.shutdown'));
+        $this->assertNull($result);
+
+        $data = $this->panel->data();
+        $this->assertArrayHasKey('core', $data);
+        $this->assertArrayHasKey('app', $data);
+        $this->assertArrayHasKey('plugins', $data);
+        $this->assertArrayHasKey('DebugKit', $data['plugins']);
+        $this->assertArrayHasKey('Other', $data['plugins']['DebugKit']);
+    }
+
+    /**
+     * Test that the log panel outputs a summary.
+     *
+     * @return void
+     */
+    public function testSummary()
+    {
+        $total = $this->panel->summary();
+        $this->assertGreaterThan(50, $total);
+    }
+}


### PR DESCRIPTION
Add the total number of files included in the include panel. This makes 'fat' requests a bit more visible.