### PR TITLE
Resolves #625 - loadPanel receiving an undefined id

### DIFF
--- a/webroot/js/toolbar-app.js
+++ b/webroot/js/toolbar-app.js
@@ -122,6 +122,10 @@ Toolbar.prototype = {
   },
 
   loadPanel: function(id) {
+    if (id === undefined) {
+      return;
+    }
+
     var url = this.baseUrl + 'debug-kit/panels/view/' + id;
     var contentArea = this.content.find('#panel-content');
     var _this = this;


### PR DESCRIPTION
Fixed the scroll arrows not having a data-id attribute. As it seems that when a button anywhere on the toolbar is clicked it's `data-id` attribute is passed to the ajax for loading. However the arrow buttons do not have this attribute, so `undefined` was being passed, and the resulting php from the ajax was throwing a 404.