### PR TITLE
Right align toolbar tabs.

### DIFF
--- a/webroot/css/toolbar.css
+++ b/webroot/css/toolbar.css
@@ -79,6 +79,7 @@ strong {
 	overflow: hidden;
 	white-space: nowrap;
 	display: flex;
+    justify-content: flex-end;
 }
 
 .hidden {


### PR DESCRIPTION
Since the toolbar icon is placed on the right, having panels left aligned means one has to unnecessarily move the mouse towards left of screen, on highish resolutions with few panels, even to click the rightmost panel, after clicking the icon.