### PR TITLE
Ignore schema reflection queries by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ There are several built-in panels, they are:
 // Before loading DebugKit
 Configure::write('DebugKit.panels', ['DebugKit.Packages' => false]);
 ```
+* `DebugKit.includeSchemaReflection` - Set to true to enable logging of schema
+  reflection queries. Disabled by default.
 
 ## Developing Your Own Panels
 

--- a/src/Database/Log/DebugLog.php
+++ b/src/Database/Log/DebugLog.php
@@ -63,15 +63,25 @@ class DebugLog extends QueryLogger
     protected $_totalRows = 0;
 
     /**
+     * Set to true to capture schema reflection queries
+     * in the SQL log panel.
+     *
+     * @var bool
+     */
+    protected $_includeSchema = false;
+
+    /**
      * Constructor
      *
      * @param \Cake\Database\Log\QueryLogger $logger The logger to decorate and spy on.
      * @param string $name The name of the connection being logged.
+     * @param bool $includeSchema Whether or not schema reflection should be included.
      */
-    public function __construct($logger, $name)
+    public function __construct($logger, $name, $includeSchema = false)
     {
         $this->_logger = $logger;
         $this->_connectionName = $name;
+        $this->_includeSchema = $includeSchema;
     }
 
     /**
@@ -129,6 +139,11 @@ class DebugLog extends QueryLogger
                 $this->_logger->log($query);
             }
         }
+
+        if ($this->_includeSchema === false && $this->isSchemaQuery($query)) {
+            return;
+        }
+
         if (!empty($query->params)) {
             $query->query = $this->_interpolate($query);
         }
@@ -140,5 +155,32 @@ class DebugLog extends QueryLogger
             'took' => $query->took,
             'rows' => $query->numRows
         ];
+    }
+
+    /**
+     * Sniff SQL statements for things only found in schema reflection.
+     *
+     * @param \Cake\Database\Log\LoggedQuery $query The query to check.
+     * @return bool
+     */
+    protected function isSchemaQuery(LoggedQuery $query)
+    {
+        $querystring = $query->query;
+        return (
+            // Multiple engines
+            strpos($querystring, 'FROM information_schema') !== false ||
+            // Postgres
+            strpos($querystring, 'FROM pg_catalog') !== false ||
+            // MySQL
+            strpos($querystring, 'SHOW TABLE') ===  0 ||
+            strpos($querystring, 'SHOW FULL COLUMNS') === 0 ||
+            strpos($querystring, 'SHOW INDEXES') === 0 ||
+            // Sqlite
+            strpos($querystring, 'FROM sqlite_master') !== false ||
+            strpos($querystring, 'PRAGMA') === 0 ||
+            // Sqlserver
+            strpos($querystring, 'FROM INFORMATION_SCHEMA') !== false ||
+            strpos($querystring, 'FROM sys.') !== false
+        );
     }
 }

--- a/src/Database/Log/DebugLog.php
+++ b/src/Database/Log/DebugLog.php
@@ -166,13 +166,14 @@ class DebugLog extends QueryLogger
     protected function isSchemaQuery(LoggedQuery $query)
     {
         $querystring = $query->query;
+
         return (
             // Multiple engines
             strpos($querystring, 'FROM information_schema') !== false ||
             // Postgres
             strpos($querystring, 'FROM pg_catalog') !== false ||
             // MySQL
-            strpos($querystring, 'SHOW TABLE') ===  0 ||
+            strpos($querystring, 'SHOW TABLE') === 0 ||
             strpos($querystring, 'SHOW FULL COLUMNS') === 0 ||
             strpos($querystring, 'SHOW INDEXES') === 0 ||
             // Sqlite

--- a/src/Panel/SqlLogPanel.php
+++ b/src/Panel/SqlLogPanel.php
@@ -12,6 +12,7 @@
  */
 namespace DebugKit\Panel;
 
+use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
@@ -43,6 +44,8 @@ class SqlLogPanel extends DebugPanel
     public function initialize()
     {
         $configs = ConnectionManager::configured();
+        $includeSchemaReflection = (bool)Configure::read('DebugKit.includeSchemaReflection');
+
         foreach ($configs as $name) {
             $connection = ConnectionManager::get($name);
             if ($connection->configName() === 'debug_kit') {
@@ -57,7 +60,7 @@ class SqlLogPanel extends DebugPanel
                 $this->_loggers[] = $logger;
                 continue;
             }
-            $logger = new DebugLog($logger, $name);
+            $logger = new DebugLog($logger, $name, $includeSchemaReflection);
 
             $connection->logQueries(true);
             $connection->logger($logger);

--- a/tests/TestCase/Panel/SqlLogPanelTest.php
+++ b/tests/TestCase/Panel/SqlLogPanelTest.php
@@ -12,6 +12,7 @@
  */
 namespace DebugKit\Test\TestCase\Panel;
 
+use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
 use Cake\Event\Event;
 use Cake\ORM\Table;
@@ -75,6 +76,21 @@ class SqlLogPanelTest extends TestCase
         $this->panel->initialize();
         $second = $db->logger();
         $this->assertSame($second, $logger);
+    }
+
+    /**
+     * Ensure that subrequests don't double proxy the logger.
+     *
+     * @return void
+     */
+    public function testInitializePassesIncludeSchema()
+    {
+        Configure::write('DebugKit.includeSchemaReflection', true);
+        $this->panel->initialize();
+        $db = ConnectionManager::get('test');
+        $logger = $db->logger();
+        $this->assertInstanceOf('DebugKit\Database\Log\DebugLog', $logger);
+        $this->assertAttributeEquals(true, '_includeSchema', $logger);
     }
 
     /**


### PR DESCRIPTION
Disable capturing schema queries by default. This feature can be turned off by setting `DebugKit.includeSchemaReflection` to true.

Refs #539