### PR TITLE
Fix deprecation for isNew(bool)

### DIFF
--- a/src/ToolbarService.php
+++ b/src/ToolbarService.php
@@ -232,7 +232,7 @@ class ToolbarService
         $requests->gc();
 
         $row = $requests->newEntity($data);
-        $row->isNew(true);
+        $row->setNew(true);
 
         foreach ($this->registry->loaded() as $name) {
             $panel = $this->registry->{$name};


### PR DESCRIPTION
In cake 4.0 isNew as setter is deprecated, setNew should be used.