### PR TITLE
Load panels before passing to the next middleware

### DIFF
--- a/src/Middleware/DebugKitMiddleware.php
+++ b/src/Middleware/DebugKitMiddleware.php
@@ -53,14 +53,16 @@ class DebugKitMiddleware implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
+        if ($this->service->isEnabled()) {
+            $this->service->loadPanels();
+            $this->service->initializePanels();
+        }
         $response = $handler->handle($request);
 
         if (!$this->service->isEnabled()) {
             return $response;
         }
 
-        $this->service->loadPanels();
-        $this->service->initializePanels();
         $row = $this->service->saveData($request, $response);
         if (!$row) {
             return $response;


### PR DESCRIPTION
Loading panels after the wrapped middleware is complete results in panels using a `shutdown` handler to collect their data to not ever be fired causing broken panels.