### PR TITLE
fix warning in php8

### DIFF
--- a/src/Panel/VariablesPanel.php
+++ b/src/Panel/VariablesPanel.php
@@ -98,7 +98,7 @@ class VariablesPanel extends DebugPanel
         $controller = $event->getSubject();
         $errors = [];
 
-        $walker = function (&$item) use (&$walker) {
+        $walker = function ($item) use (&$walker) {
             if (
                 $item instanceof Collection ||
                 $item instanceof Query ||


### PR DESCRIPTION
 DebugKit\Panel\VariablesPanel::DebugKit\Panel\{closure}(): Argument #1 ($item) must be passed by reference, value given