### PR TITLE
Hide debug-kit noise routes.

### DIFF
--- a/src/Template/Element/routes_panel.ctp
+++ b/src/Template/Element/routes_panel.ctp
@@ -15,6 +15,9 @@ $routes = Cake\Routing\Router::routes();
     </thead>
     <tbody>
     <?php foreach ($routes as $route): ?>
+        <?php if (strpos($route->getName(), 'debugkit.') === 0) {
+            continue;
+        }?>
         <tr class="<?= ($matchedRoute === $route->template) ? 'highlighted' : '' ?>">
             <td><?= h(\Cake\Utility\Hash::get($route->options, '_name', $route->getName())) ?></td>
             <td class="left"><?= h($route->template) ?></td>


### PR DESCRIPTION
Resolves https://github.com/cakephp/debug_kit/issues/551