### PR TITLE
Simulate app request contenxt when rendering mail previews

### DIFF
--- a/src/Controller/MailPreviewController.php
+++ b/src/Controller/MailPreviewController.php
@@ -20,6 +20,7 @@ use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Event\Event;
 use Cake\Http\Exception\NotFoundException;
+use Cake\Routing\Router;
 use Cake\Utility\Inflector;
 use DebugKit\Mailer\AbstractResult;
 use DebugKit\Mailer\PreviewResult;
@@ -114,6 +115,11 @@ class MailPreviewController extends Controller
      */
     public function email($name, $method)
     {
+        // Clear the plugin attribute from the request instance
+        // Router is holding onto so that we can render mail previews
+        // in a plugin less request context.
+        Router::pushRequest($this->request->withParam('plugin', null));
+
         $plugin = $this->request->getQuery('plugin');
         $email = $this->findPreview($name, $method, $plugin);
         $partType = $this->request->getQuery('part');

--- a/tests/TestCase/Controller/MailPreviewControllerTest.php
+++ b/tests/TestCase/Controller/MailPreviewControllerTest.php
@@ -44,6 +44,10 @@ class MailPreviewControllerTest extends IntegrationTestCase
     {
         parent::setUp();
         Plugin::load('DebugkitTestPlugin', ['path' => APP . 'Plugin' . DS . 'DebugkitTestPlugin' . DS]);
+        Router::scope('/', function ($routes) {
+            $routes->connect('/users/:action/*', ['controller' => 'Users']);
+        });
+
         Router::plugin('DebugKit', function (RouteBuilder $routes) {
             $routes->scope(
                 '/mail_preview',
@@ -80,6 +84,7 @@ class MailPreviewControllerTest extends IntegrationTestCase
 
         $this->assertResponseOk();
         $this->assertResponseContains('Testing email action.');
+        $this->assertResponseContains('/users/verify/token', 'Should contain URL from app context');
     }
 
     /**

--- a/tests/test_app/Template/Email/text/test_email.ctp
+++ b/tests/test_app/Template/Email/text/test_email.ctp
@@ -1,1 +1,2 @@
 Testing email action.
+<?= $this->Url->build(['controller' => 'Users', 'action' => 'verify', 'token']) ?>


### PR DESCRIPTION
Mailers will not expect the request context to be inside debugkit. Instead we should simulate the app context so that mailer links don't need `plugin => null` everywhere.

Refs #600