### PR TITLE
Let variables panel test serialization and handle debug info exceptions.

### DIFF
--- a/src/Panel/VariablesPanel.php
+++ b/src/Panel/VariablesPanel.php
@@ -62,6 +62,32 @@ class VariablesPanel extends DebugPanel
     }
 
     /**
+     * Safely retrieves debug information from an object
+     * and applies a callback.
+     *
+     * @param callable $walker The walker to apply on the debug info array.
+     * @param object $item The item whose debug info to retrieve.
+     *
+     * @return array|string
+     */
+    protected function _walkDebugInfo(callable $walker, $item)
+    {
+        try {
+            $info = $item->__debugInfo();
+        } catch (\Exception $exception) {
+            return sprintf(
+                'Could not retrieve debug info - %s. Error: %s in %s, line %s',
+                get_class($item),
+                $exception->getMessage(),
+                $exception->getFile(),
+                $exception->getLine()
+            );
+        }
+
+        return array_map($walker, $info);
+    }
+
+    /**
      * Shutdown event
      *
      * @param \Cake\Event\Event $event The event
@@ -81,12 +107,12 @@ class VariablesPanel extends DebugPanel
                     $item = $item->toArray();
                 } catch (\Cake\Database\Exception $e) {
                     //Likely issue is unbuffered query; fall back to __debugInfo
-                    $item = array_map($walker, $item->__debugInfo());
+                    $item = $this->_walkDebugInfo($walker, $item);
                 } catch (RuntimeException $e) {
                     // Likely a non-select query.
-                    $item = array_map($walker, $item->__debugInfo());
+                    $item = $this->_walkDebugInfo($walker, $item);
                 } catch (InvalidArgumentException $e) {
-                    $item = array_map($walker, $item->__debugInfo());
+                    $item = $this->_walkDebugInfo($walker, $item);
                 }
             } elseif ($item instanceof Closure ||
                 $item instanceof PDO ||
@@ -103,7 +129,23 @@ class VariablesPanel extends DebugPanel
                 );
             } elseif (is_object($item) && method_exists($item, '__debugInfo')) {
                 // Convert objects into using __debugInfo.
-                $item = array_map($walker, $item->__debugInfo());
+                $item = $this->_walkDebugInfo($walker, $item);
+            }
+
+            if (is_object($item) ||
+                is_resource($item)
+            ) {
+                try {
+                    serialize($item);
+                } catch (\Exception $e) {
+                    $item = sprintf(
+                        'Unserializable object - %s. Error: %s in %s, line %s',
+                        get_class($item),
+                        $e->getMessage(),
+                        $e->getFile(),
+                        $e->getLine()
+                    );
+                }
             }
 
             return $item;

--- a/src/Panel/VariablesPanel.php
+++ b/src/Panel/VariablesPanel.php
@@ -127,25 +127,25 @@ class VariablesPanel extends DebugPanel
                     $item->getFile(),
                     $item->getLine()
                 );
-            } elseif (is_object($item) && method_exists($item, '__debugInfo')) {
-                // Convert objects into using __debugInfo.
-                $item = $this->_walkDebugInfo($walker, $item);
-            }
-
-            if (is_object($item) ||
-                is_resource($item)
-            ) {
-                try {
-                    serialize($item);
-                } catch (\Exception $e) {
-                    $item = sprintf(
-                        'Unserializable object - %s. Error: %s in %s, line %s',
-                        get_class($item),
-                        $e->getMessage(),
-                        $e->getFile(),
-                        $e->getLine()
-                    );
+            } elseif (is_object($item)) {
+                if (method_exists($item, '__debugInfo')) {
+                    // Convert objects into using __debugInfo.
+                    $item = $this->_walkDebugInfo($walker, $item);
+                } else {
+                    try {
+                        serialize($item);
+                    } catch (\Exception $e) {
+                        $item = sprintf(
+                            'Unserializable object - %s. Error: %s in %s, line %s',
+                            get_class($item),
+                            $e->getMessage(),
+                            $e->getFile(),
+                            $e->getLine()
+                        );
+                    }
                 }
+            } elseif (is_resource($item)) {
+                $item = sprintf('[%s] %s', get_resource_type($item), $item);
             }
 
             return $item;

--- a/tests/TestCase/Panel/VariablesPanelTest.php
+++ b/tests/TestCase/Panel/VariablesPanelTest.php
@@ -78,8 +78,11 @@ class VariablesPanelTest extends TestCase
             'unserializable' => $unserializable
         ]);
 
+        $resource = fopen('data:text/plain;base64,', 'r');
+
         $controller = new \stdClass();
         $controller->viewVars = [
+            'resource' => $resource,
             'unserializableDebugInfo' => $unserializableDebugInfo,
             'debugInfoException' => $debugInfoException,
             'updateQuery' => $update,
@@ -93,6 +96,7 @@ class VariablesPanelTest extends TestCase
         $this->panel->shutdown($event);
         $output = $this->panel->data();
 
+        $this->assertRegExp('/^\[stream\] Resource id #\d+$/', $output['content']['resource']);
         $this->assertInternalType('array', $output['content']['unserializableDebugInfo']);
         $this->assertStringStartsWith(
             'Unserializable object - stdClass. Error: You cannot serialize or unserialize PDO instances',


### PR DESCRIPTION
I stumbled over a weird problem, that is, a JSON request in which an exception occurrs would somehow respond with an HTML error page instead of serialized JSON data, but only for some specific type of exception, in this case for an `InvalidArgumentException` caused by a non-existing association ("x is not associated with y").

The problem was that the variables panel invokes `__debugInfo()` on the the erroneous query, where the same exception would be triggered again as a result of `Query::sql()` being invoked, which then in turn caused the already rendered but not yet sent JSON response to be "overwritten" with the same error but this time in HTML format.

This patch furthermore applies some serialization testing that is currently also done on all data in `ToolbarService::saveData()`. This allows to present at least a partial variable tree, instead of swallowing everything. This may not be an ideal solution, and maybe it would be better to implement something similar for use in `ToolbarService::saveData()` instead, not quite sure about that?