### PR TITLE
Use rand() to trigger garbage collection

### DIFF
--- a/src/Model/Table/RequestsTable.php
+++ b/src/Model/Table/RequestsTable.php
@@ -82,7 +82,7 @@ class RequestsTable extends Table
      */
     protected function shouldGc()
     {
-        return time() % 100 === 0;
+        return rand(1, 100) === 100;
     }
 
     /**


### PR DESCRIPTION
Time based GC might sometimes to fail if requests are periodical (ex. every 2 seconds at odd seconds, so never on 100th second) or many requests in short burst, and database might grow quickly.

Simple random number might be more stable to trigger GC.

I'm thinking too if probability could depend on value of `DebugKit.requestCount` as it grew to 100 stored requests on average while only last 20 are used.