### PR TITLE
Allowing sqlite tests to run locally

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -88,7 +88,7 @@ Cache::config([
 
 // Ensure default test connection is defined
 if (!getenv('db_dsn')) {
-    putenv('db_dsn=sqlite:/' . TMP . 'debug_kit_test.sqlite');
+    putenv('db_dsn=sqlite://127.0.0.1/' . TMP . 'debug_kit_test.sqlite');
 }
 
 $config = [


### PR DESCRIPTION
Tests weren't running locally without defining a host.