### PR TITLE
Fix that DeprecationsPanel ignores the errorLevel

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -30,6 +30,7 @@ if (!$service->isEnabled() || php_sapi_name() === 'cli' || php_sapi_name() === '
 }
 
 if (!empty($service->getConfig('panels')['DebugKit.Deprecations'])) {
+    $errorLevel = Configure::read('Error.errorLevel', E_ALL | E_STRICT);
     $previousHandler = set_error_handler(
         function ($code, $message, $file, $line, $context = null) use (&$previousHandler) {
             if ($code == E_USER_DEPRECATED || $code == E_DEPRECATED) {
@@ -40,7 +41,8 @@ if (!empty($service->getConfig('panels')['DebugKit.Deprecations'])) {
             if ($previousHandler) {
                 return $previousHandler($code, $message, $file, $line, $context);
             }
-        }
+        },
+        $errorLevel | E_USER_DEPRECATED | E_DEPRECATED
     );
 }
 


### PR DESCRIPTION
I was looking for a while why the notice error where displayed and found that the DeprecationsPanel overwrites the set_error_handler with the default `$error_types`.

For now, I set the default value of `Configure::read` to the default value of `set_error_handler` `$error_types` argument. 