### PR TITLE
Make panel data binary values.

### DIFF
--- a/src/Model/Entity/Panel.php
+++ b/src/Model/Entity/Panel.php
@@ -25,4 +25,20 @@ class Panel extends Entity
      * @var array
      */
     protected $_hidden = ['content'];
+
+    /**
+     * Read the stream contents.
+     *
+     * Over certain sizes PDO will return file handles.
+     * For backwards compatibility and consistency we smooth over that difference here.
+     *
+     * @return string
+     */
+    protected function _getContent($content)
+    {
+        if (is_resource($content)) {
+            return stream_get_contents($content);
+        }
+        return $content;
+    }
 }

--- a/tests/Fixture/PanelsFixture.php
+++ b/tests/Fixture/PanelsFixture.php
@@ -33,7 +33,7 @@ class PanelsFixture extends TestFixture
         'title' => ['type' => 'string'],
         'element' => ['type' => 'string'],
         'summary' => ['type' => 'string'],
-        'content' => ['type' => 'text'],
+        'content' => ['type' => 'binary'],
         '_constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id']],
             'unique_panel' => ['type' => 'unique', 'columns' => ['request_id', 'panel']],


### PR DESCRIPTION
postgres gets really sad when you put null bytes into character columns. With this change new schema will use binary columns which work fine in postgres.

The entity accessor makes reading small and big blobs work the same.

Refs #392 