### PR TITLE
Add Explain button to SQL log panel

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -8,6 +8,10 @@ Router::plugin('DebugKit', function ($routes) {
         ['controller' => 'Toolbar', 'action' => 'clearCache']
     );
     $routes->connect(
+        '/toolbar/sql_explain',
+        ['controller' => 'Toolbar', 'action' => 'sqlExplain']
+    );
+    $routes->connect(
         '/toolbar/*',
         ['controller' => 'Requests', 'action' => 'view']
     );

--- a/src/Database/Log/DebugLog.php
+++ b/src/Database/Log/DebugLog.php
@@ -130,10 +130,18 @@ class DebugLog extends QueryLogger
         $this->_totalTime += $query->took;
         $this->_totalRows += $query->numRows;
 
+        $extra = [];
+        if (isset($query->queryString)) {
+            $extra = [
+                'queryString' => $query->queryString,
+                'params' => $query->params,
+            ];
+        }
+
         $this->_queries[] = [
             'query' => $query->query,
             'took' => $query->took,
-            'rows' => $query->numRows
-        ];
+            'rows' => $query->numRows,
+        ] + $extra;
     }
 }

--- a/src/Template/Element/sql_log_panel.ctp
+++ b/src/Template/Element/sql_log_panel.ctp
@@ -15,6 +15,9 @@
  * @since         DebugKit 0.1
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
+use Cake\Datasource\ConnectionManager;
+use Cake\Utility\Security;
+
 $noOutput = true;
 
 // Configure sqlformatter colours.
@@ -44,6 +47,9 @@ SqlFormatter::$pre_attributes = 'style="color: #222; background-color: transpare
         continue;
     endif;
 
+    $connection = ConnectionManager::get($logger->name());
+    $isExplainable = method_exists($connection, 'canExplain');
+
     $noOutput = false;
     ?>
     <div class="sql-log-panel-query-log">
@@ -65,14 +71,38 @@ SqlFormatter::$pre_attributes = 'style="color: #222; background-color: transpare
                     <th><?= __d('debug_kit', 'Query') ?></th>
                     <th><?= __d('debug_kit', 'Rows') ?></th>
                     <th><?= __d('debug_kit', 'Took (ms)') ?></th>
+                    <?php if ($isExplainable): ?>
+                        <th><?= __d('debug_kit', 'Actions') ?></th>
+                    <?php endif ?>
                 </tr>
             </thead>
             <tbody>
                 <?php foreach ($queries as $query): ?>
-                <tr>
+                <tr class="sql-log">
                     <td><?= SqlFormatter::format($query['query']) ?></td>
                     <td><?= h($query['rows']) ?></td>
                     <td><?= h($query['took']) ?></td>
+                    <?php if ($isExplainable): ?>
+                        <td>
+                        <?php if (isset($query['queryString']) && $connection->canExplain($query['queryString'])): ?>
+                        <?php
+                        $data = json_encode([
+                            'connection' => $logger->name(),
+                            'query' => $query['queryString'],
+                            'params' => $query['params']
+                        ]);
+                        echo $this->Form->create();
+                        echo $this->Form->hidden('data', ['value' => $data]);
+                        echo $this->Form->hidden('hash', ['value' => Security::hash($data, null, true)]);
+                        echo $this->Form->button('Explain', ['type' => 'button', 'class' => 'btn-primary sql-explain-link']);
+                        echo $this->Form->end();
+                        ?>
+                        <?php endif ?>
+                        </td>
+                    <?php endif ?>
+                </tr>
+                <tr class="sql-explain">
+                    <td colspan="4"></td>
                 </tr>
                 <?php endforeach; ?>
             </tbody>
@@ -84,3 +114,57 @@ SqlFormatter::$pre_attributes = 'style="color: #222; background-color: transpare
 <?php if ($noOutput): ?>
 <div class="warning"><?= __d('debug_kit', 'No active database connections') ?></div>
 <?php endif ?>
+
+<script>
+$(document).ready(function() {
+    var baseUrl = '<?= $this->Url->build([
+        'plugin' => 'DebugKit',
+        'controller' => 'Toolbar',
+        'action' => 'sqlExplain'
+    ]); ?>';
+
+    function createTable(result) {
+        var $table = $('<table>');
+        for (var i = 0; i < result.length; ++i) {
+            var $row = $('<tr>');
+            for (var j = 0; j < result[i].length; ++j) {
+                var $cell = $(i == 0 ? '<th>' : '<td>');
+                $cell.text( result[i][j] );
+                $row.append($cell);
+            }
+            $table.append($row);
+        }
+        return $table;
+    }
+
+    $('.sql-explain-link').on('click', function(e) {
+        var el = $(this);
+        var $container = el.parents('tr:eq(0)').next('tr.sql-explain').children('td');
+
+        if (el.hasClass('clicked')) {
+            $container.children().fadeToggle('fast');
+            return false;
+        }
+        el.addClass('clicked');
+
+        var data = el.parents('form').serialize();
+
+        var xhr = $.ajax({
+            url: baseUrl,
+            data: data,
+            dataType: 'json',
+            type: 'POST'
+        });
+
+        xhr.done(function(response) {
+            var result = response.result;
+            var $table = createTable(result);
+            $container.append($table);
+            $table.fadeIn('fast');
+        }).error(function(response) {
+            $container.append('<p class="warning">Could not fetch EXPLAIN for query</p>');
+        });
+        e.preventDefault();
+    });
+});
+</script>

--- a/tests/TestCase/Database/Log/DebugLogTest.php
+++ b/tests/TestCase/Database/Log/DebugLogTest.php
@@ -41,7 +41,7 @@ class DebugLogTest extends TestCase
     public function testLog()
     {
         $query = new LoggedQuery();
-        $query->sql = 'SELECT * FROM posts';
+        $query->query = 'SELECT * FROM posts';
         $query->took = 10;
         $query->numRows = 5;
 
@@ -72,5 +72,46 @@ class DebugLogTest extends TestCase
         $query = new LoggedQuery();
         $logger = new DebugLog($orig, 'test');
         $logger->log($query);
+    }
+
+    /**
+     * Test logs contain extra information if queryString is present.
+     *
+     * @return void
+     */
+    public function testLoggedQueryFormatWithExtra()
+    {
+        $query = new LoggedQuery();
+        $query->query = 'SELECT * FROM posts WHERE id = :id';
+        $query->params = ['id' => 1];
+        $query->took = 10;
+        $query->numRows = 1;
+
+        $this->logger->log($query);
+
+        $query = new LoggedQuery();
+        $query->query = $query->queryString = 'SELECT * FROM posts WHERE id = :id';
+        $query->params = ['id' => 2];
+        $query->took = 10;
+        $query->numRows = 1;
+
+        $this->logger->log($query);
+
+        $expected = [
+            [
+                'query' => 'SELECT * FROM posts WHERE id = 1',
+                'took' => 10,
+                'rows' => 1,
+            ],
+            [
+                'query' => 'SELECT * FROM posts WHERE id = 2',
+                'took' => 10,
+                'rows' => 1,
+                'queryString' => 'SELECT * FROM posts WHERE id = :id',
+                'params' => ['id' => 2],
+            ],
+        ];
+
+        $this->assertEquals($expected, $this->logger->queries());
     }
 }

--- a/webroot/css/toolbar.css
+++ b/webroot/css/toolbar.css
@@ -397,6 +397,45 @@ pre,
 	font-family: Monaco, Consolas, mono-space;
 }
 
+/**
+ * Sql Log panel
+ */
+.sql-log td {
+	padding-bottom: 0;
+	border-bottom: none;
+}
+
+.sql-explain {
+	border-top: none;
+}
+
+.sql-explain > td {
+	padding-top: 0;
+}
+
+.sql-explain table {
+	display: none;
+	margin: 0;
+	margin-top: 9px;
+	border-collapse: separate;
+	border-spacing: 1px;
+}
+
+.sql-explain p {
+	margin: 0;
+	margin-top: 9px;
+}
+
+.sql-explain table th {
+	border: none;
+	background: #eaeae7;
+	line-height: 16px;
+}
+
+.sql-explain table td {
+	background: #fafafa;
+	border: none;
+}
 
 /**
  * Warnings and info boxes.


### PR DESCRIPTION
After cakephp/cakephp#9421 merged, DebugKit will show you Explain buttons in SQL log panel. I confirmed working with Vivaldi 1.3, IE 11, Edge 25, Chrome 53 and FF 48, on WIndows.

### MySQL
![explain-mysql](https://cloud.githubusercontent.com/assets/7399393/18274549/e49b31c4-747d-11e6-9854-76068d6528d0.png)

### PostgreSQL
![explain-postgres](https://cloud.githubusercontent.com/assets/7399393/18274550/e49f51aa-747d-11e6-94fd-fb4f46dd1830.png)

### SQLite
![explain-sqlite](https://cloud.githubusercontent.com/assets/7399393/18274551/e4a6e7bc-747d-11e6-8b3c-2be55014b2ab.png)
