### PR TITLE
Fix unknown Message::message method

### DIFF
--- a/src/Mailer/Transport/DebugKitTransport.php
+++ b/src/Mailer/Transport/DebugKitTransport.php
@@ -69,8 +69,8 @@ class DebugKitTransport extends AbstractTransport
     {
         $headers = $message->getHeaders(['from', 'sender', 'replyTo', 'readReceipt', 'returnPath', 'to', 'cc']);
         $parts = [
-            'text' => $message->message(Message::MESSAGE_TEXT),
-            'html' => $message->message(Message::MESSAGE_HTML),
+            'text' => $message->getBodyText(),
+            'html' => $message->getBodyHtml(),
         ];
 
         $headers['Subject'] = $message->getOriginalSubject();


### PR DESCRIPTION
The method got removed in https://github.com/cakephp/cakephp/pull/13536/commits/aeac7a45b675810ea10bb419f402d89bdf938ece