### PR TITLE
Increase length of URL column to TEXT.

### DIFF
--- a/tests/Fixture/RequestsFixture.php
+++ b/tests/Fixture/RequestsFixture.php
@@ -37,7 +37,7 @@ class RequestsFixture extends TestFixture
      */
     public $fields = [
         'id' => ['type' => 'uuid', 'null' => false],
-        'url' => ['type' => 'string', 'null' => false],
+        'url' => ['type' => 'text', 'null' => false],
         'content_type' => ['type' => 'string'],
         'status_code' => ['type' => 'integer'],
         'method' => ['type' => 'string'],


### PR DESCRIPTION
URLs can be much larger than 255 characters.

Refs #520