### PR TITLE
Ignore log files genearated by tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.diff
 *.err
+*.log
 *.orig
 *.rej
 *.swo


### PR DESCRIPTION
Files are created in the root directory of the project when running tests outside of an app. So easy to accidentally add them to the project.