### PR TITLE
Make TLD configurable.

### DIFF
--- a/src/ToolbarService.php
+++ b/src/ToolbarService.php
@@ -131,7 +131,8 @@ class ToolbarService
         }
 
         $tld = end($host);
-        $safeTopLevelDomains = array_merge(['localhost', 'dev', 'invalid', 'test', 'example', 'local'], (array)$this->getConfig('safeTld'));
+        $safeTopLevelDomains = ['localhost', 'dev', 'invalid', 'test', 'example', 'local'];
+        $safeTopLevelDomains = array_merge($safeTopLevelDomains, (array)$this->getConfig('safeTld'));
 
         if (!in_array($tld, $safeTopLevelDomains, true) && !$this->getConfig('forceEnable')) {
             $host = implode('.', $host);

--- a/src/ToolbarService.php
+++ b/src/ToolbarService.php
@@ -136,7 +136,7 @@ class ToolbarService
 
         if (!in_array($tld, $safeTopLevelDomains, true) && !$this->getConfig('forceEnable')) {
             $host = implode('.', $host);
-            $safeList = implode(',', $safeTopLevelDomains);
+            $safeList = implode(', ', $safeTopLevelDomains);
             Log::warning(
                 "DebugKit is disabling itself as your host `{$host}` " .
                 "is not in the known safe list of top-level-domains ({$safeList}). " .

--- a/src/ToolbarService.php
+++ b/src/ToolbarService.php
@@ -64,6 +64,7 @@ class ToolbarService
             'DebugKit.Deprecations' => true,
         ],
         'forceEnable' => false,
+        'safeTld' => []
     ];
 
     /**
@@ -130,11 +131,11 @@ class ToolbarService
         }
 
         $tld = end($host);
-        $safeTLD = ["localhost", "dev", "invalid", "test", "example", "local"];
+        $safeTopLevelDomains = array_merge(['localhost', 'dev', 'invalid', 'test', 'example', 'local'], (array)$this->getConfig('safeTld'));
 
-        if (!in_array($tld, $safeTLD) && !$this->getConfig('forceEnable')) {
+        if (!in_array($tld, $safeTopLevelDomains, true) && !$this->getConfig('forceEnable')) {
             $host = implode('.', $host);
-            $safeList = implode(',', $safeTLD);
+            $safeList = implode(',', $safeTopLevelDomains);
             Log::warning(
                 "DebugKit is disabling itself as your host `{$host}` " .
                 "is not in the known safe list of top-level-domains ({$safeList}). " .

--- a/tests/TestCase/ToolbarServiceTest.php
+++ b/tests/TestCase/ToolbarServiceTest.php
@@ -366,7 +366,7 @@ class ToolbarServiceTest extends TestCase
         Configure::write('debug', true);
         putenv("HTTP_HOST=$domain");
         $bar = new ToolbarService($this->events, []);
-        $this->assertEquals($isEnabled, $bar->isEnabled());
+        $this->assertSame($isEnabled, $bar->isEnabled());
 
         $bar = new ToolbarService($this->events, ['forceEnable' => true]);
         $this->assertTrue($bar->isEnabled(), 'When forced should always be on.');
@@ -392,6 +392,24 @@ class ToolbarServiceTest extends TestCase
             ['172.112.34.2', false],
             ['6.112.34.2', false],
         ];
+    }
+
+    /**
+     * Tests isEnabled() with custom safe TLD.
+     *
+     * @return void
+     */
+    public function testIsEnabledProductionEnvCustomTld()
+    {
+        $domain = 'myapp.foobar';
+        Configure::write('debug', true);
+
+        putenv("HTTP_HOST=$domain");
+        $bar = new ToolbarService($this->events, []);
+        $this->assertFalse($bar->isEnabled());
+
+        $bar = new ToolbarService($this->events, ['safeTld' => ['foobar']]);
+        $this->assertTrue($bar->isEnabled(), 'When safe TLD should always be on.');
     }
 
     /**


### PR DESCRIPTION
Resolves https://github.com/cakephp/debug_kit/issues/617

I didnt move the defaults up as config defaults, so it currently merges instead of overwriting.
I am also fine with overwriting and empty config array to "skip" the check if people prefer to have that option rather than using  'safeTld' config to just "add". The current approach seems "safer", though.