### PR TITLE
Fix failure when debug_kit connection does not exist 

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.18.2@19aa905f7c3c7350569999a93c40ae91ae4e1626">
-  <file src="src/Controller/DashboardController.php">
-    <NullableReturnStatement occurrences="1">
-      <code>$this-&gt;redirect(['action' =&gt; 'index'])</code>
-    </NullableReturnStatement>
-  </file>
+<files psalm-version="4.x-dev@">
   <file src="src/Controller/MailPreviewController.php">
     <PossiblyInvalidArgument occurrences="1">
       <code>$partType</code>
@@ -101,12 +96,12 @@
     </MoreSpecificReturnType>
   </file>
   <file src="src/Panel/SqlLogPanel.php">
-    <UndefinedInterfaceMethod occurrences="1">
-      <code>genericInstances</code>
-    </UndefinedInterfaceMethod>
     <TypeDoesNotContainType occurrences="1">
       <code>!$connection instanceof ConnectionInterface</code>
     </TypeDoesNotContainType>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>genericInstances</code>
+    </UndefinedInterfaceMethod>
   </file>
   <file src="src/Plugin.php">
     <InvalidArgument occurrences="1"/>
@@ -120,15 +115,16 @@
     <DeprecatedMethod occurrences="1">
       <code>makeNeatArray</code>
     </DeprecatedMethod>
-    <InvalidArgument occurrences="2">
-      <code>$value</code>
-      <code>$values</code>
-    </InvalidArgument>
     <InternalClass occurrences="1">
       <code>new HtmlFormatter()</code>
     </InternalClass>
     <InternalMethod occurrences="1">
       <code>dump</code>
     </InternalMethod>
+    <InvalidArgument occurrences="3">
+      <code>$currentAncestors</code>
+      <code>$value</code>
+      <code>$values</code>
+    </InvalidArgument>
   </file>
 </files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -7,7 +7,7 @@
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     autoloader="tests/bootstrap.php"
     usePhpDocMethodsWithoutMagicCall="true"
-    errorBaseline="psalm-baseline.xml"
+    errorBaseline="./psalm-baseline.xml"
 >
     <projectFiles>
         <directory name="src" />

--- a/src/Cache/Engine/DebugEngine.php
+++ b/src/Cache/Engine/DebugEngine.php
@@ -28,7 +28,7 @@ class DebugEngine extends CacheEngine
     /**
      * Proxied cache engine config.
      *
-     * @var mixed
+     * @var array
      */
     protected $_config;
 

--- a/src/Model/Entity/Panel.php
+++ b/src/Model/Entity/Panel.php
@@ -29,7 +29,7 @@ class Panel extends Entity
     /**
      * Some fields should not be in JSON/array exports.
      *
-     * @var array
+     * @var string[]
      */
     protected $_hidden = ['content'];
 

--- a/src/ToolbarService.php
+++ b/src/ToolbarService.php
@@ -260,7 +260,10 @@ class ToolbarService
             $requests = $this->getTableLocator()->get('DebugKit.Requests');
             $requests->gc();
         } catch (MissingDatasourceConfigException $e) {
-            Log::warning('Unable to save request. Check your custom debut_kit datasource connection or check that SQLite extension is enabled..');
+            Log::warning(
+                'Unable to save request. Check your debug_kit datasource connection ' .
+                'or ensure that PDO SQLite extension is enabled.'
+            );
             Log::warning($e->getMessage());
 
             return false;

--- a/src/ToolbarService.php
+++ b/src/ToolbarService.php
@@ -260,7 +260,7 @@ class ToolbarService
             $requests = $this->getTableLocator()->get('DebugKit.Requests');
             $requests->gc();
         } catch (MissingDatasourceConfigException $e) {
-            Log::warning('Unable to save request. You need to define the debug_kit connection.');
+            Log::warning('Unable to save request. Check your custom debut_kit datasource connection or check that SQLite extension is enabled..');
             Log::warning($e->getMessage());
 
             return false;

--- a/tests/TestCase/Panel/SqlLogPanelTest.php
+++ b/tests/TestCase/Panel/SqlLogPanelTest.php
@@ -126,6 +126,6 @@ class SqlLogPanelTest extends TestCase
         $articles->findById(1)->first();
 
         $result = $this->panel->summary();
-        $this->assertRegExp('/\d+ \\/ \d+ ms/', $result);
+        $this->assertMatchesRegularExpression('/\d+ \\/ \d+ ms/', $result);
     }
 }

--- a/tests/TestCase/ToolbarServiceTest.php
+++ b/tests/TestCase/ToolbarServiceTest.php
@@ -240,6 +240,34 @@ class ToolbarServiceTest extends TestCase
     }
 
     /**
+     * Test that saveData gracefully handles missing connections
+     *
+     * @return void
+     */
+    public function testSaveDataMissingConnection()
+    {
+        $restore = ConnectionManager::getConfig('test_debug_kit');
+        ConnectionManager::drop('test_debug_kit');
+
+        $request = new Request([
+            'url' => '/articles',
+            'environment' => ['REQUEST_METHOD' => 'GET'],
+        ]);
+        $response = new Response([
+            'statusCode' => 200,
+            'type' => 'text/html',
+            'body' => '<html><title>test</title><body><p>some text</p></body>',
+        ]);
+
+        $bar = new ToolbarService($this->events, []);
+        $bar->loadPanels();
+        $row = $bar->saveData($request, $response);
+        $this->assertEmpty($row);
+
+        ConnectionManager::setConfig('test_debug_kit', $restore);
+    }
+
+    /**
      * Test injectScripts()
      *
      * @return void

--- a/tests/TestCase/View/Helper/ToolbarHelperTest.php
+++ b/tests/TestCase/View/Helper/ToolbarHelperTest.php
@@ -92,7 +92,7 @@ class ToolbarHelperTest extends TestCase
         $restore = Debugger::configInstance('exportFormatter');
         Debugger::configInstance('exportFormatter', TextFormatter::class);
         $result = $this->Toolbar->dump(false);
-        $this->assertRegExp('/<\w/', $result, 'Contains HTML tags.');
+        $this->assertMatchesRegularExpression('/<\w/', $result, 'Contains HTML tags.');
         $this->assertSame(
             TextFormatter::class,
             Debugger::configInstance('exportFormatter'),


### PR DESCRIPTION
When the host application doesn't have SQLite installed failing to save the toolbar data should not cause the page to 500. Instead we can log the error and not end up showing the toolbar iframe as there is not Request persisted.

Refs cakephp/cakephp#15492