### PR TITLE
Fix warnings when streaming HTML responses are used.

### DIFF
--- a/src/Routing/Filter/DebugBarFilter.php
+++ b/src/Routing/Filter/DebugBarFilter.php
@@ -233,6 +233,9 @@ class DebugBarFilter extends DispatcherFilter
             return;
         }
         $body = $response->body();
+        if (!is_string($body)) {
+            return;
+        }
         $pos = strrpos($body, '</body>');
         if ($pos === false) {
             return;

--- a/tests/TestCase/Cache/Engine/DebugEngineTest.php
+++ b/tests/TestCase/Cache/Engine/DebugEngineTest.php
@@ -42,7 +42,7 @@ class DebugEngineTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $mock = $this->getMock('Cake\Cache\CacheEngine');
+        $mock = $this->getMockBuilder('Cake\Cache\CacheEngine')->getMock();
         $this->mock = $mock;
         $this->engine = new DebugEngine($mock);
         $this->engine->init();

--- a/tests/TestCase/Controller/ToolbarControllerTest.php
+++ b/tests/TestCase/Controller/ToolbarControllerTest.php
@@ -69,7 +69,7 @@ class ToolbarControllerTest extends IntegrationTestCase
      */
     public function testClearCache()
     {
-        $mock = $this->getMock('Cake\Cache\CacheEngine');
+        $mock = $this->getMockBuilder('Cake\Cache\CacheEngine')->getMock();
         $mock->expects($this->once())
             ->method('init')
             ->will($this->returnValue(true));

--- a/tests/TestCase/Database/Log/DebugLogTest.php
+++ b/tests/TestCase/Database/Log/DebugLogTest.php
@@ -69,7 +69,7 @@ class DebugLogTest extends TestCase
      */
     public function testLogDecorates()
     {
-        $orig = $this->getMock('Cake\Database\Log\QueryLogger');
+        $orig = $this->getMockBuilder('Cake\Database\Log\QueryLogger')->getMock();
         $orig->expects($this->once())
             ->method('log');
 

--- a/tests/TestCase/Routing/Filter/DebugBarFilterTest.php
+++ b/tests/TestCase/Routing/Filter/DebugBarFilterTest.php
@@ -124,7 +124,7 @@ class DebugBarFilterTest extends TestCase
             'statusCode' => 200,
             'type' => 'text/html',
         ]);
-        $response->body(function() {
+        $response->body(function () {
             echo 'I am a teapot!';
         });
 

--- a/tests/TestCase/Routing/Filter/DebugBarFilterTest.php
+++ b/tests/TestCase/Routing/Filter/DebugBarFilterTest.php
@@ -110,6 +110,31 @@ class DebugBarFilterTest extends TestCase
     }
 
     /**
+     * Test that afterDispatch ignores streaming bodies
+     *
+     * @return void
+     */
+    public function testAfterDispatchIgnoreStreamBodies()
+    {
+        $request = new Request([
+            'url' => '/articles',
+            'params' => ['plugin' => null]
+        ]);
+        $response = new Response([
+            'statusCode' => 200,
+            'type' => 'text/html',
+        ]);
+        $response->body(function() {
+            echo 'I am a teapot!';
+        });
+
+        $bar = new DebugBarFilter($this->events, []);
+        $event = new Event('Dispatcher.afterDispatch', $bar, compact('request', 'response'));
+        $this->assertNull($bar->afterDispatch($event));
+        $this->assertInstanceOf('Closure', $response->body());
+    }
+
+    /**
      * Test that afterDispatch saves panel data.
      *
      * @return void


### PR DESCRIPTION
With the advent of streaming responses, some HTML responses will be streamed. DebugKit can't realistically insert itself into these streamed response bodies.

Refs #452