### PR TITLE
Don't proxy invalid configuration

### DIFF
--- a/src/Panel/CachePanel.php
+++ b/src/Panel/CachePanel.php
@@ -41,12 +41,14 @@ class CachePanel extends DebugPanel
             $config = Cache::getConfig($name);
             if (isset($config['className']) && $config['className'] instanceof DebugEngine) {
                 $instance = $config['className'];
-            } else {
+            } elseif (isset($config['className'])) {
                 Cache::drop($name);
                 $instance = new DebugEngine($config);
                 Cache::setConfig($name, $instance);
             }
-            $this->_instances[$name] = $instance;
+            if (isset($instance)) {
+                $this->_instances[$name] = $instance;
+            }
         }
     }
 

--- a/tests/TestCase/Panel/CachePanelTest.php
+++ b/tests/TestCase/Panel/CachePanelTest.php
@@ -48,6 +48,7 @@ class CachePanelTest extends TestCase
     {
         parent::tearDown();
         Cache::drop('debug_kit_test');
+        Cache::drop('incomplete');
     }
 
     /**
@@ -62,6 +63,21 @@ class CachePanelTest extends TestCase
         $result = $this->panel->data();
         $this->assertArrayHasKey('debug_kit_test', $result['metrics']);
         $this->assertArrayHasKey('_cake_model_', $result['metrics']);
+    }
+
+    /**
+     * test initialize incomplete data
+     *
+     * @return void
+     */
+    public function testInitializeNoProxyIncompleteConfig()
+    {
+        $data = ['duration' => '+2 seconds'];
+        Cache::setConfig('incomplete', $data);
+        $this->panel->initialize();
+
+        $config = Cache::getConfig('incomplete');
+        $this->assertSame($data, $config);
     }
 
     /**


### PR DESCRIPTION
If a cache configuration doesn't have a `className` we shouldn't proxy it as it is malformed.

Fixes #682