### PR TITLE
Hide debugkit routes with a toggle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ php:
 
 sudo: false
 
+services:
+  - postgresql
+  - mysql
+
 env:
   matrix:
     - DB=mysql db_dsn='mysql://root@127.0.0.1/cakephp_test'

--- a/src/Panel/RoutesPanel.php
+++ b/src/Panel/RoutesPanel.php
@@ -37,7 +37,7 @@ class RoutesPanel extends DebugPanel
         }
 
         $routes = array_filter(Router::routes(), function ($route) {
-            return $route->defaults['plugin'] === 'DebugKit';
+            return $route->defaults['plugin'] !== 'DebugKit';
         });
 
         return count($routes);

--- a/src/Panel/RoutesPanel.php
+++ b/src/Panel/RoutesPanel.php
@@ -37,7 +37,7 @@ class RoutesPanel extends DebugPanel
         }
 
         $routes = array_filter(Router::routes(), function ($route) {
-            return strpos($route->getName(), 'debugkit.') !== 0;
+            return $route->defaults['plugin'] === 'DebugKit';
         });
 
         return count($routes);

--- a/src/Panel/RoutesPanel.php
+++ b/src/Panel/RoutesPanel.php
@@ -39,6 +39,7 @@ class RoutesPanel extends DebugPanel
         $routes = array_filter(Router::routes(), function ($route) {
             return strpos($route->getName(), 'debugkit.') !== 0;
         });
+
         return count($routes);
     }
 

--- a/src/Panel/RoutesPanel.php
+++ b/src/Panel/RoutesPanel.php
@@ -36,7 +36,10 @@ class RoutesPanel extends DebugPanel
             return 0;
         }
 
-        return count(Router::routes());
+        $routes = array_filter(Router::routes(), function ($route) {
+            return strpos($route->getName(), 'debugkit.') !== 0;
+        });
+        return count($routes);
     }
 
     /**

--- a/src/Template/Element/routes_panel.ctp
+++ b/src/Template/Element/routes_panel.ctp
@@ -17,7 +17,15 @@ $routes = Cake\Routing\Router::routes();
     </thead>
     <tbody>
     <?php foreach ($routes as $route): ?>
-        <tr class="<?= ($matchedRoute === $route->template) ? 'highlighted' : '' ?>">
+        <?php 
+        $class = '';
+        if ($matchedRoute === $route->template):
+            $class = 'highlighted';
+        elseif (strpos($route->getName(), 'debugkit.') === 0):
+            $class = 'debugkit-route hidden';
+        endif;
+        ?>
+        <tr class="<?= $class ?>">
             <td><?= h(Hash::get($route->options, '_name', $route->getName())) ?></td>
             <td class="left"><?= h($route->template) ?></td>
             <td class="left"><pre><?= json_encode($route->defaults, JSON_PRETTY_PRINT) ?></pre></td>
@@ -25,3 +33,16 @@ $routes = Cake\Routing\Router::routes();
     <?php endforeach; ?>
     </tbody>
 </table>
+<button type="button" class="btn-primary" id="toggle-debugkit-routes">
+    <?= __d('debug_kit', 'Toggle debugkit internal routes') ?>
+</button>
+
+<script>
+$(document).ready(function() {
+    $('#toggle-debugkit-routes').on('click', function (event) {
+        event.preventDefault();
+        var routes = $('.debugkit-route');
+        routes.toggleClass('hidden');
+    });
+});
+</script>

--- a/src/Template/Element/routes_panel.ctp
+++ b/src/Template/Element/routes_panel.ctp
@@ -21,7 +21,7 @@ $routes = Cake\Routing\Router::routes();
         $class = '';
         if ($matchedRoute === $route->template):
             $class = 'highlighted';
-        elseif (strpos($route->getName(), 'debugkit.') === 0):
+        elseif ($route->defaults['plugin'] === 'DebugKit'):
             $class = 'debugkit-route hidden';
         endif;
         ?>

--- a/webroot/css/toolbar.css
+++ b/webroot/css/toolbar.css
@@ -501,6 +501,7 @@ pre,
 	color: #fff;
 	border-radius: 4px;
 	box-shadow: 0 2px 0 #2a6496;
+	padding: 4px 10px;
 }
 .btn-primary:active {
 	box-shadow: none;


### PR DESCRIPTION
Alternate solution to #553 that hides the routes but includes a toggle to show them if you want to see them. I've also updated the summary number as it shouldn't include debugkit routes which are hidden by default.

I've also made buttons a bit bigger as they were really small before.