### PR TITLE
run VACUUM command to free disc space

### DIFF
--- a/src/Model/Table/RequestsTable.php
+++ b/src/Model/Table/RequestsTable.php
@@ -13,6 +13,7 @@
 namespace DebugKit\Model\Table;
 
 use Cake\Core\Configure;
+use Cake\Database\Driver\Sqlite;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 use DebugKit\Model\Entity\Request;
@@ -108,5 +109,10 @@ class RequestsTable extends Table
 
         $statement = $query->execute();
         $statement->closeCursor();
+
+        $conn = $this->getConnection();
+        if ($conn->getDriver() instanceof Sqlite) {
+            $conn->execute('VACUUM;');
+        }
     }
 }


### PR DESCRIPTION
I noticed that the size of `debug_kit.sqlite` will keep growing even though the `RequestsTable` has a garbage collection implemented. 

After some research (https://stackoverflow.com/questions/35787220/sqlite-file-size-not-decreasing-after-deleting-some-rows-from-database-in-ios and https://sqlite.org/lang_vacuum.html) I found out that disc space is not automatically freed. It is only freed if the database is recreated with the VACUUM; command.