### PR TITLE
Remove deprecations to work in 3.6.

### DIFF
--- a/src/Panel/PanelRegistry.php
+++ b/src/Panel/PanelRegistry.php
@@ -16,6 +16,7 @@ use Cake\Core\App;
 use Cake\Core\ObjectRegistry;
 use Cake\Event\EventDispatcherTrait;
 use Cake\Event\EventManager;
+use RuntimeException;
 
 /**
  * Registry object for panels.
@@ -60,7 +61,7 @@ class PanelRegistry extends ObjectRegistry
      */
     protected function _throwMissingClassError($class, $plugin)
     {
-        throw new \RuntimeException("Unable to find '$class' panel.");
+        throw new RuntimeException(__d('debug_kit', "Unable to find '{0}' panel.", $class));
     }
 
     /**

--- a/src/ToolbarService.php
+++ b/src/ToolbarService.php
@@ -133,7 +133,8 @@ class ToolbarService
      */
     public function loadPanels()
     {
-        foreach ($this->getConfig('panels') as $panel => $enabled) {
+        $panels = $this->getConfig('panels');
+        foreach ($panels as $panel => $enabled) {
             list($panel, $enabled) = (is_numeric($panel)) ? [$enabled, true] : [$panel, $enabled];
             if ($enabled) {
                 $this->registry->load($panel);


### PR DESCRIPTION
The following is needed for 3.6 to work due to the deprecation notices being thrown.