### PR TITLE
[2.2] Fix explainQuery not working with PHP7.2 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: precise
+
 php:
   - 5.3
   - 5.4

--- a/Model/ToolbarAccess.php
+++ b/Model/ToolbarAccess.php
@@ -13,13 +13,21 @@
  */
 
 App::uses('ConnectionManager', 'Model');
+App::uses('Model', 'Model');
 
 /**
  * Class ToolbarAccess
  *
  * Contains logic for accessing DebugKit specific information.
  */
-class ToolbarAccess extends Object {
+class ToolbarAccess extends Model {
+
+/**
+ * No database table.
+ *
+ * @var mixed
+ */
+	public $useTable = false;
 
 /**
  * Runs an explain on a query if the connection supports EXPLAIN.


### PR DESCRIPTION
I have changed Object to Model (with useTable = false). Though I am not sure I can change the class tree in a bugfix release, direct use of CakeObject would break legacy 2.x applications.
Instead I could use `class_alias('Object', 'CakeObject')` if the `CakeObject` class was not found. But if users or some plugin's author also did it withtout class_exists() checks, those applications might break. So I thought that using Model class would be safe. But if you prefer class_alias(), I will revise my commits. Either way is fine for me if it works with PHP 7.2.