### PR TITLE
adds a timestamp to toolbar.js and updates test

### DIFF
--- a/src/ToolbarService.php
+++ b/src/ToolbarService.php
@@ -218,12 +218,13 @@ class ToolbarService
             str_replace('/', DIRECTORY_SEPARATOR, WWW_ROOT . 'debug_kit/' . $url),
             str_replace('/', DIRECTORY_SEPARATOR, Plugin::path('DebugKit') . 'webroot/' . $url)
         ];
-        $url = '/debug_kit/'.$url;
-        foreach($filePaths as $filePath) {
+        $url = '/debug_kit/' . $url;
+        foreach ($filePaths as $filePath) {
             if (file_exists($filePath)) {
                 return $url . '?' . filemtime($filePath);
             }
         }
+
         return $url;
     }
 

--- a/src/ToolbarService.php
+++ b/src/ToolbarService.php
@@ -13,6 +13,7 @@ namespace DebugKit;
 
 use Cake\Core\Configure;
 use Cake\Core\InstanceConfigTrait;
+use Cake\Core\Plugin;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
 use Cake\Http\Response;
@@ -206,6 +207,27 @@ class ToolbarService
     }
 
     /**
+     * Reads the modified date of a file in the webroot, and returns the integer
+     *
+     * @return string
+     */
+    public function getToolbarUrl()
+    {
+        $url = 'js/toolbar.js';
+        $filePaths = [
+            str_replace('/', DIRECTORY_SEPARATOR, WWW_ROOT . 'debug_kit/' . $url),
+            str_replace('/', DIRECTORY_SEPARATOR, Plugin::path('DebugKit') . 'webroot/' . $url)
+        ];
+        $url = '/debug_kit/'.$url;
+        foreach($filePaths as $filePath) {
+            if (file_exists($filePath)) {
+                return $url . '?' . filemtime($filePath);
+            }
+        }
+        return $url;
+    }
+
+    /**
      * Injects the JS to build the toolbar.
      *
      * The toolbar will only be injected if the response's content type
@@ -238,7 +260,7 @@ class ToolbarService
             '<script id="__debug_kit" data-id="%s" data-url="%s" src="%s"></script>',
             $row->id,
             $url,
-            Router::url('/debug_kit/js/toolbar.js')
+            Router::url($this->getToolbarUrl())
         );
         $contents = substr($contents, 0, $pos) . $script . substr($contents, $pos);
         $body->rewind();

--- a/tests/TestCase/Middleware/DebugKitMiddlewareTest.php
+++ b/tests/TestCase/Middleware/DebugKitMiddlewareTest.php
@@ -13,6 +13,7 @@
 namespace DebugKit\Test\Middleware;
 
 use Cake\Core\Configure;
+use Cake\Core\Plugin;
 use Cake\Database\Driver\Sqlite;
 use Cake\Datasource\ConnectionManager;
 use Cake\Http\CallbackStream;
@@ -94,9 +95,11 @@ class DebugKitMiddlewareTest extends TestCase
         $this->assertNotNull($result->panels[10]->summary);
         $this->assertEquals('Sql Log', $result->panels[10]->title);
 
+        $timeStamp = filemtime(Plugin::path('DebugKit') . 'webroot' . DS . 'js' . DS . 'toolbar.js');
+
         $expected = '<html><title>test</title><body><p>some text</p>' .
             '<script id="__debug_kit" data-id="' . $result->id . '" ' .
-            'data-url="http://localhost/" src="/debug_kit/js/toolbar.js"></script>' .
+            'data-url="http://localhost/" src="/debug_kit/js/toolbar.js?' . $timeStamp . '"></script>' .
             '</body>';
         $body = $response->getBody();
         $this->assertTextEquals($expected, '' . $body);

--- a/tests/TestCase/Routing/Filter/DebugBarFilterTest.php
+++ b/tests/TestCase/Routing/Filter/DebugBarFilterTest.php
@@ -13,6 +13,7 @@
 namespace DebugKit\Test\Routing\Filter;
 
 use Cake\Core\Configure;
+use Cake\Core\Plugin;
 use Cake\Database\Driver\Sqlite;
 use Cake\Datasource\ConnectionManager;
 use Cake\Event\Event;
@@ -184,9 +185,11 @@ class DebugBarFilterTest extends TestCase
         $this->assertSame('0', $result->panels[10]->summary);
         $this->assertEquals('Sql Log', $result->panels[10]->title);
 
+        $timeStamp = filemtime(Plugin::path('DebugKit') . 'webroot' . DS . 'js' . DS . 'toolbar.js');
+
         $expected = '<html><title>test</title><body><p>some text</p>' .
             '<script id="__debug_kit" data-id="' . $result->id . '" ' .
-            'data-url="http://localhost/" src="/debug_kit/js/toolbar.js"></script>' .
+            'data-url="http://localhost/" src="/debug_kit/js/toolbar.js?' . $timeStamp . '"></script>' .
             '</body>';
         $this->assertTextEquals($expected, $response->body());
     }

--- a/tests/TestCase/ToolbarServiceTest.php
+++ b/tests/TestCase/ToolbarServiceTest.php
@@ -13,6 +13,7 @@
 namespace DebugKit\Test;
 
 use Cake\Core\Configure;
+use Cake\Core\Plugin;
 use Cake\Database\Driver\Sqlite;
 use Cake\Datasource\ConnectionManager;
 use Cake\Event\EventManager;
@@ -236,9 +237,11 @@ class ToolbarServiceTest extends TestCase
         $row = $bar->saveData($request, $response);
         $response = $bar->injectScripts($row, $response);
 
+        $timeStamp = filemtime(Plugin::path('DebugKit') . 'webroot' . DS . 'js' . DS . 'toolbar.js');
+
         $expected = '<html><title>test</title><body><p>some text</p>' .
             '<script id="__debug_kit" data-id="' . $row->id . '" ' .
-            'data-url="http://localhost/" src="/debug_kit/js/toolbar.js"></script>' .
+            'data-url="http://localhost/" src="/debug_kit/js/toolbar.js?' . $timeStamp . '"></script>' .
             '</body>';
         $this->assertTextEquals($expected, $response->body());
         $this->assertTrue($response->hasHeader('X-DEBUGKIT-ID'), 'Should have a tracking id');


### PR DESCRIPTION
Closes #570 

This PR adds a timestamp to the `toolbar.js` file which resolves caching issues in the browser.

I've tried to handle the edge case were the developer has copied the files locally to their webroot. What I don't do is verify if the two files are the same. I think that's a completely different issue.
