### PR TITLE
Add a new Packages Panel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "require": {
         "cakephp/cakephp": ">=3.1.0 <4.0",
         "cakephp/plugin-installer": "*",
+        "composer/composer": "^1.3",
         "jdorn/sql-formatter": "~1.2"
     },
     "require-dev": {

--- a/src/Panel/PackagesPanel.php
+++ b/src/Panel/PackagesPanel.php
@@ -22,10 +22,6 @@ use DebugKit\DebugPanel;
  */
 class PackagesPanel extends DebugPanel
 {
-    const REQUIREMENT = 'Requirements';
-
-    const DEV_REQUIREMENT = 'Dev Requirements';
-
     /**
      * Get the panel data
      *
@@ -33,15 +29,18 @@ class PackagesPanel extends DebugPanel
      */
     public function data()
     {
-        $packages = [];
+        $packages = $devPackages = [];
 
         $lockFile = new JsonFile(ROOT . DIRECTORY_SEPARATOR . 'composer.lock');
         if ($lockFile->exists()) {
             $lockContent = $lockFile->read();
-            $packages[self::REQUIREMENT] = $lockContent['packages'];
-            $packages[self::DEV_REQUIREMENT] = $lockContent['packages-dev'];
+            $packages = $lockContent['packages'];
+            $devPackages = $lockContent['packages-dev'];
         }
 
-        return compact('packages');
+        return [
+            'packages' => $packages,
+            'devPackages' => $devPackages,
+        ];
     }
 }

--- a/src/Panel/PackagesPanel.php
+++ b/src/Panel/PackagesPanel.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         DebugKit 3.5.2
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace DebugKit\Panel;
+
+use Composer\Json\JsonFile;
+use DebugKit\DebugPanel;
+
+/**
+ * Packages Panel - Reads all installed packages in the project.
+ *
+ */
+class PackagesPanel extends DebugPanel
+{
+    const REQUIREMENT = 'Requirements';
+
+    const DEV_REQUIREMENT = 'Dev Requirements';
+
+    /**
+     * Get the panel data
+     *
+     * @return array
+     */
+    public function data()
+    {
+        $packages = [];
+
+        $lockFile = new JsonFile(ROOT . DIRECTORY_SEPARATOR . 'composer.lock');
+        if ($lockFile->exists()) {
+            $lockContent = $lockFile->read();
+            $packages[self::REQUIREMENT] = $lockContent['packages'];
+            $packages[self::DEV_REQUIREMENT] = $lockContent['packages-dev'];
+        }
+
+        return compact('packages');
+    }
+}

--- a/src/Template/Element/packages_panel.ctp
+++ b/src/Template/Element/packages_panel.ctp
@@ -17,36 +17,61 @@
  * @type array $packages
  */
 ?>
-
-<?php if (!empty($packages)): ?>
-    <?php foreach ($packages as $title => $requirements): ?>
-    <section class="section-tile">
-        <h3><?= __d('debug_kit', $title) ?> </h3>
-        <table cellspacing="0" cellpadding="0" class="debug-table">
-            <thead>
-            <tr>
-                <th>Name</th>
-                <th>Version</th>
-            </tr>
-            </thead>
-            <tbody>
-            <?php foreach ($requirements as $package): ?>
-                <?php extract($package); ?>
-                <tr>
-                    <td title="<?= $description ?>">
-                        <a href="https://packagist.org/packages/<?= $name ?>" title="<?= $description ?>" target="_blank" class="package-link"><?= $name ?></a>
-                    </td>
-                    <td>
-                        <span class="package-version"><span class="panel-summary"><?= $version ?></span></span>
-                    </td>
-                </tr>
-            <?php endforeach; ?>
-            </tbody>
-        </table>
-    </section>
-    <?php endforeach; ?>
-<?php else: ?>
+<?php if (empty($packages) && empty($devPackages)): ?>
     <div class="warning">
-        <?= __d('debug_kit', "'composer.lock' not found"); ?>
+        <?= __d('debug_kit', '{0} not found', "'composer.lock'"); ?>
     </div>
+<?php else: ?>
+    <?php if (!empty($packages)): ?>
+        <section class="section-tile">
+            <h3><?= __d('debug_kit', 'Requirements ({0})', count($packages)) ?> </h3>
+            <table cellspacing="0" cellpadding="0" class="debug-table">
+                <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Version</th>
+                </tr>
+                </thead>
+                <tbody>
+                <?php foreach ($packages as $package): ?>
+                    <?php extract($package); ?>
+                    <tr>
+                        <td title="<?= h($description) ?>">
+                            <a href="https://packagist.org/packages/<?= h($name) ?>" title="<?= h($description) ?>" target="_blank" class="package-link"><?= h($name) ?></a>
+                        </td>
+                        <td>
+                            <span class="package-version"><span class="panel-summary"><?= h($version) ?></span></span>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+        </section>
+    <?php endif; ?>
+    <?php if (!empty($devPackages)): ?>
+        <section class="section-tile">
+            <h3><?= __d('debug_kit', 'Dev Requirements ({0})', count($devPackages)) ?> </h3>
+            <table cellspacing="0" cellpadding="0" class="debug-table">
+                <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Version</th>
+                </tr>
+                </thead>
+                <tbody>
+                <?php foreach ($devPackages as $package): ?>
+                    <?php extract($package); ?>
+                    <tr>
+                        <td title="<?= h($description) ?>">
+                            <a href="https://packagist.org/packages/<?= h($name) ?>" title="<?= h($description) ?>" target="_blank" class="package-link"><?= h($name) ?></a>
+                        </td>
+                        <td>
+                            <span class="package-version"><span class="panel-summary"><?= h($version) ?></span></span>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+        </section>
+    <?php endif; ?>
 <?php endif; ?>

--- a/src/Template/Element/packages_panel.ctp
+++ b/src/Template/Element/packages_panel.ctp
@@ -1,0 +1,52 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         DebugKit 3.5.2
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+/**
+ * @type \DebugKit\View\AjaxView $this
+ * @type array $packages
+ */
+?>
+
+<?php if (!empty($packages)): ?>
+    <?php foreach ($packages as $title => $requirements): ?>
+    <section class="section-tile">
+        <h3><?= __d('debug_kit', $title) ?> </h3>
+        <table cellspacing="0" cellpadding="0" class="debug-table">
+            <thead>
+            <tr>
+                <th>Name</th>
+                <th>Version</th>
+            </tr>
+            </thead>
+            <tbody>
+            <?php foreach ($requirements as $package): ?>
+                <?php extract($package); ?>
+                <tr>
+                    <td title="<?= $description ?>">
+                        <a href="https://packagist.org/packages/<?= $name ?>" title="<?= $description ?>" target="_blank" class="package-link"><?= $name ?></a>
+                    </td>
+                    <td>
+                        <span class="package-version"><span class="panel-summary"><?= $version ?></span></span>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+            </tbody>
+        </table>
+    </section>
+    <?php endforeach; ?>
+<?php else: ?>
+    <div class="warning">
+        <?= __d('debug_kit', "'composer.lock' not found"); ?>
+    </div>
+<?php endif; ?>

--- a/src/Template/Requests/view.ctp
+++ b/src/Template/Requests/view.ctp
@@ -28,9 +28,6 @@ use Cake\Core\Configure;
         <?php endif ?>
     </li>
     <?php endforeach; ?>
-    <li class="panel cake-version">
-        <span class="panel-summary"><?= Configure::version() ?></span>
-    </li>
     <li id="panel-button">
         <?= $this->Html->image('DebugKit.cake.icon.png', [
             'alt' => 'Debug Kit', 'title' => 'CakePHP ' . Configure::version() . ' Debug Kit'

--- a/src/ToolbarService.php
+++ b/src/ToolbarService.php
@@ -56,6 +56,7 @@ class ToolbarService
             'DebugKit.Include',
             'DebugKit.History',
             'DebugKit.Routes',
+            'DebugKit.Packages',
         ],
         'forceEnable' => false,
     ];

--- a/tests/TestCase/Panel/PackagesPanelTest.php
+++ b/tests/TestCase/Panel/PackagesPanelTest.php
@@ -39,18 +39,28 @@ class PackagesPanelTest extends TestCase
     }
 
     /**
+     * Packages view variables provider
+     * @return array
+     */
+    public function packagesProvider()
+    {
+        return [
+            'requirements' => ['packages'],
+            'dev requirements' => ['devPackages'],
+        ];
+    }
+    /**
      * test data
      *
+     * @dataProvider packagesProvider
      * @return void
      */
-    public function testData()
+    public function testData($package)
     {
         $data = $this->panel->data();
-        $this->assertArrayHasKey('packages', $data);
-        $this->assertArrayHasKey('Requirements', $data['packages']);
-        $this->assertArrayHasKey('Dev Requirements', $data['packages']);
+        $this->assertArrayHasKey($package, $data);
 
-        $singlePackage = current($data['packages']['Requirements']);
+        $singlePackage = current($data[$package]);
         $this->assertArrayHasKey('name', $singlePackage);
         $this->assertArrayHasKey('description', $singlePackage);
         $this->assertArrayHasKey('version', $singlePackage);

--- a/tests/TestCase/Panel/PackagesPanelTest.php
+++ b/tests/TestCase/Panel/PackagesPanelTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         DebugKit 3.5.2
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ **/
+namespace DebugKit\Test\TestCase\Panel;
+
+use Cake\TestSuite\TestCase;
+use DebugKit\Panel\PackagesPanel;
+
+/**
+ * Class PackagesPanelTest
+ *
+ */
+class PackagesPanelTest extends TestCase
+{
+    /**
+     * @var PackagesPanel
+     */
+    protected $panel;
+
+    /**
+     * set up
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->panel = new PackagesPanel();
+    }
+
+    /**
+     * test data
+     *
+     * @return void
+     */
+    public function testData()
+    {
+        $data = $this->panel->data();
+        $this->assertArrayHasKey('packages', $data);
+        $this->assertArrayHasKey('Requirements', $data['packages']);
+        $this->assertArrayHasKey('Dev Requirements', $data['packages']);
+
+        $singlePackage = current($data['packages']['Requirements']);
+        $this->assertArrayHasKey('name', $singlePackage);
+        $this->assertArrayHasKey('description', $singlePackage);
+        $this->assertArrayHasKey('version', $singlePackage);
+    }
+}

--- a/tests/TestCase/Routing/Filter/DebugBarFilterTest.php
+++ b/tests/TestCase/Routing/Filter/DebugBarFilterTest.php
@@ -179,10 +179,10 @@ class DebugBarFilterTest extends TestCase
         $this->assertEquals(200, $result->status_code);
         $this->assertGreaterThan(1, $result->panels);
 
-        $this->assertEquals('SqlLog', $result->panels[8]->panel);
-        $this->assertEquals('DebugKit.sql_log_panel', $result->panels[8]->element);
-        $this->assertSame('0', $result->panels[8]->summary);
-        $this->assertEquals('Sql Log', $result->panels[8]->title);
+        $this->assertEquals('SqlLog', $result->panels[9]->panel);
+        $this->assertEquals('DebugKit.sql_log_panel', $result->panels[9]->element);
+        $this->assertSame('0', $result->panels[9]->summary);
+        $this->assertEquals('Sql Log', $result->panels[9]->title);
 
         $expected = '<html><title>test</title><body><p>some text</p>' .
             '<script id="__debug_kit" data-id="' . $result->id . '" ' .

--- a/tests/TestCase/ToolbarServiceTest.php
+++ b/tests/TestCase/ToolbarServiceTest.php
@@ -147,10 +147,10 @@ class ToolbarServiceTest extends TestCase
         $this->assertEquals(200, $result->status_code);
         $this->assertGreaterThan(1, $result->panels);
 
-        $this->assertEquals('SqlLog', $result->panels[8]->panel);
-        $this->assertEquals('DebugKit.sql_log_panel', $result->panels[8]->element);
-        $this->assertSame('0', $result->panels[8]->summary);
-        $this->assertEquals('Sql Log', $result->panels[8]->title);
+        $this->assertEquals('SqlLog', $result->panels[9]->panel);
+        $this->assertEquals('DebugKit.sql_log_panel', $result->panels[9]->element);
+        $this->assertSame('0', $result->panels[9]->summary);
+        $this->assertEquals('Sql Log', $result->panels[9]->title);
     }
 
     /**

--- a/webroot/css/toolbar.css
+++ b/webroot/css/toolbar.css
@@ -423,11 +423,6 @@ pre,
     white-space: nowrap;
 }
 
-.package-btn {
-    text-decoration: none;
-    padding: 2px 6px;
-}
-
 .package-link {
     color: #000000;
     text-decoration: none;

--- a/webroot/css/toolbar.css
+++ b/webroot/css/toolbar.css
@@ -412,6 +412,26 @@ pre,
 	font-family: Monaco, Consolas, mono-space;
 }
 
+/**
+ * Packages panel
+ */
+.package-version {
+    background: #D33C44;
+    border-radius: 4px;
+    line-height: 20px;
+    display: inline-block;
+    white-space: nowrap;
+}
+
+.package-btn {
+    text-decoration: none;
+    padding: 2px 6px;
+}
+
+.package-link {
+    color: #000000;
+    text-decoration: none;
+}
 
 /**
  * Warnings and info boxes.

--- a/webroot/css/toolbar.css
+++ b/webroot/css/toolbar.css
@@ -68,7 +68,7 @@ p {
 .toolbar.open {
 	border-radius: 0;
 	overflow: auto;
-	padding-right: 100px;
+	padding-right: 40px;
 }
 
 .hidden {
@@ -129,13 +129,6 @@ p {
 
 .history-mode .panel-active .panel-button {
 	color: #ab47bc;
-}
-
-.cake-version {
-	position:absolute;
-	right:40px;
-	cursor: default;
-	padding-right: 0;
 }
 
 /**

--- a/webroot/js/debug_kit.js
+++ b/webroot/js/debug_kit.js
@@ -12,7 +12,7 @@ $(document).ready(function() {
   toolbar = new Toolbar({
     button: $('#toolbar'),
     content: $('#panel-content-container'),
-    panelButtons: $('.panel').not('.cake-version'),
+    panelButtons: $('.panel'),
     panelClose: $('#panel-close'),
     keyboardScope : $(document),
     currentRequest: __debugKitId,


### PR DESCRIPTION
This add the packages Panel as discussed  in #478 

For now it is dead simple, just parsing the `composer.lock` but I love the idea proposed by @lorenzo to get an up-to-date report or something. I will probably try to see how it can be done in the next weeks.

Is this ok to target master ?

![b500f8b4-dbe2-11e6-83d9-b6063db7f361](https://cloud.githubusercontent.com/assets/4977112/22019405/c46a6598-dcb3-11e6-95bf-c3d1660401f8.gif)

