### PR TITLE
Fix missing tracking id for history panel.

### DIFF
--- a/src/ToolbarService.php
+++ b/src/ToolbarService.php
@@ -216,6 +216,7 @@ class ToolbarService
      */
     public function injectScripts($row, ResponseInterface $response)
     {
+        $response = $response->withHeader('X-DEBUGKIT-ID', $row->id);
         if (strpos($response->getHeaderLine('Content-Type'), 'html') === false) {
             return $response;
         }
@@ -242,8 +243,6 @@ class ToolbarService
         $body->rewind();
         $body->write($contents);
 
-        return $response
-            ->withHeader('X-DEBUGKIT-ID', $row->id)
-            ->withBody($body);
+        return $response->withBody($body);
     }
 }

--- a/tests/TestCase/ToolbarServiceTest.php
+++ b/tests/TestCase/ToolbarServiceTest.php
@@ -220,6 +220,7 @@ class ToolbarServiceTest extends TestCase
             'data-url="http://localhost/" src="/debug_kit/js/toolbar.js"></script>' .
             '</body>';
         $this->assertTextEquals($expected, $response->body());
+        $this->assertTrue($response->hasHeader('X-DEBUGKIT-ID'), 'Should have a tracking id');
     }
 
     /**
@@ -245,6 +246,7 @@ class ToolbarServiceTest extends TestCase
         $result = $bar->injectScripts($row, $response);
         $this->assertInstanceOf('Cake\Network\Response', $result);
         $this->assertSame(file_get_contents(__FILE__), '' . $result->getBody());
+        $this->assertTrue($result->hasHeader('X-DEBUGKIT-ID'), 'Should have a tracking id');
     }
 
     /**
@@ -299,6 +301,7 @@ class ToolbarServiceTest extends TestCase
         $row = $bar->saveData($request, $response);
         $response = $bar->injectScripts($row, $response);
         $this->assertTextEquals('{"some":"json"}', $response->body());
+        $this->assertTrue($response->hasHeader('X-DEBUGKIT-ID'), 'Should have a tracking id');
     }
 
     /**


### PR DESCRIPTION
Add X-DEBUGKIT-ID that was lost during the refactor to the `ToolbarService`. This header was accidentally dropped in the refactor as there were no tests ensuring it stuck around.

Refs #513