### PR TITLE
Publish 4.x docs as part of docs image.

### DIFF
--- a/docs.Dockerfile
+++ b/docs.Dockerfile
@@ -6,8 +6,11 @@ RUN pip install git+https://github.com/sphinx-contrib/video.git@master
 COPY docs /data/docs
 
 RUN cd /data/docs-builder && \
-  # In the future repeat website for each version
-  make website LANGS="en fr ja pt" SOURCE=/data/docs DEST=/data/website/3.x
+  # Make 3.x docs
+  make website LANGS="en fr ja pt" SOURCE=/data/docs DEST=/data/website/3.x && \
+  # Make 4.x docs
+  git checkout 4.x && \
+  make website LANGS="en fr ja pt" SOURCE=/data/docs DEST=/data/website/4.x
 
 # Move media files into the output directory so video elements work.
 RUN mkdir -p /data/website/3.x/html/_static \
@@ -20,4 +23,5 @@ COPY --from=builder /data/website /data/website
 COPY --from=builder /data/docs-builder/nginx.conf /etc/nginx/conf.d/default.conf
 
 # Move each version into place
-RUN mv /data/website/3.x/html/ /usr/share/nginx/html/3.x
+RUN mv /data/website/3.x/html/ /usr/share/nginx/html/3.x && \
+  mv /data/website/4.x/html/ /usr/share/nginx/html/4.x

--- a/docs/config/all.py
+++ b/docs/config/all.py
@@ -24,6 +24,7 @@ project = 'CakePHP DebugKit'
 # Other versions that display in the version picker menu.
 version_list = [
     {'name': '3.x', 'number': '/debugkit/3.x', 'title': '3.x', 'current': True},
+    {'name': '4.x', 'number': '/debugkit/4.x', 'title': '4.x'},
 ]
 
 # Languages available.


### PR DESCRIPTION
Update the build script for debugkit docs to also generate the 4.x docs at the same time.