### PR TITLE
Improve local storage check for Safari private mode

### DIFF
--- a/webroot/js/toolbar-app.js
+++ b/webroot/js/toolbar-app.js
@@ -49,14 +49,11 @@ Toolbar.prototype = {
 			if (!window.localStorage) {
 				this._localStorageAvailable = false;
 			} else {
-				try
-				{
+				try {
 					window.localStorage.setItem('testKey', '1');
 					window.localStorage.removeItem('testKey');
 					this._localStorageAvailable = true;
-				}
-				catch (error)
-				{
+				} catch (error) {
 					this._localStorageAvailable = false;
 				}
 			}

--- a/webroot/js/toolbar-app.js
+++ b/webroot/js/toolbar-app.js
@@ -14,6 +14,7 @@ Toolbar.prototype = {
 	_currentPanel: null,
 	_lastPanel: null,
 	_state: 0,
+	_localStorageAvailable: null,
 	currentRequest: null,
 	originalRequest: null,
 	ajaxRequests: [],
@@ -43,15 +44,36 @@ Toolbar.prototype = {
 		return this.state();
 	},
 
+	localStorageAvailable: function() {
+		if (this._localStorageAvailable === null) {
+			if (!window.localStorage) {
+				this._localStorageAvailable = false;
+			} else {
+				try
+				{
+					window.localStorage.setItem('testKey', '1');
+					window.localStorage.removeItem('testKey');
+					this._localStorageAvailable = true;
+				}
+				catch (error)
+				{
+					this._localStorageAvailable = false;
+				}
+			}
+		}
+
+		return this._localStorageAvailable;
+	},
+
 	saveState: function() {
-		if (!window.localStorage) {
+		if (!this.localStorageAvailable()) {
 			return;
 		}
 		window.localStorage.setItem('toolbar_state', this._state);
 	},
 
 	loadState: function() {
-		if (!window.localStorage) {
+		if (!this.localStorageAvailable()) {
 			return;
 		}
 		var old = window.localStorage.getItem('toolbar_state');


### PR DESCRIPTION
Safari in private browsing mode has the `localStorage` object available, but setting any item on it fails. See for example [this Stack Overflow post](http://stackoverflow.com/questions/14555347/html5-localstorage-error-with-safari-quota-exceeded-err-dom-exception-22-an).

This improved check should catch that error, thus allowing us to actually open de debug bar in Safari in a private window.