### PR TITLE
Fixate the table names of fixtures.

### DIFF
--- a/tests/Fixture/PanelsFixture.php
+++ b/tests/Fixture/PanelsFixture.php
@@ -22,6 +22,15 @@ use Cake\TestSuite\Fixture\TestFixture;
 class PanelsFixture extends TestFixture
 {
     /**
+     * table property
+     *
+     * This is necessary to prevent userland inflections from causing issues.
+     *
+     * @var string
+     */
+    public $table = 'panels';
+
+    /**
      * fields property
      *
      * @var array

--- a/tests/Fixture/RequestsFixture.php
+++ b/tests/Fixture/RequestsFixture.php
@@ -22,6 +22,15 @@ use Cake\TestSuite\Fixture\TestFixture;
 class RequestsFixture extends TestFixture
 {
     /**
+     * table property
+     *
+     * This is necessary to prevent userland inflections from causing issues.
+     *
+     * @var string
+     */
+    public $table = 'requests';
+
+    /**
      * fields property
      *
      * @var array


### PR DESCRIPTION
Fixating the table names removes inflections which cause issues when applications apply alternate inflections.

Refs #406