### PR TITLE
Always setting layout and class

### DIFF
--- a/src/Controller/PanelsController.php
+++ b/src/Controller/PanelsController.php
@@ -53,9 +53,11 @@ class PanelsController extends Controller
      */
     public function beforeRender(Event $event)
     {
-        $this->viewBuilder()
-            ->layout('DebugKit.panel')
-            ->className('DebugKit.Ajax');
+        $this->viewBuilder()->layout('DebugKit.toolbar');
+
+        if (!$this->request->is('json')) {
+            $this->viewBuilder()->className('DebugKit.Ajax');
+        }
     }
 
     /**

--- a/src/Controller/PanelsController.php
+++ b/src/Controller/PanelsController.php
@@ -53,11 +53,9 @@ class PanelsController extends Controller
      */
     public function beforeRender(Event $event)
     {
-        $builder = $this->viewBuilder();
-        if (!$builder->className()) {
-            $builder->layout('DebugKit.panel')
-                ->className('DebugKit.Ajax');
-        }
+        $this->viewBuilder()
+            ->layout('DebugKit.panel')
+            ->className('DebugKit.Ajax');
     }
 
     /**

--- a/src/Controller/RequestsController.php
+++ b/src/Controller/RequestsController.php
@@ -48,9 +48,11 @@ class RequestsController extends Controller
      */
     public function beforeRender(Event $event)
     {
-        $this->viewBuilder()
-            ->layout('DebugKit.toolbar')
-            ->className('DebugKit.Ajax');
+        $this->viewBuilder()->layout('DebugKit.toolbar');
+
+        if (!$this->request->is('json')) {
+            $this->viewBuilder()->className('DebugKit.Ajax');
+        }
     }
 
     /**

--- a/src/Controller/RequestsController.php
+++ b/src/Controller/RequestsController.php
@@ -48,11 +48,9 @@ class RequestsController extends Controller
      */
     public function beforeRender(Event $event)
     {
-        $this->viewBuilder()->layout('DebugKit.toolbar');
-
-        if (!$this->request->is('json')) {
-            $this->viewBuilder()->className('DebugKit.Ajax');
-        }
+        $this->viewBuilder()
+            ->layout('DebugKit.toolbar')
+            ->className('DebugKit.Ajax');
     }
 
     /**

--- a/tests/TestCase/Controller/PanelsControllerTest.php
+++ b/tests/TestCase/Controller/PanelsControllerTest.php
@@ -46,6 +46,25 @@ class PanelsControllerTest extends IntegrationTestCase
     }
 
     /**
+     * tests index page returns as JSON
+     *
+     * @return void
+     */
+    public function testIndex()
+    {
+        $this->configRequest([
+            'headers' => [
+                'accept' => 'application/json, text/javascript, */*; q=0.01',
+            ]
+        ]);
+
+        $this->get('/debug_kit/panels/index/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
+
+        $this->assertResponseOk();
+        $this->assertContentType('application/json');
+    }
+
+    /**
      * Test getting a panel that exists.
      *
      * @return void


### PR DESCRIPTION
DebugKit seemed to be inheriting our view class and layout, which in turn was loading our app's CSS and JS and breaking the toolbar (and taking a long time as it had to load a ton of stuff).

I don't have a good understanding behind the bug caused by https://github.com/cakephp/debug_kit/commit/bcf8b1a8cd2b56d32985d6759e2874ef95f89336, so I want to be sure that reverting it won't cause people's panels to break.

Pinging @markstory as you're the guy who wrote the commit 😄 