### PR TITLE
Feat/improve dump

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -149,6 +149,9 @@
     </TypeDoesNotContainType>
   </file>
   <file src="src/View/Helper/ToolbarHelper.php">
+    <DeprecatedMethod occurrences="1">
+      <code>makeNeatArray</code>
+    </DeprecatedMethod>
     <InvalidArgument occurrences="1">
       <code>$value</code>
     </InvalidArgument>

--- a/src/View/Helper/ToolbarHelper.php
+++ b/src/View/Helper/ToolbarHelper.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 namespace DebugKit\View\Helper;
 
 use ArrayAccess;
-use Cake\Error\Debugger;
 use Cake\Error\Debug\HtmlFormatter;
+use Cake\Error\Debugger;
 use Cake\View\Helper;
 use Closure;
 use Iterator;
@@ -76,6 +76,7 @@ class ToolbarHelper extends Helper
         if ($restore) {
             $debugger->setConfig('exportFormatter', $exportFormatter);
         }
+
         return implode([
             '<div class="cake-debug-output cake-debug" style="direction:ltr">',
             $contents,

--- a/src/View/Helper/ToolbarHelper.php
+++ b/src/View/Helper/ToolbarHelper.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 namespace DebugKit\View\Helper;
 
 use ArrayAccess;
+use Cake\Error\Debugger;
+use Cake\Error\Debug\HtmlFormatter;
 use Cake\View\Helper;
 use Closure;
 use Iterator;
@@ -56,6 +58,32 @@ class ToolbarHelper extends Helper
     }
 
     /**
+     * Dump the value in $value into an interactive HTML output.
+     *
+     * @param mixed $value The value to output.
+     * @return string Formatted HTML
+     */
+    public function dump($value)
+    {
+        $debugger = Debugger::getInstance();
+        $exportFormatter = $debugger->getConfig('exportFormatter');
+        $restore = false;
+        if ($exportFormatter !== HtmlFormatter::class) {
+            $restore = true;
+            $debugger->setConfig('exportFormatter', HtmlFormatter::class);
+        }
+        $contents = Debugger::exportVar($value, 25);
+        if ($restore) {
+            $debugger->setConfig('exportFormatter', $exportFormatter);
+        }
+        return implode([
+            '<div class="cake-debug-output cake-debug" style="direction:ltr">',
+            $contents,
+            '</div>',
+        ]);
+    }
+
+    /**
      * Recursively goes through an array and makes neat HTML out of it.
      *
      * @param mixed $values Array to make pretty.
@@ -65,6 +93,7 @@ class ToolbarHelper extends Helper
      * @param \SplObjectStorage $currentAncestors Object references found down
      * the path.
      * @return string
+     * @deprecated 4.4.0 Use ToolbarHelper::dump() instead.
      */
     public function makeNeatArray(
         $values,

--- a/templates/element/include_panel.php
+++ b/templates/element/include_panel.php
@@ -28,7 +28,7 @@ if (!isset($cake) && isset($core)) {
 }
 ?>
 <h4><?= __d('debug_kit', 'Include Paths') ?></h4>
-<?= $this->Toolbar->makeNeatArray($paths) ?>
+<?= $this->Toolbar->dump($paths) ?>
 
 <h4><?= __d('debug_kit', 'Included Files') ?></h4>
-<?= $this->Toolbar->makeNeatArray(compact('app', 'cake', 'plugins', 'vendor', 'other')) ?>
+<?= $this->Toolbar->dump(compact('app', 'cake', 'plugins', 'vendor', 'other')) ?>

--- a/templates/element/request_panel.php
+++ b/templates/element/request_panel.php
@@ -32,14 +32,14 @@
 <?php endif; ?>
 
 <h4><?= __d('debug_kit', 'Routing Params') ?></h4>
-<?= $this->Toolbar->makeNeatArray($params) ?>
+<?= $this->Toolbar->dump($params) ?>
 
 <h4><?= __d('debug_kit', 'Post data') ?></h4>
 <?php
 if (empty($data)):
     echo '<p class="info">' . __d('debug_kit', 'No post data.') . '</p>';
 else:
-    echo $this->Toolbar->makeNeatArray($data);
+    echo $this->Toolbar->dump($data);
 endif;
 ?>
 
@@ -48,18 +48,18 @@ endif;
 if (empty($query)):
     echo '<p class="info">' . __d('debug_kit', 'No querystring data.') . '</p>';
 else:
-    echo $this->Toolbar->makeNeatArray($query);
+    echo $this->Toolbar->dump($query);
 endif;
 ?>
 
 <h4>Cookie</h4>
 <?php if (isset($cookie)): ?>
-    <?= $this->Toolbar->makeNeatArray($cookie) ?>
+    <?= $this->Toolbar->dump($cookie) ?>
 <?php else: ?>
     <p class="info"><?= __d('debug_kit', 'No Cookie data.') ?></p>
 <?php endif; ?>
 
 <?php if (!empty($matchedRoute)): ?>
 <h4><?= __d('debug_kit', 'Matched Route') ?></h4>
-    <p><?= $this->Toolbar->makeNeatArray(['template' => $matchedRoute]) ?></p>
+    <p><?= $this->Toolbar->dump(['template' => $matchedRoute]) ?></p>
 <?php endif; ?>

--- a/templates/element/session_panel.php
+++ b/templates/element/session_panel.php
@@ -17,4 +17,4 @@
  * @var array $content
  */
 ?>
-<?= $this->Toolbar->makeNeatArray($content);
+<?= $this->Toolbar->dump($content);

--- a/templates/element/variables_panel.php
+++ b/templates/element/variables_panel.php
@@ -27,10 +27,10 @@ endif;
 if (!empty($content)):
     printf('<label class="toggle-checkbox"><input type="checkbox" class="neat-array-sort"%s>%s</label>', $sort ? ' checked="checked"' : '', __d('debug_kit', 'Sort variables by name'));
     $this->Toolbar->setSort($sort);
-    echo $this->Toolbar->makeNeatArray($content);
+    echo $this->Toolbar->dump($content);
 endif;
 
 if (!empty($errors)):
     echo '<h4>' . __d('debug_kit', 'Validation errors') . '</h4>';
-    echo $this->Toolbar->makeNeatArray($errors);
+    echo $this->Toolbar->dump($errors);
 endif;

--- a/templates/layout/panel.php
+++ b/templates/layout/panel.php
@@ -5,7 +5,7 @@
 echo $this->fetch('content');
 ?>
 <script type="text/javascript">
-if (window.__cakeDebugBlockInit()) {
+if (window.__cakeDebugBlockInit) {
     window.__cakeDebugBlockInit();
 }
 </script>

--- a/templates/layout/panel.php
+++ b/templates/layout/panel.php
@@ -2,5 +2,10 @@
 /**
  * @var \DebugKit\View\AjaxView $this
  */
-
 echo $this->fetch('content');
+?>
+<script type="text/javascript">
+if (window.__cakeDebugBlockInit()) {
+    window.__cakeDebugBlockInit();
+}
+</script>

--- a/tests/TestCase/View/Helper/ToolbarHelperTest.php
+++ b/tests/TestCase/View/Helper/ToolbarHelperTest.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
  */
 namespace DebugKit\Test\TestCase\View\Helper;
 
+use Cake\Error\Debugger;
+use Cake\Error\Debug\TextFormatter;
 use Cake\Http\ServerRequest as Request;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
@@ -63,6 +65,21 @@ class ToolbarHelperTest extends TestCase
     {
         parent::tearDown();
         unset($this->Toolbar);
+    }
+
+    public function testDumpCoerceHtml()
+    {
+        $restore = Debugger::configInstance('exportFormatter');
+        Debugger::configInstance('exportFormatter', TextFormatter::class);
+        $result = $this->Toolbar->dump(false);
+        $this->assertRegExp('/<\w/', $result, 'Contains HTML tags.');
+        $this->assertSame(
+            TextFormatter::class, 
+            Debugger::configInstance('exportFormatter'),
+            'Should restore setting'
+        );
+        // Restore back to original value.
+        Debugger::configInstance('exportFormatter', $restore);
     }
 
     /**

--- a/tests/TestCase/View/Helper/ToolbarHelperTest.php
+++ b/tests/TestCase/View/Helper/ToolbarHelperTest.php
@@ -15,8 +15,8 @@ declare(strict_types=1);
  */
 namespace DebugKit\Test\TestCase\View\Helper;
 
-use Cake\Error\Debugger;
 use Cake\Error\Debug\TextFormatter;
+use Cake\Error\Debugger;
 use Cake\Http\ServerRequest as Request;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
@@ -74,7 +74,7 @@ class ToolbarHelperTest extends TestCase
         $result = $this->Toolbar->dump(false);
         $this->assertRegExp('/<\w/', $result, 'Contains HTML tags.');
         $this->assertSame(
-            TextFormatter::class, 
+            TextFormatter::class,
             Debugger::configInstance('exportFormatter'),
             'Should restore setting'
         );


### PR DESCRIPTION
Make the variable dump output use the new HTML formatting provided in CakePHP. This makes DebugKit more consistent with the rest of Cake and will allow us to remove some code from DebugKit. Furthermore, it makes the types of variables easier to spot than today solving #771 