### PR TITLE
Fix Include Panel on Windows.

### DIFF
--- a/src/Panel/IncludePanel.php
+++ b/src/Panel/IncludePanel.php
@@ -61,7 +61,7 @@ class IncludePanel extends DebugPanel
      */
     protected function _prepare()
     {
-        $return = ['core' => [], 'app' => [], 'plugins' => []];
+        $return = ['cake' => [], 'app' => [], 'plugins' => []];
 
         foreach (get_included_files() as $file) {
             $pluginName = $this->_isPluginFile($file);
@@ -70,14 +70,14 @@ class IncludePanel extends DebugPanel
                 $return['plugins'][$pluginName][$this->_getFileType($file)][] = $this->_niceFileName($file, $pluginName);
             } elseif ($this->_isAppFile($file)) {
                 $return['app'][$this->_getFileType($file)][] = $this->_niceFileName($file, 'app');
-            } elseif ($this->_isCoreFile($file)) {
-                $return['core'][$this->_getFileType($file)][] = $this->_niceFileName($file, 'core');
+            } elseif ($this->_isCakeFile($file)) {
+                $return['cake'][$this->_getFileType($file)][] = $this->_niceFileName($file, 'cake');
             }
         }
 
         $return['paths'] = $this->_includePaths();
 
-        ksort($return['core']);
+        ksort($return['cake']);
         ksort($return['plugins']);
         ksort($return['app']);
         return $return;
@@ -97,12 +97,12 @@ class IncludePanel extends DebugPanel
     }
 
     /**
-     * Check if a path is part of cake core
+     * Check if a path is part of CakePHP
      *
      * @param string $file File to check
      * @return bool
      */
-    protected function _isCoreFile($file)
+    protected function _isCakeFile($file)
     {
         return strstr($file, CAKE);
     }
@@ -140,7 +140,7 @@ class IncludePanel extends DebugPanel
      * @param string $file File to check
      * @param string $type The file type
      *  - app for app files
-     *  - core for core files
+     *  - cake for cake files
      *  - PluginName for the name of a plugin
      * @return bool
      */
@@ -150,8 +150,8 @@ class IncludePanel extends DebugPanel
             case 'app':
                 return str_replace(APP, 'APP/', $file);
 
-            case 'core':
-                return str_replace(CAKE, 'CORE/', $file);
+            case 'cake':
+                return str_replace(CAKE, 'CAKE/', $file);
 
             default:
                 return str_replace($this->_pluginPaths[$type], $type . '/', $file);
@@ -167,7 +167,7 @@ class IncludePanel extends DebugPanel
     protected function _getFileType($file)
     {
         foreach ($this->_fileTypes as $type) {
-            if (stripos($file, '/' . $type . '/') !== false) {
+            if (stripos($file, DIRECTORY_SEPARATOR . $type . DIRECTORY_SEPARATOR) !== false) {
                 return $type;
             }
         }

--- a/src/Template/Element/include_panel.ctp
+++ b/src/Template/Element/include_panel.ctp
@@ -1,9 +1,5 @@
 <?php
 /**
- * Included Files Element
- *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -15,9 +11,13 @@
  * @since         DebugKit 2.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
+// Backwards compat for old DebugKit data.
+if (!isset($cake) && isset($core)) {
+    $cake = $core;
+}
 ?>
 <h4>Include Paths</h4>
 <?= $this->Toolbar->makeNeatArray($paths) ?>
 
 <h4>Included Files</h4>
-<?= $this->Toolbar->makeNeatArray(['core' => $core, 'app' => $app, 'plugins' => $plugins]) ?>
+<?= $this->Toolbar->makeNeatArray(['cake' => $cake, 'app' => $app, 'plugins' => $plugins]) ?>

--- a/tests/TestCase/Panel/IncludePanelTest.php
+++ b/tests/TestCase/Panel/IncludePanelTest.php
@@ -46,7 +46,7 @@ class IncludePanelTest extends TestCase
         $this->assertNull($result);
 
         $data = $this->panel->data();
-        $this->assertArrayHasKey('core', $data);
+        $this->assertArrayHasKey('cake', $data);
         $this->assertArrayHasKey('app', $data);
         $this->assertArrayHasKey('plugins', $data);
         $this->assertArrayHasKey('DebugKit', $data['plugins']);


### PR DESCRIPTION
* Fix incorrectly group files on windows.
* Rename 'core' to 'cake'. I feel this name better represents what the files are. core is a bit ambiguous.

Refs #424