### PR TITLE
PHPs unserialize issues an E_NOTICE 

### DIFF
--- a/src/Controller/PanelsController.php
+++ b/src/Controller/PanelsController.php
@@ -95,6 +95,6 @@ class PanelsController extends Controller
         $panel = $this->Panels->get($id);
 
         $this->set('panel', $panel);
-        $this->set(unserialize($panel->content));
+        $this->set(@unserialize($panel->content));
     }
 }


### PR DESCRIPTION
PHPs unserialize issues an E_NOTICE when unserializing a class that has a private __wakeup method.

private __wakeup is useful in singletons.

Moving errors to exceptions to handle this case, seemed overkill.

The panel showed warnings for these, 
with the errors suppressed "@", 
names of the class instances still show but PHP does not issue a notice anymore.
