### PR TITLE
Fix DeprecationsPanelTest hiding php errors

### DIFF
--- a/tests/TestCase/Panel/DeprecationsPanelTest.php
+++ b/tests/TestCase/Panel/DeprecationsPanelTest.php
@@ -40,14 +40,16 @@ class DeprecationsPanelTest extends TestCase
 
         $this->panel = new DeprecationsPanel();
 
-        $previousHandler = set_error_handler(function ($code, $message, $file, $line, $context = null) {
+        set_error_handler(function ($code, $message, $file, $line, $context = null) {
             DeprecationsPanel::addDeprecatedError(compact('code', 'message', 'file', 'line', 'context'));
         });
-        deprecationWarning('Something going away', 0);
-        deprecationWarning('Something else going away', 0);
-        trigger_error('Raw error', E_USER_DEPRECATED);
-
-        set_error_handler($previousHandler);
+        try {
+            deprecationWarning('Something going away', 0);
+            deprecationWarning('Something else going away', 0);
+            trigger_error('Raw error', E_USER_DEPRECATED);
+        } finally {
+            restore_error_handler();
+        }
     }
 
     public function testShutdown()


### PR DESCRIPTION
Refs https://github.com/cakephp/debug_kit/issues/795

We were hiding php errors and warnings in tests after DeprecationsPanelTest.