### PR TITLE
Skip DebugKit on CLI

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -42,11 +42,12 @@ class Plugin extends BasePlugin
     public function bootstrap(PluginApplicationInterface $app): void
     {
         $service = new ToolbarService(EventManager::instance(), (array)Configure::read('DebugKit'));
-        $this->service = $service;
 
         if (!$service->isEnabled() || php_sapi_name() === 'cli' || php_sapi_name() === 'phpdbg') {
             return;
         }
+
+        $this->service = $service;
 
         $this->setDeprecationHandler($service);
 


### PR DESCRIPTION
Fixes https://github.com/cakephp/app/issues/770

`Plugin::middleware()` below checks `if ($this->service)`, but it was always assigned in `Plugin::bootstrap()` before CLI check.