### PR TITLE
fix: pass default-param to underlying cache-engine

### DIFF
--- a/src/Cache/Engine/DebugEngine.php
+++ b/src/Cache/Engine/DebugEngine.php
@@ -196,7 +196,7 @@ class DebugEngine extends CacheEngine
     public function getMultiple($keys, $default = null): iterable
     {
         $start = microtime(true);
-        $result = $this->_engine->getMultiple($keys);
+        $result = $this->_engine->getMultiple($keys, $default);
         $duration = microtime(true) - $start;
 
         $this->track('get hit');


### PR DESCRIPTION
fixes #781