### PR TITLE
Update travis config to match cakephp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 
 php:
   - 7.2
-  - 7.3
   - 7.4
 
 dist: xenial
@@ -13,8 +12,8 @@ services:
 
 env:
   matrix:
-    - DB=mysql db_dsn='mysql://root@127.0.0.1/cakephp_test'
-    - DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
+    - DB=mysql db_dsn='mysql://root@127.0.0.1/cakephp'
+    - DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp'
     - DB=sqlite
   global:
     - DEFAULT=1
@@ -26,15 +25,12 @@ matrix:
     - php: 7.3
       env: CHECKS=1 DEFAULT=0
 
-  allow_failures:
-    - php: 7.4
-
 install:
   - composer install --prefer-dist --no-interaction
 
 before_script:
-  - if [[ $DB == 'mysql' ]]; then mysql -u root -e 'CREATE DATABASE cakephp_test;'; fi
-  - if [[ $DB == 'pgsql' ]]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi
+  - if [[ $DB == 'mysql' ]]; then mysql -u root -e 'CREATE DATABASE cakephp;'; fi
+  - if [[ $DB == 'pgsql' ]]; then psql -c 'CREATE DATABASE cakephp;' -U postgres; fi
   - if [[ $CHECKS == 1 ]]; then composer require --dev psalm/phar:^3.6; fi
 
 script:


### PR DESCRIPTION
Update php versions and remove php 7.4 failure. Update test db names to match cakephp.