### PR TITLE
In certain circumstances, when beforeRender is invoked multiple times…

### DIFF
--- a/Lib/Panel/VariablesPanel.php
+++ b/Lib/Panel/VariablesPanel.php
@@ -25,6 +25,12 @@ class VariablesPanel extends DebugPanel {
  * @return array
  */
 	public function beforeRender(Controller $controller) {
-		return array_merge($controller->viewVars, array('$request->data' => $controller->request->data));
+		$viewVars = $controller->viewVars;
+		unset(
+			$viewVars['debugToolbarPanels'],
+			$viewVars['debugToolbarJavascript'],
+			$viewVars['debugToolbarCss']
+		);
+		return array_merge($viewVars, array('$request->data' => $controller->request->data));
 	}
 }


### PR DESCRIPTION
…the debugToolbarPanels variable ends up recursively containing itself. Hundreds of thousands of deeply nested HTML tags, along with the JS that traverses them, make browsers very sad.