### PR TITLE
Fix tests in 3.4.0+

### DIFF
--- a/src/ToolbarService.php
+++ b/src/ToolbarService.php
@@ -210,9 +210,16 @@ class ToolbarService
         if (strpos($response->type(), 'html') === false) {
             return $response;
         }
-        $body = $response->getBody();
-        if (!$body->isSeekable()) {
-            return $response;
+        if (method_exists($response, 'getBody')) {
+            $body = $response->getBody();
+            if (!$body->isSeekable()) {
+                return $response;
+            }
+        } else {
+            $body = $response->body();
+            if (!is_string($body)) {
+                return $response;
+            }
         }
         $pos = strrpos($body, '</body>');
         if ($pos === false) {

--- a/tests/TestCase/Routing/Filter/DebugBarFilterTest.php
+++ b/tests/TestCase/Routing/Filter/DebugBarFilterTest.php
@@ -136,7 +136,11 @@ class DebugBarFilterTest extends TestCase
         $bar = new DebugBarFilter($this->events, []);
         $event = new Event('Dispatcher.afterDispatch', $bar, compact('request', 'response'));
         $bar->afterDispatch($event);
-        $this->assertEquals('I am a teapot!', $response->body());
+        if (version_compare(PHP_VERSION, '5.6.0', '>=')) {
+            $this->assertEquals('I am a teapot!', $response->body());
+        } else {
+            $this->assertInstanceOf('Closure', $response->body());
+        }
     }
 
     /**

--- a/tests/TestCase/ToolbarServiceTest.php
+++ b/tests/TestCase/ToolbarServiceTest.php
@@ -206,7 +206,11 @@ class ToolbarServiceTest extends TestCase
 
         $result = $bar->injectScripts($row, $response);
         $this->assertInstanceOf('Cake\Network\Response', $result);
-        $this->assertEquals('I am a teapot!', $result->body());
+        if (version_compare(PHP_VERSION, '5.6.0', '>=')) {
+            $this->assertEquals('I am a teapot!', $response->body());
+        } else {
+            $this->assertInstanceOf('Closure', $response->body());
+        }
     }
 
 


### PR DESCRIPTION
Apply patch from @fquffio posted in #471 to fix tests and not break compatibility with <3.4.x. This is a much better fix than the hastily pushed bad change I made last night.