### PR TITLE
Make word-break property compatible with Firefox Browser

### DIFF
--- a/webroot/css/toolbar.css
+++ b/webroot/css/toolbar.css
@@ -66,7 +66,7 @@ p {
 }
 
 .hidden {
-    display: none;
+	display: none;
 }
 
 /* Open close button */
@@ -218,7 +218,7 @@ table th {
 	line-height: 16px;
 }
 table tbody tr:nth-child(odd) {
-    background-color: #f9f9f9;
+	background-color: #f9f9f9;
 }
 
 .debug-table td {
@@ -232,7 +232,7 @@ table tbody tr:nth-child(odd) {
 }
 .debug-table td:nth-child(n+2) {
 	word-wrap: break-word;
-    word-break: break-all;
+	word-break: break-all;
 	word-break: break-word; /* Not standard for webkit */
 }
 

--- a/webroot/css/toolbar.css
+++ b/webroot/css/toolbar.css
@@ -232,6 +232,7 @@ table tbody tr:nth-child(odd) {
 }
 .debug-table td:nth-child(n+2) {
 	word-wrap: break-word;
+    word-break: break-all;
 	word-break: break-word; /* Not standard for webkit */
 }
 


### PR DESCRIPTION
Firefox not implement break-word value but accepts break-all with similar effect

Now (without break-all) on Firefox

![captura de pantalla 2016-07-13 a las 16 44 39](https://cloud.githubusercontent.com/assets/4248492/16808634/8de11e38-491d-11e6-9bc8-ec4ff9f40d87.png)
