### PR TITLE
Use proper object class names instead of just object string.

### DIFF
--- a/src/View/Helper/ToolbarHelper.php
+++ b/src/View/Helper/ToolbarHelper.php
@@ -103,7 +103,7 @@ class ToolbarHelper extends Helper
             if (is_array($value) && count($value) > 0) {
                 $out .= '(array)';
             } elseif (is_object($value)) {
-                $out .= '(object)';
+                $out .= '(' . (get_class($value) ?: 'object') . ')';
             }
             if ($value === null) {
                 $value = '(null)';

--- a/tests/TestCase/View/Helper/ToolbarHelperTest.php
+++ b/tests/TestCase/View/Helper/ToolbarHelperTest.php
@@ -114,8 +114,8 @@ class ToolbarHelperTest extends TestCase
      */
     public function testMakeNeatArrayCyclicObjects()
     {
-        $a = new stdClass;
-        $b = new stdClass;
+        $a = new stdClass();
+        $b = new stdClass();
         $a->child = $b;
         $b->parent = $a;
 
@@ -123,12 +123,12 @@ class ToolbarHelperTest extends TestCase
         $result = $this->Toolbar->makeNeatArray($in);
         $expected = [
             ['ul' => ['class' => 'neat-array depth-0']],
-            '<li', '<strong', 'obj', '/strong', ' (object)',
+            '<li', '<strong', 'obj', '/strong', ' (stdClass)',
             ['ul' => ['class' => 'neat-array depth-1']],
-            '<li', '<strong', 'child', '/strong', ' (object)',
+            '<li', '<strong', 'child', '/strong', ' (stdClass)',
             ['ul' => ['class' => 'neat-array depth-2']],
             '<li', '<strong', 'parent', '/strong',
-            ' (object) - recursion',
+            ' (stdClass) - recursion',
             '/li',
             '/ul',
             '/li',
@@ -146,8 +146,8 @@ class ToolbarHelperTest extends TestCase
      */
     public function testMakeNeatArrayDuplicateObjects()
     {
-        $a = new stdClass;
-        $b = new stdClass;
+        $a = new stdClass();
+        $b = new stdClass();
         $a->first = $b;
         $a->second = $b;
 
@@ -155,13 +155,13 @@ class ToolbarHelperTest extends TestCase
         $result = $this->Toolbar->makeNeatArray($in);
         $expected = [
             ['ul' => ['class' => 'neat-array depth-0']],
-            '<li', '<strong', 'obj', '/strong', ' (object)',
+            '<li', '<strong', 'obj', '/strong', ' (stdClass)',
             ['ul' => ['class' => 'neat-array depth-1']],
-            '<li', '<strong', 'first', '/strong', ' (object)',
+            '<li', '<strong', 'first', '/strong', ' (stdClass)',
             ['ul' => ['class' => 'neat-array depth-2']],
             '/ul',
             '/li',
-            '<li', '<strong', 'second', '/strong', ' (object)',
+            '<li', '<strong', 'second', '/strong', ' (stdClass)',
             ['ul' => ['class' => 'neat-array depth-2']],
             '/ul',
             '/li',
@@ -312,7 +312,7 @@ class ToolbarHelperTest extends TestCase
             ['ul' => ['class' => 'neat-array depth-0']],
             '<li', '<strong', 'key', '/strong', ' value', '/li',
             '<li', '<strong', 'nested', '/strong',
-            ' (object)',
+            ' (stdClass)',
             ['ul' => ['class' => 'neat-array depth-1']],
             '<li', '<strong', 'name', '/strong', ' mark', '/li',
             '/ul',


### PR DESCRIPTION
I wondered that no one else ever complained about this not being usable.. :)
Without class names it is hard to work with the variables in view templates

Before:
![1](https://user-images.githubusercontent.com/39854/34462416-d0e73178-ee43-11e7-8a43-021cb0f00fd0.png)

After:
![2](https://user-images.githubusercontent.com/39854/34462417-d2a26ef6-ee43-11e7-9e96-f11e2b3d444b.png)
