### PR TITLE
Prevent Debugkit from running in production

### DIFF
--- a/tests/TestCase/ToolbarServiceTest.php
+++ b/tests/TestCase/ToolbarServiceTest.php
@@ -61,6 +61,17 @@ class ToolbarServiceTest extends TestCase
     }
 
     /**
+     * teardown
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+        putenv('HTTP_HOST=');
+    }
+
+    /**
      * Test loading panels.
      *
      * @return void
@@ -342,6 +353,41 @@ class ToolbarServiceTest extends TestCase
         Configure::write('debug', false);
         $bar = new ToolbarService($this->events, []);
         $this->assertFalse($bar->isEnabled(), 'debug is off, panel is disabled');
+    }
+
+    /**
+     * Test isEnabled returns false for some suspiciously production environments
+     *
+     * @param string $domain The domain name where the app is hosted
+     * @param bool $isEnabled The expectation for isEnabled()
+     * @dataProvider domainsProvider
+     * @return void
+     */
+    public function testIsEnabledProductionEnv($domain, $isEnabled)
+    {
+        Configure::write('debug', true);
+        putenv("HTTP_HOST=$domain");
+        $bar = new ToolbarService($this->events, []);
+        $this->assertEquals($isEnabled, $bar->isEnabled());
+    }
+
+    public function domainsProvider()
+    {
+        return [
+            ['localhost', true],
+            ['192.168.1.34', true],
+            ['10.14.34.5', true],
+            ['myapp.localhost', true],
+            ['myapp.dev', true],
+            ['myapp', true],
+            ['myapp.invalid', true],
+            ['myapp.test', true],
+            ['myapp.com', false],
+            ['myapp.io', false],
+            ['myapp.net', false],
+            ['172.112.34.2', false],
+            ['6.112.34.2', false],
+        ];
     }
 
     /**


### PR DESCRIPTION
Running an application with debug mode on AND installing dev dependencies in a
production environment is obviously the developers' fault for not following the
instructions provided. But we can do better than that.

Instead of blaming them when their secrets are exposed to the internet, we can
run some simple checks that can tells us whether or not the aplications is running
visibly to the www.

In the valid cases developers need DebugKit running in producition-like systems (like a
QA environment), they still have the option of `forceEnable`.