### PR TITLE
Test improvements about assertEquals and namespace

### DIFF
--- a/tests/TestCase/Cache/Engine/DebugEngineTest.php
+++ b/tests/TestCase/Cache/Engine/DebugEngineTest.php
@@ -185,6 +185,6 @@ class DebugEngineTest extends TestCase
             'path' => TMP,
             'groups' => ['test', 'test2'],
         ], 'test', $this->logger);
-        $this->assertEquals('File', (string)$engine);
+        $this->assertSame('File', (string)$engine);
     }
 }

--- a/tests/TestCase/Controller/DashboardControllerTest.php
+++ b/tests/TestCase/Controller/DashboardControllerTest.php
@@ -74,6 +74,6 @@ class DashboardControllerTest extends IntegrationTestCase
         $this->post('/debug-kit/dashboard/reset');
 
         $this->assertRedirect('/debug-kit');
-        $this->assertEquals(0, $requests->find()->count());
+        $this->assertSame(0, $requests->find()->count());
     }
 }

--- a/tests/TestCase/DebugIncludeTest.php
+++ b/tests/TestCase/DebugIncludeTest.php
@@ -56,7 +56,7 @@ class DebugIncludeTest extends TestCase
     {
         $include = new DebugInclude();
 
-        $this->assertEquals('DebugKit', $include->getPluginName(__FILE__));
+        $this->assertSame('DebugKit', $include->getPluginName(__FILE__));
         $this->assertFalse($include->getPluginName(TMP));
     }
 
@@ -65,7 +65,7 @@ class DebugIncludeTest extends TestCase
         $include = new DebugInclude();
 
         $path = CAKE . 'Controller/Controller.php';
-        $this->assertEquals('cakephp/cakephp', $include->getComposerPackageName($path));
+        $this->assertSame('cakephp/cakephp', $include->getComposerPackageName($path));
     }
 
     public function testNiceFileName()
@@ -102,8 +102,8 @@ class DebugIncludeTest extends TestCase
     {
         $include = new DebugInclude();
 
-        $this->assertEquals('Controller', $include->getFileType(CAKE . 'Controller/Controller.php'));
-        $this->assertEquals('Component', $include->getFileType(CAKE . 'Controller/Component/FlashComponent.php'));
-        $this->assertEquals('Console', $include->getFileType(CAKE . 'Console/Shell.php'));
+        $this->assertSame('Controller', $include->getFileType(CAKE . 'Controller/Controller.php'));
+        $this->assertSame('Component', $include->getFileType(CAKE . 'Controller/Component/FlashComponent.php'));
+        $this->assertSame('Console', $include->getFileType(CAKE . 'Console/Shell.php'));
     }
 }

--- a/tests/TestCase/DebugMemoryTest.php
+++ b/tests/TestCase/DebugMemoryTest.php
@@ -30,10 +30,10 @@ class DebugMemoryTest extends TestCase
     public function testMemoryUsage()
     {
         $result = DebugMemory::getCurrent();
-        $this->assertTrue(is_int($result));
+        $this->assertIsInt($result);
 
         $result = DebugMemory::getPeak();
-        $this->assertTrue(is_int($result));
+        $this->assertIsInt($result);
     }
 
     /**
@@ -64,7 +64,7 @@ class DebugMemoryTest extends TestCase
         $result = DebugMemory::getAll(true);
         $this->assertCount(1, $result);
         $this->assertTrue(isset($result['test marker']));
-        $this->assertTrue(is_numeric($result['test marker']));
+        $this->assertIsNumeric($result['test marker']);
 
         $result = DebugMemory::getAll();
         $this->assertEmpty($result);

--- a/tests/TestCase/DebugPanelTest.php
+++ b/tests/TestCase/DebugPanelTest.php
@@ -36,17 +36,17 @@ class DebugPanelTest extends TestCase
 
     public function testTitle()
     {
-        $this->assertEquals('Simple', $this->panel->title());
+        $this->assertSame('Simple', $this->panel->title());
     }
 
     public function testElementName()
     {
-        $this->assertEquals('DebugKit.simple_panel', $this->panel->elementName());
+        $this->assertSame('DebugKit.simple_panel', $this->panel->elementName());
 
         $this->panel->plugin = 'Derpy';
-        $this->assertEquals('Derpy.simple_panel', $this->panel->elementName());
+        $this->assertSame('Derpy.simple_panel', $this->panel->elementName());
 
         $this->panel->plugin = false;
-        $this->assertEquals('simple_panel', $this->panel->elementName());
+        $this->assertSame('simple_panel', $this->panel->elementName());
     }
 }

--- a/tests/TestCase/DebugSqlTest.php
+++ b/tests/TestCase/DebugSqlTest.php
@@ -60,7 +60,7 @@ SELECT panels.id AS %s FROM panels panels
 EXPECTED;
         $fieldName = $this->connection->getDriver() instanceof Postgres ? '"panels__id"' : 'panels__id';
         $expected = sprintf($expectedText, str_replace(ROOT, '', __FILE__), __LINE__ - 11, $fieldName);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -87,7 +87,7 @@ FROM
 EXPECTED;
         $fieldName = $this->connection->getDriver() instanceof Postgres ? '"panels__id"' : 'panels__id';
         $expected = sprintf($expectedHtml, str_replace(ROOT, '', __FILE__), __LINE__ - 15, $fieldName);
-        $this->assertEquals(str_replace("\r", '', $expected), str_replace("\r", '', $result));
+        $this->assertSame(str_replace("\r", '', $expected), str_replace("\r", '', $result));
     }
 
     /**

--- a/tests/TestCase/DebugTimerTest.php
+++ b/tests/TestCase/DebugTimerTest.php
@@ -78,11 +78,11 @@ class DebugTimerTest extends TestCase
 
         $file = Debugger::trimPath(__FILE__);
         $expected = $file . ' line ' . $lineNo;
-        $this->assertEquals($expected, $key);
+        $this->assertSame($expected, $key);
 
         $timer = $timers[$expected];
         $this->assertTrue($timer['time'] > 0.0020);
-        $this->assertEquals($expected, $timers[$expected]['message']);
+        $this->assertSame($expected, $timers[$expected]['message']);
     }
 
     /**
@@ -100,7 +100,7 @@ class DebugTimerTest extends TestCase
         $this->assertTrue(DebugTimer::stop());
 
         $timers = DebugTimer::getAll();
-        $this->assertSame(3, count($timers), 'incorrect number of timers %s');
+        $this->assertCount(3, $timers, 'incorrect number of timers %s');
         $firstTimerLine = __LINE__ - 9;
         $secondTimerLine = __LINE__ - 8;
         $file = Debugger::trimPath(__FILE__);
@@ -130,14 +130,14 @@ class DebugTimerTest extends TestCase
         DebugTimer::stop('my timer');
 
         $timers = DebugTimer::getAll();
-        $this->assertSame(3, count($timers), 'wrong timer count %s');
+        $this->assertCount(3, $timers, 'wrong timer count %s');
 
         $this->assertTrue(isset($timers['my timer']));
         $this->assertTrue(isset($timers['my timer #2']));
 
         $this->assertTrue($timers['my timer']['time'] > $timers['my timer #2']['time'], 'timer 2 is longer? %s');
-        $this->assertEquals('This is the first call', $timers['my timer']['message']);
-        $this->assertEquals('This is the second call #2', $timers['my timer #2']['message']);
+        $this->assertSame('This is the first call', $timers['my timer']['message']);
+        $this->assertSame('This is the second call #2', $timers['my timer #2']['message']);
     }
 
     /**
@@ -183,7 +183,7 @@ class DebugTimerTest extends TestCase
         $timers = DebugTimer::getAll();
 
         $this->assertCount(3, $timers);
-        $this->assertTrue(is_float($timers['test1']['time']));
+        $this->assertIsFloat($timers['test1']['time']);
         $this->assertTrue(isset($timers['test1']['message']));
         $this->assertTrue(isset($timers['test2']['message']));
     }

--- a/tests/TestCase/Middleware/DebugKitMiddlewareTest.php
+++ b/tests/TestCase/Middleware/DebugKitMiddlewareTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace DebugKit\Test\Middleware;
+namespace DebugKit\Test\TestCase\Middleware;
 
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
@@ -107,17 +107,17 @@ class DebugKitMiddlewareTest extends TestCase
             ->contain('Panels')
             ->first();
 
-        $this->assertEquals('GET', $result->method);
-        $this->assertEquals('/articles', $result->url);
+        $this->assertSame('GET', $result->method);
+        $this->assertSame('/articles', $result->url);
         $this->assertNotEmpty($result->requested_at);
         $this->assertNotEmpty('text/html', $result->content_type);
         $this->assertSame(200, $result->status_code);
         $this->assertGreaterThan(1, $result->panels);
 
-        $this->assertEquals('SqlLog', $result->panels[11]->panel);
-        $this->assertEquals('DebugKit.sql_log_panel', $result->panels[11]->element);
+        $this->assertSame('SqlLog', $result->panels[11]->panel);
+        $this->assertSame('DebugKit.sql_log_panel', $result->panels[11]->element);
         $this->assertNotNull($result->panels[11]->summary);
-        $this->assertEquals('Sql Log', $result->panels[11]->title);
+        $this->assertSame('Sql Log', $result->panels[11]->title);
 
         $timeStamp = filemtime(Plugin::path('DebugKit') . 'webroot' . DS . 'js' . DS . 'toolbar.js');
 
@@ -196,7 +196,7 @@ class DebugKitMiddlewareTest extends TestCase
         $requests = $this->getTableLocator()->get('DebugKit.Requests');
         $total = $requests->find()->where(['url' => '/articles'])->count();
 
-        $this->assertEquals(1, $total, 'Should track response');
+        $this->assertSame(1, $total, 'Should track response');
         $body = (string)$result->getBody();
         $this->assertSame('OK', $body);
     }
@@ -214,6 +214,6 @@ class DebugKitMiddlewareTest extends TestCase
         $prop = new \ReflectionProperty(DebugKitMiddleware::class, 'service');
         $prop->setAccessible(true);
         $service = $prop->getValue($layer);
-        $this->assertEquals('bar', $service->getConfig('foo'));
+        $this->assertSame('bar', $service->getConfig('foo'));
     }
 }

--- a/tests/TestCase/Panel/DeprecationsPanelTest.php
+++ b/tests/TestCase/Panel/DeprecationsPanelTest.php
@@ -65,17 +65,17 @@ class DeprecationsPanelTest extends TestCase
 
         $error = $data['plugins']['DebugKit'][0];
         $this->assertStringContainsString('Something going away', $error['message']);
-        $this->assertEquals('DebugKit/tests/TestCase/Panel/DeprecationsPanelTest.php', $error['niceFile']);
-        $this->assertEquals(46, $error['line']);
+        $this->assertSame('DebugKit/tests/TestCase/Panel/DeprecationsPanelTest.php', $error['niceFile']);
+        $this->assertSame(46, $error['line']);
 
         $error = $data['plugins']['DebugKit'][2];
         $this->assertStringContainsString('Raw error', $error['message']);
-        $this->assertEquals('DebugKit/tests/TestCase/Panel/DeprecationsPanelTest.php', $error['niceFile']);
-        $this->assertEquals(48, $error['line']);
+        $this->assertSame('DebugKit/tests/TestCase/Panel/DeprecationsPanelTest.php', $error['niceFile']);
+        $this->assertSame(48, $error['line']);
     }
 
     public function testSummary()
     {
-        $this->assertEquals('3', $this->panel->summary());
+        $this->assertSame('3', $this->panel->summary());
     }
 }

--- a/tests/TestCase/Panel/EnvironmentPanelTest.php
+++ b/tests/TestCase/Panel/EnvironmentPanelTest.php
@@ -65,6 +65,6 @@ class EnvironmentPanelTest extends TestCase
         $output = $this->panel->data();
         $this->assertIsArray($output);
         $this->assertSame(['php', 'ini', 'cake', 'app'], array_keys($output));
-        $this->assertEquals('mysql://user:password@localhost/my_db', $output['php']['TEST_URL_1']);
+        $this->assertSame('mysql://user:password@localhost/my_db', $output['php']['TEST_URL_1']);
     }
 }

--- a/tests/TestCase/ToolbarServiceTest.php
+++ b/tests/TestCase/ToolbarServiceTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace DebugKit\Test;
+namespace DebugKit\Test\TestCase;
 
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
@@ -226,17 +226,17 @@ class ToolbarServiceTest extends TestCase
             ->contain('Panels')
             ->first();
 
-        $this->assertEquals('GET', $result->method);
-        $this->assertEquals('/articles', $result->url);
+        $this->assertSame('GET', $result->method);
+        $this->assertSame('/articles', $result->url);
         $this->assertNotEmpty($result->requested_at);
         $this->assertNotEmpty('text/html', $result->content_type);
         $this->assertSame(200, $result->status_code);
         $this->assertGreaterThan(1, $result->panels);
 
-        $this->assertEquals('SqlLog', $result->panels[11]->panel);
-        $this->assertEquals('DebugKit.sql_log_panel', $result->panels[11]->element);
+        $this->assertSame('SqlLog', $result->panels[11]->panel);
+        $this->assertSame('DebugKit.sql_log_panel', $result->panels[11]->element);
         $this->assertSame('0', $result->panels[11]->summary);
-        $this->assertEquals('Sql Log', $result->panels[11]->title);
+        $this->assertSame('Sql Log', $result->panels[11]->title);
     }
 
     /**
@@ -319,7 +319,7 @@ class ToolbarServiceTest extends TestCase
 
         $result = $bar->injectScripts($row, $response);
         $this->assertInstanceOf('Cake\Http\Response', $result);
-        $this->assertEquals('I am a teapot!', $response->getBody());
+        $this->assertSame('I am a teapot!', (string)$response->getBody());
     }
 
     /**


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to replace `assertEquals` and make assertion equals strict.
- Using the specific assertion internal type methods to replace `is_` type checking function.