### PR TITLE
[2.2] Fix restoreCurrentState not working

### DIFF
--- a/webroot/js/js_debug_toolbar.js
+++ b/webroot/js/js_debug_toolbar.js
@@ -835,11 +835,9 @@ DEBUGKIT.historyPanel = function () {
 
 	// Private method to handle restoration to current request.
 	var restoreCurrentState = function () {
-		var id, i, panelContent, tag;
-
 		historyLinks.removeClass('loading');
 
-		$.each(toolbar.panels, function (panel, id) {
+		$.each(toolbar.panels, function (i, panel) {
 			if (panel.content === undefined) {
 				return;
 			}


### PR DESCRIPTION
The 'Restore to current request' link on the History tab was not working. The signature should be `function (Integer index, Element element)`. Also, I removed unused variables.