### PR TITLE
Fix query DebugLog

### DIFF
--- a/src/Database/Log/DebugLog.php
+++ b/src/Database/Log/DebugLog.php
@@ -16,6 +16,7 @@ namespace DebugKit\Database\Log;
 
 use Cake\Database\Log\LoggedQuery;
 use Cake\Log\Engine\BaseLog;
+use Psr\Log\LoggerInterface;
 
 /**
  * DebugKit Query logger.
@@ -36,7 +37,7 @@ class DebugLog extends BaseLog
     /**
      * Decorated logger.
      *
-     * @var \Psr\Log\LoggerInterface
+     * @var \Psr\Log\LoggerInterface|null
      */
     protected $_logger;
 
@@ -72,11 +73,11 @@ class DebugLog extends BaseLog
     /**
      * Constructor
      *
-     * @param \Psr\Log\LoggerInterface $logger The logger to decorate and spy on.
+     * @param \Psr\Log\LoggerInterface|null $logger The logger to decorate and spy on.
      * @param string $name The name of the connection being logged.
      * @param bool $includeSchema Whether or not schema reflection should be included.
      */
-    public function __construct($logger, string $name, bool $includeSchema = false)
+    public function __construct(?LoggerInterface $logger, string $name, bool $includeSchema = false)
     {
         $this->_logger = $logger;
         $this->_connectionName = $name;

--- a/src/Database/Log/DebugLog.php
+++ b/src/Database/Log/DebugLog.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 namespace DebugKit\Database\Log;
 
 use Cake\Database\Log\LoggedQuery;
-use Cake\Log\Engine\BaseLog;
+use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -25,7 +25,7 @@ use Psr\Log\LoggerInterface;
  * and stores log messages internally so they can be displayed
  * or stored for future use.
  */
-class DebugLog extends BaseLog
+class DebugLog extends AbstractLogger
 {
     /**
      * Logs from the current request.

--- a/src/Database/Log/DebugLog.php
+++ b/src/Database/Log/DebugLog.php
@@ -138,13 +138,12 @@ class DebugLog extends QueryLogger
     }
 
     /**
-     * Log queries
-     *
-     * @param \Cake\Database\Log\LoggedQuery $query The query being logged.
-     * @return void
+     * @inheritDoc
      */
-    public function log(LoggedQuery $query): void
+    public function log($level, $message, array $context = []): void
     {
+        $query = $context['query'];
+
         if ($this->_logger) {
             if ($this->_logger instanceof PsrAbstractLogger) {
                 $this->_logger->log($query, $query->error);

--- a/src/Panel/SqlLogPanel.php
+++ b/src/Panel/SqlLogPanel.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace DebugKit\Panel;
 
 use Cake\Core\Configure;
+use Cake\Datasource\ConnectionInterface;
 use Cake\Datasource\ConnectionManager;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
@@ -48,7 +49,9 @@ class SqlLogPanel extends DebugPanel
 
         foreach ($configs as $name) {
             $connection = ConnectionManager::get($name);
-            if ($connection->configName() === 'debug_kit') {
+            if ($connection->configName() === 'debug_kit'
+                || !$connection instanceof ConnectionInterface
+            ) {
                 continue;
             }
             $logger = null;
@@ -64,12 +67,7 @@ class SqlLogPanel extends DebugPanel
             $logger = new DebugLog($logger, $name, $includeSchemaReflection);
 
             $connection->enableQueryLogging(true);
-
-            if (method_exists($connection, 'setLogger')) {
-                $connection->setLogger($logger);
-            } else {
-                $connection->logger($logger);
-            }
+            $connection->setLogger($logger);
 
             $this->_loggers[] = $logger;
         }

--- a/tests/TestCase/Database/Log/DebugLogTest.php
+++ b/tests/TestCase/Database/Log/DebugLogTest.php
@@ -16,6 +16,8 @@ namespace DebugKit\Test\TestCase\Database\Log;
 use Cake\Database\Log\LoggedQuery;
 use Cake\TestSuite\TestCase;
 use DebugKit\Database\Log\DebugLog;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
 /**
  * DebugLog test case
@@ -52,12 +54,12 @@ class DebugLogTest extends TestCase
 
         $this->assertCount(0, $this->logger->queries());
 
-        $this->logger->log($query);
+        $this->logger->log(LogLevel::DEBUG, (string)$query, ['query' => $query]);
         $this->assertCount(1, $this->logger->queries());
         $this->assertEquals(10, $this->logger->totalTime());
         $this->assertEquals(5, $this->logger->totalRows());
 
-        $this->logger->log($query);
+        $this->logger->log(LogLevel::DEBUG, (string)$query, ['query' => $query]);
         $this->assertCount(2, $this->logger->queries());
         $this->assertEquals(20, $this->logger->totalTime());
         $this->assertEquals(10, $this->logger->totalRows());
@@ -78,7 +80,7 @@ class DebugLogTest extends TestCase
 
         $this->assertCount(0, $this->logger->queries());
 
-        $this->logger->log($query);
+        $this->logger->log(LogLevel::DEBUG, (string)$query, ['query' => $query]);
         $this->assertCount(0, $this->logger->queries());
     }
 
@@ -98,7 +100,7 @@ class DebugLogTest extends TestCase
         $logger = new DebugLog(null, 'test', true);
         $this->assertCount(0, $logger->queries());
 
-        $logger->log($query);
+        $logger->log(LogLevel::DEBUG, (string)$query, ['query' => $query]);
         $this->assertCount(1, $logger->queries());
     }
 
@@ -126,12 +128,12 @@ class DebugLogTest extends TestCase
      */
     public function testLogDecorates()
     {
-        $orig = $this->getMockBuilder('Cake\Database\Log\QueryLogger')->getMock();
+        $orig = $this->getMockBuilder(LoggerInterface::class)->getMock();
         $orig->expects($this->once())
             ->method('log');
 
         $query = new LoggedQuery();
         $logger = new DebugLog($orig, 'test');
-        $logger->log($query);
+        $logger->log(LogLevel::DEBUG, (string)$query, ['query' => $query]);
     }
 }


### PR DESCRIPTION
Make debug_kit work again after cakephp/cakephp#13276
Not sure about the dock block. Can't find where it gets inherit from.