### PR TITLE
Add CONFIG to CakePHP Constants list

### DIFF
--- a/src/Panel/EnvironmentPanel.php
+++ b/src/Panel/EnvironmentPanel.php
@@ -59,14 +59,14 @@ class EnvironmentPanel extends DebugPanel
             'WWW_ROOT' => WWW_ROOT
         ];
 
-        $cakeConstants = array_fill_keys(
+        $hiddenCakeConstants = array_fill_keys(
             [
-                'DS', 'ROOT', 'TIME_START', 'SECOND', 'MINUTE', 'HOUR', 'DAY', 'WEEK', 'MONTH', 'YEAR',
+                'TIME_START', 'SECOND', 'MINUTE', 'HOUR', 'DAY', 'WEEK', 'MONTH', 'YEAR',
             ],
             ''
         );
         $var = get_defined_constants(true);
-        $return['app'] = array_diff_key($var['user'], $return['cake'], $cakeConstants);
+        $return['app'] = array_diff_key($var['user'], $return['cake'], $hiddenCakeConstants);
 
         if (isset($var['hidef'])) {
             $return['hidef'] = $var['hidef'];

--- a/src/Panel/EnvironmentPanel.php
+++ b/src/Panel/EnvironmentPanel.php
@@ -48,6 +48,7 @@ class EnvironmentPanel extends DebugPanel
             'CACHE' => CACHE,
             'CAKE' => CAKE,
             'CAKE_CORE_INCLUDE_PATH' => CAKE_CORE_INCLUDE_PATH,
+            'CONFIG' => CONFIG,
             'CORE_PATH' => CORE_PATH,
             'CAKE_VERSION' => Configure::version(),
             'DS' => DS,


### PR DESCRIPTION
In Environment panel, CONFIG should be within _CakePHP Constants_ list, not _Application Constants_.

Also remove DS and ROOT from hidden constants list, as they are already in displayed list.