### PR TITLE
Revert "Use sub query instead of ids array."

### DIFF
--- a/src/Model/Table/RequestsTable.php
+++ b/src/Model/Table/RequestsTable.php
@@ -76,6 +76,16 @@ class RequestsTable extends Table
     }
 
     /**
+     * Check if garbage collection should be run
+     *
+     * @return bool
+     */
+    protected function shouldGc()
+    {
+        return time() % 100 === 0;
+    }
+
+    /**
      * Garbage collect old request data.
      *
      * Delete request data that is older than latest 20 requests.
@@ -86,7 +96,7 @@ class RequestsTable extends Table
      */
     public function gc()
     {
-        if (time() % 100 !== 0) {
+        if (!$this->shouldGc()) {
             return;
         }
         $noPurge = $this->find()

--- a/src/Model/Table/RequestsTable.php
+++ b/src/Model/Table/RequestsTable.php
@@ -101,8 +101,11 @@ class RequestsTable extends Table
         }
         $noPurge = $this->find()
             ->select(['id'])
+            ->enableHydration(false)
             ->order(['requested_at' => 'desc'])
-            ->limit(Configure::read('DebugKit.requestCount') ?: 20);
+            ->limit(Configure::read('DebugKit.requestCount') ?: 20)
+            ->extract('id')
+            ->toArray();
 
         $query = $this->Panels->query()
             ->delete()


### PR DESCRIPTION
Revert  #704 because https://travis-ci.org/cakephp/debug_kit/jobs/639115955#L287