### PR TITLE
Allow 172.16.0.0/12 and IPv6 private ranges

### DIFF
--- a/src/ToolbarService.php
+++ b/src/ToolbarService.php
@@ -138,7 +138,9 @@ class ToolbarService
         // Check if the host is a private or reserved IPv4/6 address.
         $isIp = filter_var($host, FILTER_VALIDATE_IP) !== false;
         if ($isIp) {
-            $isPublicIp = filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) !== false;
+            $flags = FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE;
+            $isPublicIp = filter_var($host, FILTER_VALIDATE_IP, $flags) !== false;
+
             return $isPublicIp;
         }
 
@@ -166,6 +168,7 @@ class ToolbarService
                 'If you would like to force DebugKit on use the `DebugKit.forceEnable` Configure option.'
             );
         }
+
         return true;
     }
 

--- a/tests/TestCase/ToolbarServiceTest.php
+++ b/tests/TestCase/ToolbarServiceTest.php
@@ -402,8 +402,8 @@ class ToolbarServiceTest extends TestCase
             ['172.112.34.2', false],
             ['6.112.34.2', false],
             ['[abcd::]', false], // public
-            ['[fc00::]', true],  // private
-            ['[::1]', true],     // localhost
+            ['[fc00::]', true], // private
+            ['[::1]', true], // localhost
         ];
     }
 

--- a/tests/TestCase/ToolbarServiceTest.php
+++ b/tests/TestCase/ToolbarServiceTest.php
@@ -398,8 +398,12 @@ class ToolbarServiceTest extends TestCase
             ['myapp.com', false],
             ['myapp.io', false],
             ['myapp.net', false],
+            ['172.18.0.10', true],
             ['172.112.34.2', false],
             ['6.112.34.2', false],
+            ['[abcd::]', false], // public
+            ['[fc00::]', true],  // private
+            ['[::1]', true],     // localhost
         ];
     }
 


### PR DESCRIPTION
While learning CakePHP, I could not get the DebugKit toolbar to appear on my server with private address 172.18.0.52. After looking around in the DebugKit code, I noticed that the private class B IPv4 range (172.16.0.0 - 172.31.255.255) is missing from the `isSuspiciouslyProduction()` method, so DebugKit thinks that 172.18.0.52 is a public address. Of course I could set `forceEnable` to `true`, to force the toolbar to appear, but that should not be necessary.

I can not simply add "172" to the array of private octects either, because there is a phpunit testcase for public address 172.112.34.2, which would then fail. The current code bases its judgement whether an IP address is public or private, only on the first octet of an IP address. As a result, it assumes (for example) that 192.1.2.3 is private, because it starts with 192, while it really is a public address.

So I decided to rework the code, and use PHP's own `filter_var` function instead, to let PHP figure out whether an address is public, private or reserved. As a free bonus, `filter_var` is IPv6 ready. So the `isSuspiciouslyProduction()` method can now recognize private IPv6 addresses as well.

`filter_var` recognizes these private ranges:
* IPv4: 10.0.0.0/8, 172.16.0.0/12 and 192.168.0.0/16
* IPv6: addresses starting with FD or FC

`filter_var` recognizes these reserved ranges:
* IPv4: 0.0.0.0/8, 169.254.0.0/16, 127.0.0.0/8 and 240.0.0.0/4
* IPv6: ::1/128, ::/128, ::ffff:0:0/96 and fe80::/10

(see https://www.php.net/manual/en/filter.filters.flags.php)

The dataprovider in `ToolbarServiceTest.php` has been updated; I added a private IPv4 address in the 172-range, and some public/private/localhost IPv6 examples. The PHPUnit tests pass.