### PR TITLE
This seems to be needed with some cases of variable content.

### DIFF
--- a/src/Panel/VariablesPanel.php
+++ b/src/Panel/VariablesPanel.php
@@ -23,9 +23,10 @@ use Cake\Utility\Hash;
 use Closure;
 use DebugKit\DebugPanel;
 use Exception;
+use InvalidArgumentException;
 use PDO;
 use RuntimeException;
-use SimpleXmlElement;
+use SimpleXMLElement;
 
 /**
  * Provides debug information on the View variables.
@@ -85,10 +86,12 @@ class VariablesPanel extends DebugPanel
                 } catch (RuntimeException $e) {
                     // Likely a non-select query.
                     $item = array_map($walker, $item->__debugInfo());
+                } catch (InvalidArgumentException $e) {
+                    $item = array_map($walker, $item->__debugInfo());
                 }
             } elseif ($item instanceof Closure ||
                 $item instanceof PDO ||
-                $item instanceof SimpleXmlElement
+                $item instanceof SimpleXMLElement
             ) {
                 $item = 'Unserializable object - ' . get_class($item);
             } elseif ($item instanceof Exception) {


### PR DESCRIPTION
I got

>Cannot convert value to string - InvalidArgumentException

and DebugKit stopped execution completely.

Apperently it was about
```
[
	(int) 0 => '5c517388-a635-41e2-bc50-b691b0d659fc'
]
```
and Cake\Database\Type\StringType->toDatabase
ROOT\Vendor\cakephp\cakephp\src\Database\Type\UuidType.php, line 39

Shouldnt DebugKit in general catch more exceptions and try to not make it impossible to continue working by rather displaying empty content than going to exception case?

Also fixed the case for another exception.