### PR TITLE
Fixed re-defining DS constant warning

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -22,7 +22,9 @@ use Cake\Log\Log;
 require_once 'vendor/autoload.php';
 
 // Path constants to a few helpful things.
-define('DS', DIRECTORY_SEPARATOR);
+if (!defined('DS')) {
+    define('DS', DIRECTORY_SEPARATOR);
+}
 define('ROOT', dirname(__DIR__));
 define('CAKE_CORE_INCLUDE_PATH', ROOT . DS . 'vendor' . DS . 'cakephp' . DS . 'cakephp');
 define('CORE_PATH', ROOT . DS . 'vendor' . DS . 'cakephp' . DS . 'cakephp' . DS);


### PR DESCRIPTION
Fixes:

> PHP Notice:  Constant DS already defined in /home/travis/build/cakephp/debug_kit/tests/bootstrap.php on line 25
