### PR TITLE
Prepare for middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
         "source": "https://github.com/cakephp/debug_kit"
     },
     "require": {
-        "cakephp/cakephp": ">=3.1.0 <4.0",
+        "cakephp/cakephp": ">=3.3.3 <4.0",
         "cakephp/plugin-installer": "*",
         "jdorn/sql-formatter": "~1.2"
     },
     "require-dev": {
-        "cakephp/cakephp-codesniffer": "dev-master",
-        "phpunit/phpunit": "4.1.*"
+        "cakephp/cakephp-codesniffer": "~2.1",
+        "phpunit/phpunit": "~4.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "source": "https://github.com/cakephp/debug_kit"
     },
     "require": {
-        "cakephp/cakephp": ">=3.3.3 <4.0",
+        "cakephp/cakephp": ">=3.1.0 <4.0",
         "cakephp/plugin-installer": "*",
         "jdorn/sql-formatter": "~1.2"
     },

--- a/src/Routing/Filter/DebugBarFilter.php
+++ b/src/Routing/Filter/DebugBarFilter.php
@@ -96,6 +96,7 @@ class DebugBarFilter extends DispatcherFilter
     public function panel($name)
     {
         $registry = $this->service->registry();
+
         return $registry->{$name};
     }
 

--- a/src/Routing/Filter/DebugBarFilter.php
+++ b/src/Routing/Filter/DebugBarFilter.php
@@ -11,16 +11,11 @@
  */
 namespace DebugKit\Routing\Filter;
 
-use Cake\Core\Configure;
 use Cake\Event\Event;
-use Cake\Event\EventDispatcherTrait;
-use Cake\Event\EventManager;
 use Cake\Network\Request;
 use Cake\Network\Response;
-use Cake\ORM\TableRegistry;
 use Cake\Routing\DispatcherFilter;
-use Cake\Routing\Router;
-use DebugKit\Panel\PanelRegistry;
+use DebugKit\ToolbarService;
 
 /**
  * Toolbar injector filter.
@@ -28,39 +23,16 @@ use DebugKit\Panel\PanelRegistry;
  * This class loads all the panels into the registry
  * and binds the correct events into the provided event
  * manager
+ *
+ * @deprecated Dispatch filters are deprecated. Long term this filter
+ * will be removed and replaced with middleware.
  */
 class DebugBarFilter extends DispatcherFilter
 {
-    use EventDispatcherTrait;
-
     /**
-     * The panel registry.
-     *
-     * @var \DebugKit\Panel\PanelRegistry
+     * @var \DebugKit\ToolbarService
      */
-    protected $_registry;
-
-    /**
-     * Default configuration.
-     *
-     * @var array
-     */
-    protected $_defaultConfig = [
-        'panels' => [
-            'DebugKit.Cache',
-            'DebugKit.Session',
-            'DebugKit.Request',
-            'DebugKit.SqlLog',
-            'DebugKit.Timer',
-            'DebugKit.Log',
-            'DebugKit.Variables',
-            'DebugKit.Environment',
-            'DebugKit.Include',
-            'DebugKit.History',
-            'DebugKit.Routes',
-        ],
-        'forceEnable' => false,
-    ];
+    protected $service;
 
     /**
      * Constructor
@@ -72,8 +44,7 @@ class DebugBarFilter extends DispatcherFilter
     {
         parent::__construct($config);
 
-        $this->eventManager($events);
-        $this->_registry = new PanelRegistry($events);
+        $this->service = new ToolbarService($events, $config);
     }
 
     /**
@@ -102,16 +73,7 @@ class DebugBarFilter extends DispatcherFilter
      */
     public function isEnabled()
     {
-        $enabled = (bool)Configure::read('debug');
-        if ($enabled) {
-            return true;
-        }
-        $force = $this->config('forceEnable');
-        if (is_callable($force)) {
-            return $force();
-        }
-
-        return $force;
+        return $this->service->isEnabled();
     }
 
     /**
@@ -121,7 +83,7 @@ class DebugBarFilter extends DispatcherFilter
      */
     public function loadedPanels()
     {
-        return $this->_registry->loaded();
+        return $this->service->registry()->loaded();
     }
 
     /**
@@ -132,7 +94,8 @@ class DebugBarFilter extends DispatcherFilter
      */
     public function panel($name)
     {
-        return $this->_registry->{$name};
+        $registry = $this->service->registry();
+        return $regisrty->{$name};
     }
 
     /**
@@ -145,9 +108,7 @@ class DebugBarFilter extends DispatcherFilter
      */
     public function setup()
     {
-        foreach ($this->config('panels') as $panel) {
-            $this->_registry->load($panel);
-        }
+        $this->service->loadPanels();
     }
 
     /**
@@ -158,9 +119,7 @@ class DebugBarFilter extends DispatcherFilter
      */
     public function beforeDispatch(Event $event)
     {
-        foreach ($this->_registry->loaded() as $panel) {
-            $this->_registry->{$panel}->initialize();
-        }
+        $this->service->initializePanels();
     }
 
     /**
@@ -173,77 +132,12 @@ class DebugBarFilter extends DispatcherFilter
     {
         /* @var Request $request */
         $request = $event->data['request'];
-        // Skip debugkit requests and requestAction()
-        if ($request->param('plugin') === 'DebugKit' || $request->is('requested')) {
-            return;
-        }
         /* @var Response $response */
         $response = $event->data['response'];
-
-        $data = [
-            'url' => $request->here(),
-            'content_type' => $response->type(),
-            'method' => $request->method(),
-            'status_code' => $response->statusCode(),
-            'requested_at' => $request->env('REQUEST_TIME'),
-            'panels' => []
-        ];
-        /* @var \DebugKit\Model\Table\RequestsTable $requests */
-        $requests = TableRegistry::get('DebugKit.Requests');
-        $requests->gc();
-
-        $row = $requests->newEntity($data);
-        $row->isNew(true);
-
-        foreach ($this->_registry->loaded() as $name) {
-            $panel = $this->_registry->{$name};
-            try {
-                $content = serialize($panel->data());
-            } catch (\Exception $e) {
-                $content = serialize([
-                    'error' => $e->getMessage(),
-                ]);
-            }
-            $row->panels[] = $requests->Panels->newEntity([
-                'panel' => $name,
-                'element' => $panel->elementName(),
-                'title' => $panel->title(),
-                'summary' => $panel->summary(),
-                'content' => $content,
-            ]);
-        }
-        $row = $requests->save($row);
-
-        $this->_injectScripts($row->id, $response);
-        $response->header(['X-DEBUGKIT-ID' => $row->id]);
-    }
-
-    /**
-     * Injects the JS to build the toolbar.
-     *
-     * The toolbar will only be injected if the response's content type
-     * contains HTML and there is a </body> tag.
-     *
-     * @param string $id ID to fetch data from.
-     * @param \Cake\Network\Response $response The response to augment.
-     * @return void
-     */
-    protected function _injectScripts($id, $response)
-    {
-        if (strpos($response->type(), 'html') === false) {
+        $row = $this->service->saveData($request, $response);
+        if (!$row) {
             return;
         }
-        $body = $response->body();
-        if (!is_string($body)) {
-            return;
-        }
-        $pos = strrpos($body, '</body>');
-        if ($pos === false) {
-            return;
-        }
-        $url = Router::url('/', true);
-        $script = "<script id=\"__debug_kit\" data-id=\"{$id}\" data-url=\"{$url}\" src=\"" . Router::url('/debug_kit/js/toolbar.js') . '"></script>';
-        $body = substr($body, 0, $pos) . $script . substr($body, $pos);
-        $response->body($body);
+        return $this->service->injectScripts($row, $response);
     }
 }

--- a/src/Routing/Filter/DebugBarFilter.php
+++ b/src/Routing/Filter/DebugBarFilter.php
@@ -12,6 +12,7 @@
 namespace DebugKit\Routing\Filter;
 
 use Cake\Event\Event;
+use Cake\Event\EventManager;
 use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Routing\DispatcherFilter;
@@ -95,7 +96,7 @@ class DebugBarFilter extends DispatcherFilter
     public function panel($name)
     {
         $registry = $this->service->registry();
-        return $regisrty->{$name};
+        return $registry->{$name};
     }
 
     /**

--- a/src/Routing/Filter/DebugBarFilter.php
+++ b/src/Routing/Filter/DebugBarFilter.php
@@ -140,6 +140,7 @@ class DebugBarFilter extends DispatcherFilter
         if (!$row) {
             return;
         }
+
         return $this->service->injectScripts($row, $response);
     }
 }

--- a/src/ToolbarService.php
+++ b/src/ToolbarService.php
@@ -123,10 +123,7 @@ class ToolbarService
     }
 
     /**
-     * Do the required setup work.
-     *
-     * - Build panels.
-     * - Connect events
+     * Load all the panels being used
      *
      * @return void
      */
@@ -140,7 +137,6 @@ class ToolbarService
     /**
      * Call the initialize method onl all the loaded panels.
      *
-     * @param \Cake\Event\Event $event The beforeDispatch event.
      * @return void
      */
     public function initializePanels()

--- a/src/ToolbarService.php
+++ b/src/ToolbarService.php
@@ -63,8 +63,8 @@ class ToolbarService
     /**
      * Constructor
      *
-     * @param array $config The configuration data for DebugKit.
      * @param \Cake\Event\EventManager $events The event manager to use defaults to the global manager
+     * @param array $config The configuration data for DebugKit.
      */
     public function __construct(EventManager $events, array $config)
     {
@@ -149,8 +149,8 @@ class ToolbarService
     /**
      * Save the toolbar state.
      *
-     * @param \Cake\Network\Request $request
-     * @param \Cake\Network\Response $respone
+     * @param \Cake\Network\Request $request The request
+     * @param \Cake\Network\Response $response The response
      * @return null|\DebugKit\Model\Entity\Request Saved request data.
      */
     public function saveData(Request $request, Response $response)
@@ -191,6 +191,7 @@ class ToolbarService
                 'content' => $content,
             ]);
         }
+
         return $requests->save($row);
     }
 
@@ -229,6 +230,7 @@ class ToolbarService
 
         $body = substr($body, 0, $pos) . $script . substr($body, $pos);
         $response->body($body);
+
         return $response;
     }
 }

--- a/src/ToolbarService.php
+++ b/src/ToolbarService.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace DebugKit;
+
+use Cake\Core\Configure;
+use Cake\Core\InstanceConfigTrait;
+use Cake\Event\Event;
+use Cake\Network\Request;
+use Cake\Network\Response;
+use Cake\ORM\TableRegistry;
+use Cake\Routing\Router;
+use DebugKit\Panel\PanelRegistry;
+
+/**
+ * Used to create the panels and inject a toolbar into
+ * matching responses.
+ *
+ * Used by the Routing Filter and Middleware.
+ */
+class ToolbarService
+{
+    use InstanceConfigTrait;
+
+    /**
+     * The panel registry.
+     *
+     * @var \DebugKit\Panel\PanelRegistry
+     */
+    protected $registry;
+
+    /**
+     * Default configuration.
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'panels' => [
+            'DebugKit.Cache',
+            'DebugKit.Session',
+            'DebugKit.Request',
+            'DebugKit.SqlLog',
+            'DebugKit.Timer',
+            'DebugKit.Log',
+            'DebugKit.Variables',
+            'DebugKit.Environment',
+            'DebugKit.Include',
+            'DebugKit.History',
+            'DebugKit.Routes',
+        ],
+        'forceEnable' => false,
+    ];
+
+    /**
+     * Constructor
+     *
+     * @param \Cake\Event\EventManager $events The event manager to use.
+     * @param array $config The configuration data for DebugKit.
+     */
+    public function __construct(EventManager $events, array $config)
+    {
+        parent::__construct($config);
+
+        $this->registry = new PanelRegistry($events);
+    }
+
+    /**
+     * Fetch the PanelRegistry
+     *
+     * @return \DebugKit\Panel\PanelRegistry
+     */
+    public function registry()
+    {
+        return $this->registry;
+    }
+
+    /**
+     * Check whether or not debug kit is enabled.
+     *
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        $enabled = (bool)Configure::read('debug');
+        if ($enabled) {
+            return true;
+        }
+        $force = $this->config('forceEnable');
+        if (is_callable($force)) {
+            return $force();
+        }
+
+        return $force;
+    }
+
+    /**
+     * Get the list of loaded panels
+     *
+     * @return array
+     */
+    public function loadedPanels()
+    {
+        return $this->registry->loaded();
+    }
+
+    /**
+     * Get the list of loaded panels
+     *
+     * @param string $name The name of the panel you want to get.
+     * @return \DebugKit\DebugPanel|null The panel or null.
+     */
+    public function panel($name)
+    {
+        return $this->registry->{$name};
+    }
+
+    /**
+     * Do the required setup work.
+     *
+     * - Build panels.
+     * - Connect events
+     *
+     * @return void
+     */
+    public function loadPanels()
+    {
+        foreach ($this->config('panels') as $panel) {
+            $this->registry->load($panel);
+        }
+    }
+
+    /**
+     * Call the initialize method onl all the loaded panels.
+     *
+     * @param \Cake\Event\Event $event The beforeDispatch event.
+     * @return void
+     */
+    public function initializePanels()
+    {
+        foreach ($this->registry->loaded() as $panel) {
+            $this->registry->{$panel}->initialize();
+        }
+    }
+
+    /**
+     * Save the toolbar state.
+     *
+     * @param \Cake\Network\Request $request
+     * @param \Cake\Network\Response $respone
+     * @return null|\DebugKit\Model\Entity\Request Saved request data.
+     */
+    public function saveData(Request $request, Response $response)
+    {
+        // Skip debugkit requests and requestAction()
+        if ($request->param('plugin') === 'DebugKit' || $request->is('requested')) {
+            return null;
+        }
+        $data = [
+            'url' => $request->here(),
+            'content_type' => $response->type(),
+            'method' => $request->method(),
+            'status_code' => $response->statusCode(),
+            'requested_at' => $request->env('REQUEST_TIME'),
+            'panels' => []
+        ];
+        /* @var \DebugKit\Model\Table\RequestsTable $requests */
+        $requests = TableRegistry::get('DebugKit.Requests');
+        $requests->gc();
+
+        $row = $requests->newEntity($data);
+        $row->isNew(true);
+
+        foreach ($this->registry->loaded() as $name) {
+            $panel = $this->registry->{$name};
+            try {
+                $content = serialize($panel->data());
+            } catch (\Exception $e) {
+                $content = serialize([
+                    'error' => $e->getMessage(),
+                ]);
+            }
+            $row->panels[] = $requests->Panels->newEntity([
+                'panel' => $name,
+                'element' => $panel->elementName(),
+                'title' => $panel->title(),
+                'summary' => $panel->summary(),
+                'content' => $content,
+            ]);
+        }
+        return $requests->save($row);
+    }
+
+    /**
+     * Injects the JS to build the toolbar.
+     *
+     * The toolbar will only be injected if the response's content type
+     * contains HTML and there is a </body> tag.
+     *
+     * @param \DebugKit\Model\Entity\Request $row The request data to inject.
+     * @param \Cake\Network\Response $response The response to augment.
+     * @return \Cake\Network\Response The modified response
+     */
+    public function injectScripts($row, $response)
+    {
+        if (strpos($response->type(), 'html') === false) {
+            return $response;
+        }
+        $body = $response->body();
+        if (!is_string($body)) {
+            return $response;
+        }
+        $pos = strrpos($body, '</body>');
+        if ($pos === false) {
+            return $response;
+        }
+        $response->header(['X-DEBUGKIT-ID' => $row->id]);
+
+        $url = Router::url('/', true);
+        $script = "<script id=\"__debug_kit\" data-id=\"{$id}\" data-url=\"{$url}\" src=\"" . Router::url('/debug_kit/js/toolbar.js') . '"></script>';
+
+        $body = substr($body, 0, $pos) . $script . substr($body, $pos);
+        $response->body($body);
+        return $response;
+    }
+}

--- a/src/ToolbarService.php
+++ b/src/ToolbarService.php
@@ -14,6 +14,7 @@ namespace DebugKit;
 use Cake\Core\Configure;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Event\Event;
+use Cake\Event\EventManager;
 use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\ORM\TableRegistry;
@@ -62,13 +63,12 @@ class ToolbarService
     /**
      * Constructor
      *
-     * @param \Cake\Event\EventManager $events The event manager to use.
      * @param array $config The configuration data for DebugKit.
+     * @param \Cake\Event\EventManager $events The event manager to use defaults to the global manager
      */
     public function __construct(EventManager $events, array $config)
     {
-        parent::__construct($config);
-
+        $this->config($config);
         $this->registry = new PanelRegistry($events);
     }
 
@@ -224,7 +224,12 @@ class ToolbarService
         $response->header(['X-DEBUGKIT-ID' => $row->id]);
 
         $url = Router::url('/', true);
-        $script = "<script id=\"__debug_kit\" data-id=\"{$id}\" data-url=\"{$url}\" src=\"" . Router::url('/debug_kit/js/toolbar.js') . '"></script>';
+        $script = sprintf(
+            '<script id="__debug_kit" data-id="%s" data-url="%s" src="%s"></script>',
+            $row->id,
+            $url,
+            Router::url('/debug_kit/js/toolbar.js')
+        );
 
         $body = substr($body, 0, $pos) . $script . substr($body, $pos);
         $response->body($body);

--- a/tests/TestCase/Routing/Filter/DebugBarFilterTest.php
+++ b/tests/TestCase/Routing/Filter/DebugBarFilterTest.php
@@ -135,7 +135,7 @@ class DebugBarFilterTest extends TestCase
 
         $bar = new DebugBarFilter($this->events, []);
         $event = new Event('Dispatcher.afterDispatch', $bar, compact('request', 'response'));
-        $this->assertNull($bar->afterDispatch($event));
+        $bar->afterDispatch($event);
         $this->assertInstanceOf('Closure', $response->body());
     }
 

--- a/tests/TestCase/ToolbarServiceTest.php
+++ b/tests/TestCase/ToolbarServiceTest.php
@@ -81,6 +81,7 @@ class ToolbarServiceTest extends TestCase
      */
     public function testInitializePanels()
     {
+        Log::drop('debug_kit_log_panel');
         $bar = new ToolbarService($this->events, []);
         $bar->loadPanels();
 

--- a/tests/TestCase/ToolbarServiceTest.php
+++ b/tests/TestCase/ToolbarServiceTest.php
@@ -1,0 +1,279 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace DebugKit\Test;
+
+use Cake\Core\Configure;
+use Cake\Database\Driver\Sqlite;
+use Cake\Datasource\ConnectionManager;
+use Cake\Event\EventManager;
+use Cake\Log\Log;
+use Cake\Network\Request;
+use Cake\Network\Response;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use DebugKit\Model\Entity\Request as RequestEntity;
+use DebugKit\ToolbarService;
+
+/**
+ * Test the debug bar
+ */
+class ToolbarServiceTest extends TestCase
+{
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.debug_kit.requests',
+        'plugin.debug_kit.panels'
+    ];
+
+    /**
+     * @var EventManager
+     */
+    protected $events;
+
+    /**
+     * setup
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->events = new EventManager();
+
+        $connection = ConnectionManager::get('test');
+        $this->skipIf($connection->driver() instanceof Sqlite, 'Schema insertion/removal breaks SQLite');
+    }
+
+    /**
+     * Test loading panels.
+     *
+     * @return void
+     */
+    public function testLoadPanels()
+    {
+        $bar = new ToolbarService($this->events, []);
+        $bar->loadPanels();
+
+        $this->assertContains('SqlLog', $bar->loadedPanels());
+        $this->assertGreaterThan(1, $this->events->listeners('Controller.shutdown'));
+        $this->assertInstanceOf('DebugKit\Panel\SqlLogPanel', $bar->panel('SqlLog'));
+    }
+
+    /**
+     * Test that beforeDispatch call initialize on each panel
+     *
+     * @return void
+     */
+    public function testInitializePanels()
+    {
+        $bar = new ToolbarService($this->events, []);
+        $bar->loadPanels();
+
+        $this->assertNull(Log::config('debug_kit_log_panel'));
+        $bar->initializePanels();
+
+        $this->assertNotEmpty(Log::config('debug_kit_log_panel'), 'Panel attached logger.');
+    }
+
+    /**
+     * Test that saveData ignores requestAction
+     *
+     * @return void
+     */
+    public function testSaveDataIgnoreRequestAction()
+    {
+        $request = new Request([
+            'url' => '/articles',
+            'params' => ['plugin' => null, 'requested' => 1]
+        ]);
+        $response = new Response([
+            'statusCode' => 200,
+            'type' => 'text/html',
+            'body' => '<html><title>test</title><body><p>some text</p></body>'
+        ]);
+
+        $bar = new ToolbarService($this->events, []);
+        $this->assertNull($bar->saveData($request, $response));
+    }
+
+    /**
+     * Test that saveData works
+     *
+     * @return void
+     */
+    public function testSaveData()
+    {
+        $request = new Request([
+            'url' => '/articles',
+            'environment' => ['REQUEST_METHOD' => 'GET']
+        ]);
+        $response = new Response([
+            'statusCode' => 200,
+            'type' => 'text/html',
+            'body' => '<html><title>test</title><body><p>some text</p></body>'
+        ]);
+
+        $bar = new ToolbarService($this->events, []);
+        $bar->loadPanels();
+        $row = $bar->saveData($request, $response);
+        $this->assertNotEmpty($row);
+
+        $requests = TableRegistry::get('DebugKit.Requests');
+        $result = $requests->find()
+            ->order(['Requests.requested_at' => 'DESC'])
+            ->contain('Panels')
+            ->first();
+
+        $this->assertEquals('GET', $result->method);
+        $this->assertEquals('/articles', $result->url);
+        $this->assertNotEmpty($result->requested_at);
+        $this->assertNotEmpty('text/html', $result->content_type);
+        $this->assertEquals(200, $result->status_code);
+        $this->assertGreaterThan(1, $result->panels);
+
+        $this->assertEquals('SqlLog', $result->panels[8]->panel);
+        $this->assertEquals('DebugKit.sql_log_panel', $result->panels[8]->element);
+        $this->assertSame('0', $result->panels[8]->summary);
+        $this->assertEquals('Sql Log', $result->panels[8]->title);
+    }
+
+    /**
+     * Test injectScripts()
+     *
+     * @return void
+     */
+    public function testInjectScriptsLastBodyTag()
+    {
+        $request = new Request([
+            'url' => '/articles',
+            'environment' => ['REQUEST_METHOD' => 'GET']
+        ]);
+        $response = new Response([
+            'statusCode' => 200,
+            'type' => 'text/html',
+            'body' => '<html><title>test</title><body><p>some text</p></body>'
+        ]);
+
+        $bar = new ToolbarService($this->events, []);
+        $bar->loadPanels();
+        $row = $bar->saveData($request, $response);
+        $response = $bar->injectScripts($row, $response);
+
+        $expected = '<html><title>test</title><body><p>some text</p>' .
+            '<script id="__debug_kit" data-id="' . $row->id . '" ' .
+            'data-url="http://localhost/" src="/debug_kit/js/toolbar.js"></script>' .
+            '</body>';
+        $this->assertTextEquals($expected, $response->body());
+    }
+
+    /**
+     * Test that saveData ignores streaming bodies
+     *
+     * @return void
+     */
+    public function testInjectScriptsStreamBodies()
+    {
+        $request = new Request([
+            'url' => '/articles',
+            'params' => ['plugin' => null]
+        ]);
+        $response = new Response([
+            'statusCode' => 200,
+            'type' => 'text/html',
+        ]);
+        $response->body(function () {
+            echo 'I am a teapot!';
+        });
+
+        $bar = new ToolbarService($this->events, []);
+        $row = new RequestEntity(['id' => 'abc123']);
+
+        $result = $bar->injectScripts($row, $response);
+        $this->assertInstanceOf('Cake\Network\Response', $result);
+        $this->assertInstanceOf('Closure', $result->body());
+        $this->assertInstanceOf('Closure', $response->body());
+    }
+
+
+    /**
+     * Test that afterDispatch does not modify response
+     *
+     * @return void
+     */
+    public function testInjectScriptsNoModifyResponse()
+    {
+        $request = new Request(['url' => '/articles']);
+
+        $response = new Response([
+            'statusCode' => 200,
+            'type' => 'application/json',
+            'body' => '{"some":"json"}'
+        ]);
+
+        $bar = new ToolbarService($this->events, []);
+        $bar->loadPanels();
+
+        $row = $bar->saveData($request, $response);
+        $response = $bar->injectScripts($row, $response);
+        $this->assertTextEquals('{"some":"json"}', $response->body());
+    }
+
+    /**
+     * test isEnabled responds to debug flag.
+     *
+     * @return void
+     */
+    public function testIsEnabled()
+    {
+        Configure::write('debug', true);
+        $bar = new ToolbarService($this->events, []);
+        $this->assertTrue($bar->isEnabled(), 'debug is on, panel is enabled');
+
+        Configure::write('debug', false);
+        $bar = new ToolbarService($this->events, []);
+        $this->assertFalse($bar->isEnabled(), 'debug is off, panel is disabled');
+    }
+
+    /**
+     * test isEnabled responds to forceEnable config flag.
+     *
+     * @return void
+     */
+    public function testIsEnabledForceEnable()
+    {
+        Configure::write('debug', false);
+        $bar = new ToolbarService($this->events, ['forceEnable' => true]);
+        $this->assertTrue($bar->isEnabled(), 'debug is off, panel is forced on');
+    }
+
+    /**
+     * test isEnabled responds to forceEnable callable.
+     *
+     * @return void
+     */
+    public function testIsEnabledForceEnableCallable()
+    {
+        Configure::write('debug', false);
+        $bar = new ToolbarService($this->events, [
+            'forceEnable' => function () {
+                return true;
+            }
+        ]);
+        $this->assertTrue($bar->isEnabled(), 'debug is off, panel is forced on');
+    }
+}


### PR DESCRIPTION
By splitting out the core logic of the `DispatchFilter` into a separate class, we'll be able to more easily add middleware support post 3.4.0.

Once 3.4.0 is in beta I'll add the middleware.