### PR TITLE
Preserve cache configuration better.

### DIFF
--- a/src/Panel/CachePanel.php
+++ b/src/Panel/CachePanel.php
@@ -56,7 +56,8 @@ class CachePanel extends DebugPanel
             } elseif (isset($config['className'])) {
                 Cache::drop($name);
                 $instance = new DebugEngine($config, $name, $this->logger);
-                Cache::setConfig($name, $instance);
+                $config['className'] = $instance;
+                Cache::setConfig($name, $config);
             }
             if (isset($instance)) {
                 $this->instances[$name] = $instance;

--- a/tests/TestCase/Panel/CachePanelTest.php
+++ b/tests/TestCase/Panel/CachePanelTest.php
@@ -37,7 +37,7 @@ class CachePanelTest extends TestCase
     {
         parent::setUp();
         $this->panel = new CachePanel();
-        Cache::setConfig('debug_kit_test', ['className' => 'Null']);
+        Cache::setConfig('debug_kit_test', ['className' => 'Null', 'path' => TMP]);
     }
 
     /**
@@ -109,5 +109,12 @@ class CachePanelTest extends TestCase
         $this->panel->initialize();
         $result2 = Cache::engine('debug_kit_test');
         $this->assertSame($result2, $result);
+    }
+
+    public function testInitializePreserveGlobalConfig()
+    {
+        $this->panel->initialize();
+        $result = Cache::getConfig('debug_kit_test');
+        $this->assertEquals($result['path'], TMP);
     }
 }


### PR DESCRIPTION
Don't overwrite the entire cache configuration data. This allows
`Cache::getConfig()` to continue working as it normally should.

Fixes #801