### PR TITLE
Make neat-array display more beautiful

### DIFF
--- a/webroot/css/toolbar.css
+++ b/webroot/css/toolbar.css
@@ -273,6 +273,11 @@ table tbody tr:nth-child(odd) {
 	padding: 0 8px;
 	font-weight: bold;
 }
+.neat-array li > strong:before {
+	position: relative;
+	left: -3px;
+	content: "\2003 ";
+}
 
 /* expandable sections */
 .neat-array li.expandable {


### PR DESCRIPTION
Make `neat-array` display
```
-> obj1 (object)
   int1  123
```
instead of 
```
-> obj1 (object)
int1  123
```

See demo

![demo](https://www.dropbox.com/s/az8i6nea1w13yso/15.jpg?dl=1 "Demo")