### PR TITLE
Fix authoritative autoloader compatibility.

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -51,7 +51,7 @@ Configuration
     Configure::write('DebugKit.forceEnable', true);
 
 * ``DebugKit.ignorePathsPattern`` - Regex pattern (including delimiter) to ignore paths.
-   DebugKit won't save data for request URLs that match this regex. Defaults to ``null``::
+  DebugKit won't save data for request URLs that match this regex. Defaults to ``null``::
 
     // Ignore image paths
     Configure::write('DebugKit.ignorePathsPattern', '/\.(jpg|png|gif)$/');

--- a/tests/Fixture/PanelsFixture.php
+++ b/tests/Fixture/PanelsFixture.php
@@ -10,7 +10,7 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Debugkit\Test\Fixture;
+namespace DebugKit\Test\Fixture;
 
 use Cake\Database\Schema\TableSchema;
 use Cake\TestSuite\Fixture\TestFixture;

--- a/tests/Fixture/RequestsFixture.php
+++ b/tests/Fixture/RequestsFixture.php
@@ -10,7 +10,7 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Debugkit\Test\Fixture;
+namespace DebugKit\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
 


### PR DESCRIPTION
This fixes the authoritative autoloader generation which bakes class names into the autoloader lookup.

Fixes #797