### PR TITLE
Don't double wrap transports

### DIFF
--- a/src/Panel/MailPanel.php
+++ b/src/Panel/MailPanel.php
@@ -47,21 +47,24 @@ class MailPanel extends DebugPanel
 
         $log = $this->emailLog = new ArrayObject();
 
-        foreach ($configs as $name => &$transport) {
+        foreach ($configs as $name => $transport) {
             if (is_object($transport)) {
-                $configs[$name] = new DebugKitTransport(['debugKitLog' => $log], $transport);
+                if (!$transport instanceof DebugKitTransport) {
+                    $configs[$name] = new DebugKitTransport(['debugKitLog' => $log], $transport);
+                }
                 continue;
             }
 
             $className = App::className($transport['className'], 'Mailer/Transport', 'Transport');
-
-            if (!$className) {
+            if (!$className || $className === DebugKitTransport::class) {
                 continue;
             }
 
             $transport['originalClassName'] = $transport['className'];
             $transport['className'] = 'DebugKit.DebugKit';
             $transport['debugKitLog'] = $log;
+
+            $configs[$name] = $transport;
         }
         $property->setValue($configs);
     }


### PR DESCRIPTION
In tests MailPanel can run multiple times and could potentially wrap its own wrappers. This prevents duplicate proxies from being added.

I'm not sure this will entirely fix #721 but it should help.

Refs #721