### PR TITLE
Update composer requirement to allow 1.x or 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "cakephp/cakephp": "^3.7.0",
         "cakephp/chronos": "^1.0.0",
         "cakephp/plugin-installer": "^1.0.0",
-        "composer/composer": "^1.3.0",
+        "composer/composer": "^1.3 | ^2.0",
         "jdorn/sql-formatter": "^1.2.0"
     },
     "require-dev": {


### PR DESCRIPTION
Update composer requirement to allow 1.x or 2.x. 
This change is a backport of #786 to debug_kit:3.x branch.