### PR TITLE
adds a trait that injects a file name comment into SQL queries

### DIFF
--- a/src/DebugSqlTemp.php
+++ b/src/DebugSqlTemp.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         DebugKit 3.11.4
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace DebugKit;
+
+use Cake\Core\Configure;
+use Cake\Error\Debugger;
+
+/**
+ * Contains methods for debugging SQL queries.
+ */
+class DebugSqlTemp
+{
+    /**
+     * Applies a comment to a query about which file created it.
+     *
+     * @param \Cake\ORM\Query $query The Query to insert a comment into.
+     * @param int $start How many entries in the stack trace to skip.
+     * @param bool $debugOnly False to always stamp queries with a comment.
+     * @return \Cake\ORM\Query
+     */
+    public static function fileStamp($query, $start = 1, $debugOnly = true)
+    {
+        if (!Configure::read('debug') && $debugOnly === true) {
+            return $query;
+        }
+
+        $traces = Debugger::trace(['start' => $start, 'format' => 'array']);
+        $file = '[unknown]';
+        $line = '??';
+
+        foreach ($traces as $trace) {
+            $path = $trace['file'];
+            $line = $trace['line'];
+            $file = Debugger::trimPath($path);
+            if ($path === '[internal]') {
+                continue;
+            }
+            if (defined('CAKE_CORE_INCLUDE_PATH') && strpos($path, CAKE_CORE_INCLUDE_PATH) !== 0) {
+                break;
+            }
+        }
+
+        return $query->modifier(sprintf('/* %s (line %s) */', $file, $line));
+    }
+}

--- a/src/DebugSqlTemp.php
+++ b/src/DebugSqlTemp.php
@@ -51,13 +51,6 @@ class DebugSqlTemp
             }
         }
 
-        $comment = sprintf('/* %s (line %s) */', $file, $line);
-
-        $sqlFileNamePlacement = (string)Configure::read('DebugKit.sqlFileNamePlacement', 'modifier');
-        if ($sqlFileNamePlacement === 'epilog' && $query->clause('epilog') === null) {
-            return $query->epilog($query->newExpr($comment));
-        }
-
-        return $query->modifier($comment);
+        return $query->modifier(sprintf('/* %s (line %s) */', $file, $line));
     }
 }

--- a/src/DebugSqlTemp.php
+++ b/src/DebugSqlTemp.php
@@ -51,6 +51,13 @@ class DebugSqlTemp
             }
         }
 
-        return $query->modifier(sprintf('/* %s (line %s) */', $file, $line));
+        $comment = sprintf('/* %s (line %s) */', $file, $line);
+
+        $sqlFileNamePlacement = (string)Configure::read('DebugKit.sqlFileNamePlacement', 'modifier');
+        if ($sqlFileNamePlacement === 'epilog' && $query->clause('epilog') === null) {
+            return $query->epilog($query->newExpr($comment));
+        }
+
+        return $query->modifier($comment);
     }
 }

--- a/src/Model/Table/PanelsTable.php
+++ b/src/Model/Table/PanelsTable.php
@@ -32,6 +32,7 @@ class PanelsTable extends Table
 {
 
     use LazyTableTrait;
+    use SqlTraceTrait;
 
     /**
      * initialize method

--- a/src/Model/Table/RequestsTable.php
+++ b/src/Model/Table/RequestsTable.php
@@ -32,6 +32,7 @@ class RequestsTable extends Table
 {
 
     use LazyTableTrait;
+    use SqlTraceTrait;
 
     /**
      * initialize method

--- a/src/Model/Table/SqlTraceTrait.php
+++ b/src/Model/Table/SqlTraceTrait.php
@@ -8,6 +8,7 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.11.5
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace DebugKit\Model\Table;

--- a/src/Model/Table/SqlTraceTrait.php
+++ b/src/Model/Table/SqlTraceTrait.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace DebugKit\Model\Table;
+
+use Cake\Core\Configure;
+use Cake\Error\Debugger;
+use Cake\ORM\Query;
+
+/**
+ * This trait modifies a Table class to inject metadata into a Query object that can be used to provide a call track
+ * in the SQL log panel.
+ *
+ * @mixin \Cake\ORM\Table
+ */
+trait SqlTraceTrait
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function query()
+    {
+        /** @var Query $query */
+        $query = parent::query();
+        if (!Configure::read('debug')) {
+            return $query;
+        }
+
+        $traces = Debugger::trace(['start' => 2, 'depth' => 3, 'format' => 'array']);
+        $file = null;
+        $line = null;
+
+        foreach ($traces as $trace) {
+            $fullPath = $trace['file'];
+            $file = Debugger::trimPath($trace['file']);
+            $line = $trace['line'];
+            if (defined('CAKE_CORE_INCLUDE_PATH') && strpos($fullPath, CAKE_CORE_INCLUDE_PATH) !== 0) {
+                break;
+            }
+        }
+
+        $comment = sprintf('/* %s (line %s) */', $file, $line);
+        $query->epilog($query->newExpr($comment));
+
+        return $query;
+    }
+}

--- a/src/Model/Table/SqlTraceTrait.php
+++ b/src/Model/Table/SqlTraceTrait.php
@@ -13,8 +13,7 @@
  */
 namespace DebugKit\Model\Table;
 
-use Cake\Core\Configure;
-use Cake\Error\Debugger;
+use DebugKit\DebugSqlTemp;
 
 /**
  * Add this trait to your Table class to append the file reference of where a Query object was created.
@@ -30,25 +29,6 @@ trait SqlTraceTrait
      */
     public function query()
     {
-        $query = parent::query();
-
-        if (!Configure::read('debug') || $query->clause('epilog') !== null) {
-            return $query;
-        }
-
-        $traces = Debugger::trace(['start' => 2, 'depth' => 3, 'format' => 'array']);
-        $file = 'n/a';
-        $line = 0;
-
-        foreach ($traces as $trace) {
-            $path = $trace['file'];
-            $line = $trace['line'];
-            $file = Debugger::trimPath($path);
-            if (defined('CAKE_CORE_INCLUDE_PATH') && strpos($path, CAKE_CORE_INCLUDE_PATH) !== 0) {
-                break;
-            }
-        }
-
-        return $query->epilog($query->newExpr(sprintf('/* %s (line %s) */', $file, $line)));
+        return DebugSqlTemp::fileStamp(parent::query(), 2);
     }
 }

--- a/src/Model/Table/SqlTraceTrait.php
+++ b/src/Model/Table/SqlTraceTrait.php
@@ -30,26 +30,24 @@ trait SqlTraceTrait
     public function query()
     {
         $query = parent::query();
-        if (!Configure::read('debug')) {
+
+        if (!Configure::read('debug') || $query->clause('epilog') !== null) {
             return $query;
         }
 
         $traces = Debugger::trace(['start' => 2, 'depth' => 3, 'format' => 'array']);
-        $file = null;
-        $line = null;
+        $file = 'n/a';
+        $line = 0;
 
         foreach ($traces as $trace) {
-            $fullPath = $trace['file'];
-            $file = Debugger::trimPath($trace['file']);
+            $path = $trace['file'];
             $line = $trace['line'];
-            if (defined('CAKE_CORE_INCLUDE_PATH') && strpos($fullPath, CAKE_CORE_INCLUDE_PATH) !== 0) {
+            $file = Debugger::trimPath($path);
+            if (defined('CAKE_CORE_INCLUDE_PATH') && strpos($path, CAKE_CORE_INCLUDE_PATH) !== 0) {
                 break;
             }
         }
 
-        $comment = sprintf('/* %s (line %s) */', $file, $line);
-        $query->epilog($query->newExpr($comment));
-
-        return $query;
+        return $query->epilog($query->newExpr(sprintf('/* %s (line %s) */', $file, $line)));
     }
 }

--- a/src/Model/Table/SqlTraceTrait.php
+++ b/src/Model/Table/SqlTraceTrait.php
@@ -14,11 +14,9 @@ namespace DebugKit\Model\Table;
 
 use Cake\Core\Configure;
 use Cake\Error\Debugger;
-use Cake\ORM\Query;
 
 /**
- * This trait modifies a Table class to inject metadata into a Query object that can be used to provide a call track
- * in the SQL log panel.
+ * Add this trait to your Table class to append the file reference of where a Query object was created.
  *
  * @mixin \Cake\ORM\Table
  */
@@ -29,7 +27,6 @@ trait SqlTraceTrait
      */
     public function query()
     {
-        /** @var Query $query */
         $query = parent::query();
         if (!Configure::read('debug')) {
             return $query;

--- a/src/Model/Table/SqlTraceTrait.php
+++ b/src/Model/Table/SqlTraceTrait.php
@@ -23,7 +23,9 @@ use Cake\Error\Debugger;
 trait SqlTraceTrait
 {
     /**
-     * {@inheritDoc}
+     * Creates a new Query instance for this repository
+     *
+     * @return \Cake\ORM\Query
      */
     public function query()
     {

--- a/tests/TestCase/DebugSqlTempTest.php
+++ b/tests/TestCase/DebugSqlTempTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace DebugKit\Test\TestCase;
+
+use Cake\Core\Configure;
+use Cake\Datasource\ConnectionManager;
+use Cake\ORM\Query;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use DebugKit\DebugSqlTemp;
+
+/**
+ * Test the debugging SQL
+ */
+class DebugSqlTestTemp extends TestCase
+{
+    /**
+     * @var \Cake\Database\Connection
+     */
+    public $connection;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.debug_kit.panels'
+    ];
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->connection = ConnectionManager::get('test');
+    }
+
+    /**
+     * Test that a file name is found when a closure is used.
+     */
+    public function testFileStampClosure()
+    {
+        $query = $this->newQuery()->select(['id']);
+        $func = function ($query) {
+            $this->assertSame($query, DebugSqlTemp::fileStamp($query));
+            return $query;
+        };
+        $query = $func($query);
+        // missing backslash on ROOT is an issue with test bootstrap, and not a bug
+        $comment = sprintf('/* ROOTtests\TestCase\DebugSqlTempTest.php (line %d) */', __LINE__ - 5);
+        $sql = (string)$query;
+        $this->assertTrue(strpos($sql, $comment) !== false, 'Expected: ' . $comment . ' Found: ' . $sql);
+
+    }
+
+    /**
+     * No comment should be set when debug is off.
+     * @skip
+     */
+    public function testFileStampDebugOff()
+    {
+        $query = $this->newQuery()->select(['id']);
+        $debug = Configure::read('debug');
+        Configure::write('debug', false);
+        $sql = (string)$query;
+        $this->assertSame($query, DebugSqlTemp::fileStamp($query, 1, true));
+        $this->assertEquals($sql, (string)$query);
+        Configure::write('debug', $debug);
+    }
+
+    /**
+     * Verify file name is correct when the table object calls the query() method on itself.
+     */
+    public function testFileStampFileName()
+    {
+        $query = $this->newQuery()->select(['id']);
+        $this->assertSame($query, DebugSqlTemp::fileStamp($query));
+        // missing backslash on ROOT is an issue with test bootstrap, and not a bug
+        $comment = sprintf('/* ROOTtests\TestCase\DebugSqlTempTest.php (line %d) */', __LINE__ - 2);
+        $sql = (string)$query;
+        $this->assertTrue(strpos($sql, $comment) !== false, 'Expected: ' . $comment . ' Found: ' . $sql);
+    }
+
+    /**
+     * Creates a Query object for testing.
+     *
+     * @return Query
+     */
+    private function newQuery()
+    {
+        return new Query($this->connection, TableRegistry::get('panels'));
+    }
+}

--- a/tests/TestCase/DebugSqlTempTest.php
+++ b/tests/TestCase/DebugSqlTempTest.php
@@ -56,14 +56,14 @@ class DebugSqlTestTemp extends TestCase
         $query = $this->newQuery()->select(['id']);
         $func = function ($query) {
             $this->assertSame($query, DebugSqlTemp::fileStamp($query));
+
             return $query;
         };
         $query = $func($query);
         // missing backslash on ROOT is an issue with test bootstrap, and not a bug
-        $comment = sprintf('/* ROOTtests\TestCase\DebugSqlTempTest.php (line %d) */', __LINE__ - 5);
+        $comment = sprintf('/* ROOTtests\TestCase\DebugSqlTempTest.php (line %d) */', __LINE__ - 6);
         $sql = (string)$query;
         $this->assertTrue(strpos($sql, $comment) !== false, 'Expected: ' . $comment . ' Found: ' . $sql);
-
     }
 
     /**

--- a/tests/TestCase/DebugSqlTempTest.php
+++ b/tests/TestCase/DebugSqlTempTest.php
@@ -60,7 +60,7 @@ class DebugSqlTestTemp extends TestCase
             return $query;
         };
         $query = $func($query);
-        $comment = sprintf('/* ROOT\tests\TestCase\DebugSqlTempTest.php (line %d) */', __LINE__ - 5);
+        $comment = sprintf(str_replace(DS, '\\', '/* ROOT\tests\TestCase\DebugSqlTempTest.php (line %d) */'), __LINE__ - 5);
         $sql = (string)$query;
         $this->assertTrue(strpos($sql, $comment) !== false, 'Expected: ' . $comment . ' Found: ' . $sql);
     }
@@ -72,13 +72,12 @@ class DebugSqlTestTemp extends TestCase
     public function testFileStampDebugOff()
     {
         $query = $this->newQuery()->select(['id']);
-        // @todo Remove this when TestCase restoring of config is fixed.
         $debug = Configure::read('debug');
         Configure::write('debug', false);
         $sql = (string)$query;
         $this->assertSame($query, DebugSqlTemp::fileStamp($query, 1, true));
         $this->assertEquals($sql, (string)$query);
-        Configure::write('debug', true);
+        Configure::write('debug', $debug);
     }
 
     /**
@@ -88,7 +87,7 @@ class DebugSqlTestTemp extends TestCase
     {
         $query = $this->newQuery()->select(['id']);
         $this->assertSame($query, DebugSqlTemp::fileStamp($query));
-        $comment = sprintf('/* ROOT\tests\TestCase\DebugSqlTempTest.php (line %d) */', __LINE__ - 1);
+        $comment = sprintf(str_replace(DS, '\\', '/* ROOT\tests\TestCase\DebugSqlTempTest.php (line %d) */'), __LINE__ - 1);
         $sql = (string)$query;
         $this->assertTrue(strpos($sql, $comment) !== false, 'Expected: ' . $comment . ' Found: ' . $sql);
     }

--- a/tests/TestCase/DebugSqlTempTest.php
+++ b/tests/TestCase/DebugSqlTempTest.php
@@ -49,23 +49,6 @@ class DebugSqlTestTemp extends TestCase
     }
 
     /**
-     * Tests placement of the file comment.
-     */
-    public function testFileStampEpilog()
-    {
-        $query = $this->newQuery()->select(['id']);
-        $mode = Configure::read('DebugKit.sqlFileNamePlacement');
-        Configure::write('DebugKit.sqlFileNamePlacement', 'epilog');
-        $this->assertSame($query, DebugSqlTemp::fileStamp($query));
-        // missing backslash on ROOT is an issue with test bootstrap, and not a bug
-        $comment = sprintf('/* ROOTtests\TestCase\DebugSqlTempTest.php (line %d) */', __LINE__ - 2);
-        Configure::write('DebugKit.sqlFileNamePlacement', $mode);
-        $sql = (string)$query;
-        // verify SQL ends with comment
-        $this->assertTrue(substr($sql, -strlen($comment)) === $comment, 'Expected: ' . $comment . ' Found: ' . $sql);
-    }
-
-    /**
      * Test that a file name is found when a closure is used.
      */
     public function testFileStampClosure()
@@ -77,8 +60,7 @@ class DebugSqlTestTemp extends TestCase
             return $query;
         };
         $query = $func($query);
-        // missing backslash on ROOT is an issue with test bootstrap, and not a bug
-        $comment = sprintf('/* ROOTtests\TestCase\DebugSqlTempTest.php (line %d) */', __LINE__ - 6);
+        $comment = sprintf('/* ROOT\tests\TestCase\DebugSqlTempTest.php (line %d) */', __LINE__ - 5);
         $sql = (string)$query;
         $this->assertTrue(strpos($sql, $comment) !== false, 'Expected: ' . $comment . ' Found: ' . $sql);
     }
@@ -90,12 +72,13 @@ class DebugSqlTestTemp extends TestCase
     public function testFileStampDebugOff()
     {
         $query = $this->newQuery()->select(['id']);
+        // @todo Remove this when TestCase restoring of config is fixed.
         $debug = Configure::read('debug');
         Configure::write('debug', false);
         $sql = (string)$query;
         $this->assertSame($query, DebugSqlTemp::fileStamp($query, 1, true));
         $this->assertEquals($sql, (string)$query);
-        Configure::write('debug', $debug);
+        Configure::write('debug', true);
     }
 
     /**
@@ -105,8 +88,7 @@ class DebugSqlTestTemp extends TestCase
     {
         $query = $this->newQuery()->select(['id']);
         $this->assertSame($query, DebugSqlTemp::fileStamp($query));
-        // missing backslash on ROOT is an issue with test bootstrap, and not a bug
-        $comment = sprintf('/* ROOTtests\TestCase\DebugSqlTempTest.php (line %d) */', __LINE__ - 2);
+        $comment = sprintf('/* ROOT\tests\TestCase\DebugSqlTempTest.php (line %d) */', __LINE__ - 1);
         $sql = (string)$query;
         $this->assertTrue(strpos($sql, $comment) !== false, 'Expected: ' . $comment . ' Found: ' . $sql);
     }

--- a/tests/TestCase/DebugSqlTempTest.php
+++ b/tests/TestCase/DebugSqlTempTest.php
@@ -49,6 +49,23 @@ class DebugSqlTestTemp extends TestCase
     }
 
     /**
+     * Tests placement of the file comment.
+     */
+    public function testFileStampEpilog()
+    {
+        $query = $this->newQuery()->select(['id']);
+        $mode = Configure::read('DebugKit.sqlFileNamePlacement');
+        Configure::write('DebugKit.sqlFileNamePlacement', 'epilog');
+        $this->assertSame($query, DebugSqlTemp::fileStamp($query));
+        // missing backslash on ROOT is an issue with test bootstrap, and not a bug
+        $comment = sprintf('/* ROOTtests\TestCase\DebugSqlTempTest.php (line %d) */', __LINE__ - 2);
+        Configure::write('DebugKit.sqlFileNamePlacement', $mode);
+        $sql = (string)$query;
+        // verify SQL ends with comment
+        $this->assertTrue(substr($sql, -strlen($comment)) === $comment, 'Expected: ' . $comment . ' Found: ' . $sql);
+    }
+
+    /**
      * Test that a file name is found when a closure is used.
      */
     public function testFileStampClosure()

--- a/tests/TestCase/Model/Table/SqlTraceTraitTest.php
+++ b/tests/TestCase/Model/Table/SqlTraceTraitTest.php
@@ -13,6 +13,7 @@
  */
 namespace DebugKit\Test\TestCase\Model\Table;
 
+use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -21,11 +22,35 @@ use Cake\TestSuite\TestCase;
 class SqlTraceTraitTest extends TestCase
 {
     /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.debug_kit.panels',
+        'plugin.debug_kit.requests'
+    ];
+
+    /**
+     * Table names.
+     *
+     * @var array
+     */
+    public $tables = [
+        'debug_kit.panels',
+        'debug_kit.requests'
+    ];
+
+    /**
      * Verify file name when calling find()
      */
     public function testFind()
     {
-
+        foreach ($this->tables as $table) {
+            $table = TableRegistry::get($table);
+            $sql = (string)$table->find()->select(['id']);
+            $this->assertTrue(strpos($sql, basename(__FILE__)) !== false, 'Expected file: ' . $sql);
+        }
     }
 
     /**
@@ -33,15 +58,11 @@ class SqlTraceTraitTest extends TestCase
      */
     public function testQuery()
     {
-
-    }
-
-    /**
-     * Verify file name is correct when the table object calls the query() method on itself.
-     */
-    public function testShortCallStack()
-    {
-
+        foreach ($this->tables as $table) {
+            $table = TableRegistry::get($table);
+            $sql = (string)$table->query();
+            $this->assertTrue(strpos($sql, basename(__FILE__)) !== false, 'Expected file: ' . $sql);
+        }
     }
 
     /**
@@ -49,6 +70,10 @@ class SqlTraceTraitTest extends TestCase
      */
     public function testUpdate()
     {
-
+        foreach ($this->tables as $table) {
+            $table = TableRegistry::get($table);
+            $sql = (string)$table->query()->update()->set(['title' => 'fooBar']);
+            $this->assertTrue(strpos($sql, basename(__FILE__)) !== false, 'Expected file: ' . $sql);
+        }
     }
 }

--- a/tests/TestCase/Model/Table/SqlTraceTraitTest.php
+++ b/tests/TestCase/Model/Table/SqlTraceTraitTest.php
@@ -13,32 +13,13 @@
  */
 namespace DebugKit\Test\TestCase\Model\Table;
 
-use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
-use DebugKit\Model\Table\PanelsTable;
 
 /**
  * Tests for SqlTraceTrait debugging comments.
  */
 class SqlTraceTraitTest extends TestCase
 {
-    /**
-     * No epilog should be set when debug is off.
-     */
-    public function testDebugOff()
-    {
-
-    }
-
-    /**
-     * Do not overwrite elipog is already set.
-     */
-    public function testEpilogAlreadySet()
-    {
-        /** @var PanelsTable $panels */
-        $panels = TableRegistry::get('Panels');
-    }
-
     /**
      * Verify file name when calling find()
      */

--- a/tests/TestCase/Model/Table/SqlTraceTraitTest.php
+++ b/tests/TestCase/Model/Table/SqlTraceTraitTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.11.5
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace DebugKit\Test\TestCase\Model\Table;
+
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use DebugKit\Model\Table\PanelsTable;
+
+/**
+ * Tests for SqlTraceTrait debugging comments.
+ */
+class SqlTraceTraitTest extends TestCase
+{
+    /**
+     * No epilog should be set when debug is off.
+     */
+    public function testDebugOff()
+    {
+
+    }
+
+    /**
+     * Do not overwrite elipog is already set.
+     */
+    public function testEpilogAlreadySet()
+    {
+        /** @var PanelsTable $panels */
+        $panels = TableRegistry::get('Panels');
+    }
+
+    /**
+     * Verify file name when calling find()
+     */
+    public function testFind()
+    {
+
+    }
+
+    /**
+     * Verify file name when calling query()
+     */
+    public function testQuery()
+    {
+
+    }
+
+    /**
+     * Verify file name is correct when the table object calls the query() method on itself.
+     */
+    public function testShortCallStack()
+    {
+
+    }
+
+    /**
+     * Verify file name when calling update()
+     */
+    public function testUpdate()
+    {
+
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,12 +20,12 @@ use Cake\Routing\DispatcherFactory;
 require_once 'vendor/autoload.php';
 
 // Path constants to a few helpful things.
-define('ROOT', dirname(__DIR__) . DS);
-define('CAKE_CORE_INCLUDE_PATH', ROOT . 'vendor' . DS . 'cakephp' . DS . 'cakephp');
-define('CORE_PATH', ROOT . 'vendor' . DS . 'cakephp' . DS . 'cakephp' . DS);
+define('ROOT', dirname(__DIR__));
+define('CAKE_CORE_INCLUDE_PATH', ROOT . DS . 'vendor' . DS . 'cakephp' . DS . 'cakephp');
+define('CORE_PATH', CAKE_CORE_INCLUDE_PATH . DS);
 define('CAKE', CORE_PATH . 'src' . DS);
-define('TESTS', ROOT . 'tests');
-define('APP', ROOT . 'tests' . DS . 'test_app' . DS);
+define('TESTS', ROOT . DS . 'tests' . DS);
+define('APP', ROOT . DS . 'tests' . DS . 'test_app' . DS);
 define('APP_DIR', 'test_app');
 define('WEBROOT_DIR', 'webroot');
 define('WWW_ROOT', APP . 'webroot' . DS);
@@ -113,7 +113,7 @@ Log::config([
     ]
 ]);
 
-Plugin::load('DebugKit', ['path' => ROOT, 'bootstrap' => true]);
+Plugin::load('DebugKit', ['path' => ROOT . DS, 'bootstrap' => true]);
 
 DispatcherFactory::add('Routing');
 DispatcherFactory::add('ControllerFactory');


### PR DESCRIPTION
closes #573 

Adds a new trait called `SqlTraceTrait` that injects a SQL comment containing the source file that created a new Query object. When you apply the trait to a Table class it overrides the `function query()` method and calls `$query->epilog($comment)` to inject the name of the file that created the query.

It works by finding the first file in a call stack that belongs to the application, and defaults to the last core source file if none found (i.e. I saw this happen for Associations).

![sql-log-example](https://user-images.githubusercontent.com/551022/34308939-86d69524-e71d-11e7-9877-665bd6aaeb33.jpg)

The comments appear in the SQL log as seen in the above image. Since this becomes part of the SQL statement the comments also get captured in the SQL server's log (possible feature side effect). The SQL log panel already applies syntax highlight so the comment has a nice gray color and doesn't visually interfere with the reading of the logs.

The comment is attached to the query using `epilog()` so it will be overwritten if the developer uses `epilog()` for something else. The goal here is to help people see where queries are created, and if you're using `epilog()` for something else, then you're likely to remember why.

The only side side is that you have to manually add this trait to your tables. I happen to have a shared base class named `AppTable` that would add this to all tables, but I know most people don't do this. So I propose if this gets merged into DebugKit that we update the bake project and application template to include this trait. Which will help people see this as a new feature.

If anyone has a better approach, please let me know. 