### PR TITLE
Allow saving requests to fail gracefully

### DIFF
--- a/tests/TestCase/ToolbarServiceTest.php
+++ b/tests/TestCase/ToolbarServiceTest.php
@@ -141,7 +141,7 @@ class ToolbarServiceTest extends TestCase
         ]);
 
         $bar = new ToolbarService($this->events, []);
-        $this->assertNull($bar->saveData($request, $response));
+        $this->assertFalse($bar->saveData($request, $response));
     }
 
     /**
@@ -162,7 +162,7 @@ class ToolbarServiceTest extends TestCase
         ]);
 
         $bar = new ToolbarService($this->events, []);
-        $this->assertNull($bar->saveData($request, $response));
+        $this->assertFalse($bar->saveData($request, $response));
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/cakephp/debug_kit/issues/759

We should allow concurrent requests without throwing fatal exceptions.