### PR TITLE
Add a tool to check composer outdated dependencies

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -20,4 +20,8 @@ Router::plugin('DebugKit', function (RouteBuilder $routes) {
         '/panels/*',
         ['controller' => 'Panels', 'action' => 'index']
     );
+    $routes->connect(
+        '/composer/check_dependencies',
+        ['controller' => 'Composer', 'action' => 'checkDependencies']
+    );
 });

--- a/src/Controller/ComposerController.php
+++ b/src/Controller/ComposerController.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         DebugKit 3.6.1
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace DebugKit\Controller;
+
+use Cake\Controller\Controller;
+use Cake\Core\Configure;
+use Cake\Event\Event;
+use Cake\Network\Exception\NotFoundException;
+use Cake\View\JsonView;
+use Composer\Command\OutdatedCommand;
+use Composer\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * Provides utility features need by the toolbar.
+ */
+class ComposerController extends Controller
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public function initialize()
+    {
+        parent::initialize();
+        $this->loadComponent('RequestHandler');
+        $this->viewBuilder()->className(JsonView::class);
+    }
+
+    /**
+     * Before filter handler.
+     *
+     * @param \Cake\Event\Event $event The event.
+     * @return void
+     * @throws \Cake\Network\Exception\NotFoundException
+     */
+    public function beforeFilter(Event $event)
+    {
+        if (!Configure::read('debug')) {
+            throw new NotFoundException();
+        }
+    }
+
+    /**
+     * Check outdated composer dependencies
+     *
+     * @return void
+     * @throws \RuntimeException
+     */
+    public function checkDependencies()
+    {
+        $this->request->allowMethod('post');
+
+        $input = new ArrayInput([
+            'command' => 'outdated',
+            '--no-interaction' => true,
+            '--direct' => (bool)$this->request->data('direct'),
+        ]);
+
+        $output = $this->executeComposerCommand($input);
+
+        $dependencies = array_filter(explode("\n", $output->fetch()));
+        foreach ($dependencies as $dependency) {
+            if (strpos($dependency, 'php_network_getaddresses') !== false) {
+                throw new \RuntimeException('You have to be connected to the internet');
+            }
+            if (strpos($dependency, '<highlight>') !== false) {
+                $packages['semverCompatible'][] = $dependency;
+                continue;
+            }
+            $packages['bcBreaks'][] = $dependency;
+        }
+        if (!empty($packages['semverCompatible'])) {
+            $packages['semverCompatible'] = trim(implode("\n", $packages['semverCompatible']));
+        }
+        if (!empty($packages['bcBreaks'])) {
+            $packages['bcBreaks'] = trim(implode("\n", $packages['bcBreaks']));
+        }
+
+        $this->set([
+            '_serialize' => ['packages'],
+            'packages' => $packages,
+        ]);
+    }
+
+    /**
+     * @param ArrayInput $input An array describing the command input
+     * @return BufferedOutput Aa Console command buffered result
+     */
+    private function executeComposerCommand(ArrayInput $input)
+    {
+        $bin = implode(DIRECTORY_SEPARATOR, [ROOT, 'vendor', 'bin', 'composer']);
+        putenv('COMPOSER_HOME=' . $bin);
+        putenv('COMPOSER_CACHE_DIR=' . CACHE);
+
+        $dir = getcwd();
+        chdir(ROOT);
+        $timeLimit = ini_get('max_execution_time');
+        set_time_limit(300);
+        $memoryLimit = ini_get('memory_limit');
+        ini_set('memory_limit', '512M');
+
+        $output = new BufferedOutput();
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->run($input, $output);
+
+        // Restore environment
+        chdir($dir);
+        set_time_limit($timeLimit);
+        ini_set('memory_limit', $memoryLimit);
+
+        return $output;
+    }
+}

--- a/src/Controller/ComposerController.php
+++ b/src/Controller/ComposerController.php
@@ -18,7 +18,6 @@ use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Network\Exception\NotFoundException;
 use Cake\View\JsonView;
-use Composer\Command\OutdatedCommand;
 use Composer\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;

--- a/src/Template/Element/packages_panel.ctp
+++ b/src/Template/Element/packages_panel.ctp
@@ -22,6 +22,11 @@
         <?= __d('debug_kit', '{0} not found', "'composer.lock'"); ?>
     </div>
 <?php else: ?>
+    <div class="check-update">
+        <button class="btn-primary">Check for Updates</button>
+        <label><input type="checkbox" class="direct-dependency"><?= __d('debug_kit', 'Direct dependencies only') ?></label>
+    </div>
+    <div class="console"></div>
     <?php if (!empty($packages)): ?>
         <section class="section-tile">
             <h3><?= __d('debug_kit', 'Requirements ({0})', count($packages)) ?> </h3>
@@ -75,3 +80,60 @@
         </section>
     <?php endif; ?>
 <?php endif; ?>
+
+<script>
+    $(document).ready(function() {
+        var baseUrl = '<?= $this->Url->build([
+            'plugin' => 'DebugKit',
+            'controller' => 'Composer',
+            'action' => 'checkDependencies'
+        ]); ?>';
+
+        var console = $('.console');
+
+        function showMessage(el, html) {
+            el.show().html(html);
+        }
+
+        function buildLoader() {
+            return '<div class="loading">Loading <?= $this->Html->image('DebugKit.cake.icon.png', ['class' => 'indicator'])?></div>';
+        }
+
+        function buildSuccessfulMessage(response) {
+            var html = '';
+            if (response.packages.bcBreaks === undefined && response.packages.semverCompatible === undefined) {
+                return '<pre class="success-message">All dependencies are up to date</pre>';
+            }
+            if (response.packages.bcBreaks !== undefined) {
+                html += '<h4>Update with potential BC break</h4>';
+                html += '<pre>' + response.packages.bcBreaks + '</pre>';
+            }
+            if (response.packages.semverCompatible !== undefined) {
+                html += '<h4>Update semver compatible</h4>';
+                html += '<pre>' + response.packages.semverCompatible + '</pre>';
+            }
+            return html;
+        }
+
+        function buildErrorMessage(response) {
+            return '<pre class="warning-message">' + JSON.parse(response.responseText).message + '</pre>';
+        }
+
+        $('.check-update button').on('click', function(e) {
+            showMessage(console, buildLoader());
+            var direct = $('.direct-dependency')[0].checked;
+            var xhr = $.ajax({
+                url: baseUrl,
+                data: {direct: direct},
+                dataType: 'json',
+                type: 'POST'
+            });
+            xhr.done(function(response) {
+                showMessage(console, buildSuccessfulMessage(response));
+            }).error(function(response) {
+                showMessage(console, buildErrorMessage(response));
+            });
+            e.preventDefault();
+        });
+    });
+</script>

--- a/src/Template/Element/packages_panel.ctp
+++ b/src/Template/Element/packages_panel.ctp
@@ -26,7 +26,7 @@
         <button class="btn-primary">Check for Updates</button>
         <label><input type="checkbox" class="direct-dependency"><?= __d('debug_kit', 'Direct dependencies only') ?></label>
     </div>
-    <div class="console"></div>
+    <div class="terminal"></div>
     <?php if (!empty($packages)): ?>
         <section class="section-tile">
             <h3><?= __d('debug_kit', 'Requirements ({0})', count($packages)) ?> </h3>
@@ -89,7 +89,7 @@
             'action' => 'checkDependencies'
         ]); ?>';
 
-        var console = $('.console');
+        var terminal = $('.terminal');
 
         function showMessage(el, html) {
             el.show().html(html);
@@ -105,11 +105,11 @@
                 return '<pre class="success-message">All dependencies are up to date</pre>';
             }
             if (response.packages.bcBreaks !== undefined) {
-                html += '<h4>Update with potential BC break</h4>';
+                html += '<h4 class="section-header">Update with potential BC break</h4>';
                 html += '<pre>' + response.packages.bcBreaks + '</pre>';
             }
             if (response.packages.semverCompatible !== undefined) {
-                html += '<h4>Update semver compatible</h4>';
+                html += '<h4 class="section-header">Update semver compatible</h4>';
                 html += '<pre>' + response.packages.semverCompatible + '</pre>';
             }
             return html;
@@ -120,7 +120,7 @@
         }
 
         $('.check-update button').on('click', function(e) {
-            showMessage(console, buildLoader());
+            showMessage(terminal, buildLoader());
             var direct = $('.direct-dependency')[0].checked;
             var xhr = $.ajax({
                 url: baseUrl,
@@ -129,9 +129,9 @@
                 type: 'POST'
             });
             xhr.done(function(response) {
-                showMessage(console, buildSuccessfulMessage(response));
+                showMessage(terminal, buildSuccessfulMessage(response));
             }).error(function(response) {
-                showMessage(console, buildErrorMessage(response));
+                showMessage(terminal, buildErrorMessage(response));
             });
             e.preventDefault();
         });

--- a/webroot/css/toolbar.css
+++ b/webroot/css/toolbar.css
@@ -543,7 +543,7 @@ pre,
     cursor: pointer;
 }
 
-.console {
+.terminal {
 	margin: 20px 0;
 	padding: 20px;
 	background-color: #1a1a1a;
@@ -552,23 +552,23 @@ pre,
 	display: none;
 }
 
-.console h4 {
+.terminal .section-header {
 	color: #428bca;
 }
 
-.console h4:first-of-type {
+.terminal .section-header:nth-of-type(1) {
 	margin-top: 0;
 }
 
-.console highlight {
+.terminal highlight {
 	color: #D33C44;
 }
 
-.console .loading {
+.terminal .loading {
 	margin: 0;
 }
 
-.console .indicator {
+.terminal .indicator {
 	vertical-align: middle;
 	width: 30px;
 	height: 30px;
@@ -577,10 +577,10 @@ pre,
 	animation: spin 4s linear infinite;
 }
 
-.console .warning-message {
+.terminal .warning-message {
 	color: #ffcc00;
 }
 
-.console .success-message {
+.terminal .success-message {
 	color: #42bd41;
 }

--- a/webroot/css/toolbar.css
+++ b/webroot/css/toolbar.css
@@ -409,16 +409,16 @@ pre,
  * Packages panel
  */
 .package-version {
-    background: #D33C44;
-    border-radius: 4px;
-    line-height: 20px;
-    display: inline-block;
-    white-space: nowrap;
+	background: #D33C44;
+	border-radius: 4px;
+	line-height: 20px;
+	display: inline-block;
+	white-space: nowrap;
 }
 
 .package-link {
-    color: #000000;
-    text-decoration: none;
+	color: #000000;
+	text-decoration: none;
 }
 
 /**
@@ -540,5 +540,47 @@ pre,
 
 .panel-content .filtered-credentials {
     text-decoration: underline;
-    cursor:pointer;
+    cursor: pointer;
+}
+
+.console {
+	margin: 20px 0;
+	padding: 20px;
+	background-color: #1a1a1a;
+	color: #ffffff;
+	line-height: 1.4;
+	display: none;
+}
+
+.console h4 {
+	color: #428bca;
+}
+
+.console h4:first-of-type {
+	margin-top: 0;
+}
+
+.console highlight {
+	color: #D33C44;
+}
+
+.console .loading {
+	margin: 0;
+}
+
+.console .indicator {
+	vertical-align: middle;
+	width: 30px;
+	height: 30px;
+	-webkit-animation: spin 4s linear infinite;
+	-moz-animation: spin 4s linear infinite;
+	animation: spin 4s linear infinite;
+}
+
+.console .warning-message {
+	color: #ffcc00;
+}
+
+.console .success-message {
+	color: #42bd41;
 }


### PR DESCRIPTION
You can check fot all outdated dependencies or choose to select only direct dependencies.

This is not ready to be merged, I'll try to find time to add tests but wanted to get feedback already.
There are places where I should add translation also if possible.

The gif screen capture is way slower than the actual behavior as it's recorded online.
![zsfkhkzhzn](https://cloud.githubusercontent.com/assets/4977112/22361616/d900d79e-e45b-11e6-9fa2-5eb61ca22f52.gif)


