### PR TITLE
Fix non-select queries causing debug kit to fail.

### DIFF
--- a/src/Panel/VariablesPanel.php
+++ b/src/Panel/VariablesPanel.php
@@ -22,8 +22,8 @@ use Cake\Utility\Hash;
 use Closure;
 use DebugKit\DebugPanel;
 use Exception;
-use RuntimeException;
 use PDO;
+use RuntimeException;
 use SimpleXmlElement;
 
 /**

--- a/src/Panel/VariablesPanel.php
+++ b/src/Panel/VariablesPanel.php
@@ -22,6 +22,7 @@ use Cake\Utility\Hash;
 use Closure;
 use DebugKit\DebugPanel;
 use Exception;
+use RuntimeException;
 use PDO;
 use SimpleXmlElement;
 
@@ -76,6 +77,9 @@ class VariablesPanel extends DebugPanel
                     $item = $item->toArray();
                 } catch (\Cake\Database\Exception $e) {
                     //Likely issue is unbuffered query; fall back to __debugInfo
+                    $item = array_map($walker, $item->__debugInfo());
+                } catch (RuntimeException $e) {
+                    // Likely a non-select query.
                     $item = array_map($walker, $item->__debugInfo());
                 }
             } elseif ($item instanceof Closure ||

--- a/tests/TestCase/Panel/VariablesPanelTest.php
+++ b/tests/TestCase/Panel/VariablesPanelTest.php
@@ -60,9 +60,11 @@ class VariablesPanelTest extends TestCase
         $result = $requests->find()->all();
         $unbufferedQuery = $requests->find('all')->bufferResults(false);
         $unbufferedQuery->toArray(); //toArray call would normally happen somewhere in View, usually implicitly
+        $update = $requests->query()->update();
 
         $controller = new \StdClass();
         $controller->viewVars = [
+            'updateQuery' => $update,
             'query' => $query,
             'unbufferedQuery' => $unbufferedQuery,
             'result set' => $result,
@@ -78,6 +80,7 @@ class VariablesPanelTest extends TestCase
             $controller->viewVars['query'],
             'Original value should not be mutated'
         );
+        $this->assertInternalType('array', $output['content']['updateQuery']);
         $this->assertInternalType('array', $output['content']['query']);
         $this->assertInternalType('array', $output['content']['unbufferedQuery']);
         $this->assertInternalType('array', $output['content']['result set']);


### PR DESCRIPTION
ORM\Query can emit RuntimeException when all() is called on a non-select query. Catch that error and use __debugInfo() instead.

Fixes #397