### PR TITLE
Forcing the panel to use the default cake's View class

### DIFF
--- a/src/Controller/PanelsController.php
+++ b/src/Controller/PanelsController.php
@@ -53,7 +53,7 @@ class PanelsController extends Controller
      */
     public function beforeRender(Event $event)
     {
-        $this->viewBuilder()->layout('DebugKit.panel');
+        $this->viewBuilder()->layout('DebugKit.panel')->className('View');
     }
 
     /**

--- a/src/Controller/RequestsController.php
+++ b/src/Controller/RequestsController.php
@@ -48,7 +48,7 @@ class RequestsController extends Controller
      */
     public function beforeRender(Event $event)
     {
-        $this->viewBuilder()->layout('DebugKit.toolbar');
+        $this->viewBuilder()->layout('DebugKit.toolbar')->className('View');
     }
 
     /**


### PR DESCRIPTION
When having an altered AppView class, the toolbar can break