### PR TITLE
fix undefined error when using zones

### DIFF
--- a/webroot/js/toolbar.js
+++ b/webroot/js/toolbar.js
@@ -64,8 +64,8 @@ if (elem) {
           requestId: this.getResponseHeader('X-DEBUGKIT-ID'),
           status: this.status,
           date: new Date,
-          method: this._arguments[0],
-          url: this._arguments[1],
+          method: this._arguments && this._arguments[0],
+          url: this._arguments && this._arguments[1],
           type: this.getResponseHeader('Content-Type')
         };
         iframe.contentWindow.postMessage('ajax-completed$$' + JSON.stringify(params), window.location.origin);


### PR DESCRIPTION
Angular 2 is using a zones library that prevents the debug kit from seeing some details about Ajax requests.

This fixes a run-time error in JS when there are no arguments.