### PR TITLE
Accept Cake\Database\Query for sql()/sqld()

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -12,10 +12,10 @@
  */
 use Cake\Core\Configure;
 use Cake\Core\Plugin as CorePlugin;
+use Cake\Database\Query;
 use Cake\Datasource\ConnectionManager;
 use Cake\Event\EventManager;
 use Cake\Log\Log;
-use Cake\ORM\Query;
 use Cake\Routing\DispatcherFactory;
 use DebugKit\DebugSql;
 use DebugKit\Middleware\DebugKitMiddleware;

--- a/src/DebugSql.php
+++ b/src/DebugSql.php
@@ -14,8 +14,8 @@
 namespace DebugKit;
 
 use Cake\Core\Configure;
+use Cake\Database\Query;
 use Cake\Error\Debugger;
-use Cake\ORM\Query;
 use SqlFormatter;
 
 /**


### PR DESCRIPTION
sql()/sqld() should accept both `Cake\ORM\Query` (`TableRegistry::get('Articles')->find()`) and `Cake\Database\Query` (`ConnectionManager::get('default')->newQuery()`)