### PR TITLE
Make references to helpers include plugin prefixes.

### DIFF
--- a/src/Controller/PanelsController.php
+++ b/src/Controller/PanelsController.php
@@ -55,7 +55,12 @@ class PanelsController extends Controller
      */
     public function beforeRender(Event $event)
     {
-        $this->viewBuilder()->setLayout('DebugKit.toolbar');
+        $this->viewBuilder()
+            ->setHelpers([
+                'Form', 'Html', 'Number', 'Url', 'DebugKit.Toolbar',
+                'DebugKit.Credentials', 'DebugKit.SimpleGraph',
+            ])
+            ->setLayout('DebugKit.toolbar');
 
         if (!$this->request->is('json')) {
             $this->viewBuilder()->setClassName('DebugKit.Ajax');

--- a/src/Template/Element/routes_panel.ctp
+++ b/src/Template/Element/routes_panel.ctp
@@ -3,6 +3,8 @@
  * @var \Cake\Routing\Route\Route[] $routes
  * @var string $matchedRoute
  */
+use Cake\Utility\Hash;
+
 $routes = Cake\Routing\Router::routes();
 ?>
 <table cellspacing="0" cellpadding="0" class="debug-table">
@@ -16,7 +18,7 @@ $routes = Cake\Routing\Router::routes();
     <tbody>
     <?php foreach ($routes as $route): ?>
         <tr class="<?= ($matchedRoute === $route->template) ? 'highlighted' : '' ?>">
-            <td><?= h(\Cake\Utility\Hash::get($route->options, '_name', $route->getName())) ?></td>
+            <td><?= h(Hash::get($route->options, '_name', $route->getName())) ?></td>
             <td class="left"><?= h($route->template) ?></td>
             <td class="left"><pre><?= json_encode($route->defaults, JSON_PRETTY_PRINT) ?></pre></td>
         </tr>


### PR DESCRIPTION
Don't use application helpers that share a name with DebugKit helpers.

Refs #618