### PR TITLE
Remove double escaping in templates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": ">=7.2",
-        "cakephp/cakephp": "^4.0",
+        "cakephp/cakephp": "^4.1",
         "cakephp/chronos": "^2.0",
         "composer/composer": "^1.3",
         "jdorn/sql-formatter": "^1.2"

--- a/templates/element/environment_panel.php
+++ b/templates/element/environment_panel.php
@@ -39,7 +39,7 @@ use Cake\Error\Debugger;
         <?php foreach ($app as $key => $val): ?>
         <tr>
             <td><?= h($key) ?></td>
-            <td><?= h(Debugger::exportVar($val)) ?></td>
+            <td><?= Debugger::exportVar($val) ?></td>
         </tr>
         <?php endforeach; ?>
     </tbody>
@@ -64,7 +64,7 @@ use Cake\Error\Debugger;
         <?php foreach ($cake as $key => $val): ?>
         <tr>
             <td><?= h($key) ?></td>
-            <td><?= h(Debugger::exportVar($val)) ?></td>
+            <td><?= Debugger::exportVar($val) ?></td>
         </tr>
         <?php endforeach; ?>
     </tbody>
@@ -140,7 +140,7 @@ use Cake\Error\Debugger;
             <?php foreach ($hidef as $key => $val): ?>
             <tr>
                 <td><?= h($key) ?></td>
-                <td><?= h(Debugger::exportVar($val)) ?></td>
+                <td><?= Debugger::exportVar($val) ?></td>
             </tr>
             <?php endforeach; ?>
         </tbody>


### PR DESCRIPTION
`Debugger::exportVar()` how emits escaped HTML in 4.1

Fixes #766