### PR TITLE
Add trace_offset to error handler

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -39,7 +39,7 @@ if (!empty($service->getConfig('panels')['DebugKit.Deprecations'])) {
                 return;
             }
             if ($previousHandler) {
-                $context['_trace_offset'] = 1;
+                $context['_trace_frame_offset'] = 1;
                 return $previousHandler($code, $message, $file, $line, $context);
             }
         },

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -39,6 +39,7 @@ if (!empty($service->getConfig('panels')['DebugKit.Deprecations'])) {
                 return;
             }
             if ($previousHandler) {
+                $context['_trace_offset'] = 1;
                 return $previousHandler($code, $message, $file, $line, $context);
             }
         },


### PR DESCRIPTION
Using the trace_offset will allow wrapped errors to have the correct
code and context displayed.

Refs #718
Refs cakephp/cakephp#14090