### PR TITLE
Improve Includes panel

### DIFF
--- a/src/Panel/IncludePanel.php
+++ b/src/Panel/IncludePanel.php
@@ -71,6 +71,8 @@ class IncludePanel extends DebugPanel
                 $return['app'][$this->_getFileType($file)][] = $this->_niceFileName($file, 'app');
             } elseif ($this->_isCakeFile($file)) {
                 $return['cake'][$this->_getFileType($file)][] = $this->_niceFileName($file, 'cake');
+            } else {
+                $return['other'][] = $this->_niceFileName($file, 'root');
             }
         }
 
@@ -137,7 +139,7 @@ class IncludePanel extends DebugPanel
     }
 
     /**
-     * Replace the path with APP, CORE or the plugin name
+     * Replace the path with APP, CAKE, ROOT or the plugin name
      *
      * @param string $file File to check
      * @param string $type The file type
@@ -154,6 +156,9 @@ class IncludePanel extends DebugPanel
 
             case 'cake':
                 return str_replace(CAKE, 'CAKE' . DIRECTORY_SEPARATOR, $file);
+
+            case 'root':
+                return str_replace(ROOT, 'ROOT', $file);
 
             default:
                 return str_replace($this->_pluginPaths[$type], $type . DIRECTORY_SEPARATOR, $file);

--- a/src/Panel/IncludePanel.php
+++ b/src/Panel/IncludePanel.php
@@ -82,6 +82,10 @@ class IncludePanel extends DebugPanel
         ksort($return['plugins']);
         ksort($return['app']);
 
+        foreach ($return['plugins'] as &$plugin) {
+            ksort($plugin);
+        }
+
         return $return;
     }
 

--- a/src/Panel/IncludePanel.php
+++ b/src/Panel/IncludePanel.php
@@ -49,7 +49,7 @@ class IncludePanel extends DebugPanel
     public function __construct()
     {
         foreach (Plugin::loaded() as $plugin) {
-            $this->_pluginPaths[$plugin] = Plugin::path($plugin);
+            $this->_pluginPaths[$plugin] = str_replace('/', DIRECTORY_SEPARATOR, Plugin::path($plugin));
         }
     }
 

--- a/src/Panel/IncludePanel.php
+++ b/src/Panel/IncludePanel.php
@@ -254,6 +254,8 @@ class IncludePanel extends DebugPanel
             $data = $this->_prepare();
         }
 
+        unset($data['paths']);
+
         return count(Hash::flatten($data));
     }
 }

--- a/src/Panel/IncludePanel.php
+++ b/src/Panel/IncludePanel.php
@@ -28,14 +28,14 @@ class IncludePanel extends DebugPanel
     /**
      * The list of plugins within the application
      *
-     * @var <type>
+     * @var string[]
      */
     protected $_pluginPaths = [];
 
     /**
      * The list of Composer packages
      *
-     * @var <type>
+     * @var string[]
      */
     protected $_composerPaths = [];
 
@@ -156,7 +156,7 @@ class IncludePanel extends DebugPanel
      * Check if a path is from a plugin
      *
      * @param string $file File to check
-     * @return bool
+     * @return string|bool plugin name, or false if not plugin
      */
     protected function _isPluginFile($file)
     {
@@ -173,7 +173,7 @@ class IncludePanel extends DebugPanel
      * Check if a path is from a Composer package
      *
      * @param string $file File to check
-     * @return bool
+     * @return string|bool package name, or false if not Composer package
      */
     protected function _isVendorFile($file)
     {
@@ -191,8 +191,8 @@ class IncludePanel extends DebugPanel
      *
      * @param string $file File to check
      * @param string $type The file type
-     * @param string $name plugin name or composer package
-     * @return bool
+     * @param string|null $name plugin name or composer package
+     * @return string Path with replaced prefix
      */
     protected function _niceFileName($file, $type, $name = null)
     {

--- a/src/Panel/IncludePanel.php
+++ b/src/Panel/IncludePanel.php
@@ -83,7 +83,7 @@ class IncludePanel extends DebugPanel
         $return = ['cake' => [], 'app' => [], 'plugins' => [], 'vendor' => [], 'other' => []];
 
         foreach (get_included_files() as $file) {
-            $pluginName = $this->_isPluginFile($file);
+            $pluginName = $this->_getPluginName($file);
 
             if ($pluginName) {
                 $return['plugins'][$pluginName][$this->_getFileType($file)][] = $this->_niceFileName($file, 'plugin', $pluginName);
@@ -92,7 +92,7 @@ class IncludePanel extends DebugPanel
             } elseif ($this->_isCakeFile($file)) {
                 $return['cake'][$this->_getFileType($file)][] = $this->_niceFileName($file, 'cake');
             } else {
-                $vendorName = $this->_isVendorFile($file);
+                $vendorName = $this->_getComposerPackageName($file);
 
                 if ($vendorName) {
                     $return['vendor'][$vendorName][] = $this->_niceFileName($file, 'vendor', $vendorName);
@@ -138,7 +138,7 @@ class IncludePanel extends DebugPanel
      */
     protected function _isCakeFile($file)
     {
-        return strstr($file, CAKE);
+        return strpos($file, CAKE) === 0;
     }
 
     /**
@@ -149,19 +149,19 @@ class IncludePanel extends DebugPanel
      */
     protected function _isAppFile($file)
     {
-        return strstr($file, APP);
+        return strpos($file, APP) === 0;
     }
 
     /**
-     * Check if a path is from a plugin
+     * Detect plugin the file belongs to
      *
      * @param string $file File to check
      * @return string|bool plugin name, or false if not plugin
      */
-    protected function _isPluginFile($file)
+    protected function _getPluginName($file)
     {
         foreach ($this->_pluginPaths as $plugin => $path) {
-            if (strstr($file, $path)) {
+            if (strpos($file, $path) === 0) {
                 return $plugin;
             }
         }
@@ -170,15 +170,15 @@ class IncludePanel extends DebugPanel
     }
 
     /**
-     * Check if a path is from a Composer package
+     * Detect Composer package the file belongs to
      *
      * @param string $file File to check
      * @return string|bool package name, or false if not Composer package
      */
-    protected function _isVendorFile($file)
+    protected function _getComposerPackageName($file)
     {
         foreach ($this->_composerPaths as $package => $path) {
-            if (strstr($file, $path)) {
+            if (strpos($file, $path) === 0) {
                 return $package;
             }
         }

--- a/src/Template/Element/include_panel.ctp
+++ b/src/Template/Element/include_panel.ctp
@@ -18,6 +18,7 @@
  * @var array $app
  * @var array $cake
  * @var array $plugins
+ * @var array $vendor
  * @var array $other
  */
 
@@ -30,4 +31,4 @@ if (!isset($cake) && isset($core)) {
 <?= $this->Toolbar->makeNeatArray($paths) ?>
 
 <h4><?= __d('debug_kit', 'Included Files') ?></h4>
-<?= $this->Toolbar->makeNeatArray(compact('app', 'cake', 'plugins', 'other')) ?>
+<?= $this->Toolbar->makeNeatArray(compact('app', 'cake', 'plugins', 'vendor', 'other')) ?>

--- a/src/Template/Element/include_panel.ctp
+++ b/src/Template/Element/include_panel.ctp
@@ -14,11 +14,11 @@
 
 /**
  * @var \DebugKit\View\AjaxView $this
- * @var string $cake
- * @var string $core
  * @var array $paths
- * @var string $app
- * @var string $plugins
+ * @var array $app
+ * @var array $cake
+ * @var array $plugins
+ * @var array $other
  */
 
 // Backwards compat for old DebugKit data.
@@ -30,4 +30,4 @@ if (!isset($cake) && isset($core)) {
 <?= $this->Toolbar->makeNeatArray($paths) ?>
 
 <h4><?= __d('debug_kit', 'Included Files') ?></h4>
-<?= $this->Toolbar->makeNeatArray(['cake' => $cake, 'app' => $app, 'plugins' => $plugins]) ?>
+<?= $this->Toolbar->makeNeatArray(compact('app', 'cake', 'plugins', 'other')) ?>

--- a/tests/TestCase/Panel/IncludePanelTest.php
+++ b/tests/TestCase/Panel/IncludePanelTest.php
@@ -50,9 +50,14 @@ class IncludePanelTest extends TestCase
         $data = $this->panel->data();
         $this->assertArrayHasKey('cake', $data);
         $this->assertArrayHasKey('app', $data);
+
         $this->assertArrayHasKey('plugins', $data);
         $this->assertArrayHasKey('DebugKit', $data['plugins']);
-        $this->assertArrayHasKey('Other', $data['plugins']['DebugKit']);
+        $this->assertArrayHasKey('other', $data['plugins']['DebugKit']);
+
+        $this->assertArrayHasKey('vendor', $data);
+
+        $this->assertArrayHasKey('other', $data);
     }
 
     /**


### PR DESCRIPTION
* Plugins were uncategorized on Windows because \ and / mismatch.
* Include panel missed many included files if they are not app/cake/plugin - add uncategorized files to 'other' group
* Many includes are from Composer vendor/ directory - add 'vendor' category and group by package
* Include panel summary displayed incorrect count, because it included count of 'Include Paths'
* Changed subgroup of app/cake/plugin to lowercase 'other' to be distinct from Controller/Model/... and to be last in list when sorted.

I've tried to add test like `$this->assertArrayHasKey('cakephp/chronos', $data['vendor']);`, but during test everything (cake/vendor/etc) is inside DebugKit directory, so everything goes into 'plugins -> DebugKit' group.

But in normal app setup, everything goes into correct categories.