### PR TITLE
Don't load DebugKit in the phpdbg cli

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -20,7 +20,7 @@ use DebugKit\Routing\Filter\DebugBarFilter;
 
 $debugBar = new DebugBarFilter(EventManager::instance(), (array)Configure::read('DebugKit'));
 
-if (!$debugBar->isEnabled() || php_sapi_name() === 'cli') {
+if (!$debugBar->isEnabled() || php_sapi_name() === 'cli' || php_sapi_name() === 'phpdbg') {
     return;
 }
 


### PR DESCRIPTION
Following Cake's support of `phpdbg`, DebugKit shouldn't load in the `phpdbg` command line environment either.