### PR TITLE
Fix exception when fixture class isn't found

### DIFF
--- a/src/Model/Table/LazyTableTrait.php
+++ b/src/Model/Table/LazyTableTrait.php
@@ -57,9 +57,10 @@ trait LazyTableTrait
         try {
             foreach ($fixtures as $name) {
                 $class = App::className($name, 'Test/Fixture', 'Fixture');
-                if ($class === false) {
+                if ($class === null) {
                     throw new \RuntimeException("Unknown fixture '$name'.");
                 }
+
                 /** @var \Cake\TestSuite\Fixture\TestFixture $fixture */
                 $fixture = new $class($connection->configName());
                 if (in_array($fixture->table, $existing)) {


### PR DESCRIPTION
Refs https://github.com/cakephp/debug_kit/issues/797

This doesn't fix the issue reported, but it fixes the check that should thrown an exception when this happens.

We don't seem to have unit tests for loading the fixtures.