### PR TITLE
Show Toolbar on Dashboard - Reload Request History

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -16,6 +16,10 @@ Router::plugin('DebugKit', ['path' => '/debug-kit'], function (RouteBuilder $rou
         ['controller' => 'Requests', 'action' => 'view']
     );
     $routes->connect(
+        '/panels/view/latest-history',
+        ['controller' => 'Panels', 'action' => 'latestHistory']
+    );
+    $routes->connect(
         '/panels/view/*',
         ['controller' => 'Panels', 'action' => 'view']
     );

--- a/src/Controller/PanelsController.php
+++ b/src/Controller/PanelsController.php
@@ -104,7 +104,7 @@ class PanelsController extends DebugKitController
             ->disableHydration()
             ->first();
         if (!$request) {
-            throw new NotFoundException();
+            throw new NotFoundException('No requests found');
         }
         /** @var array{id:string}|null $historyPanel */
         $historyPanel = $this->Panels->find('byRequest', ['requestId' => $request['id']])
@@ -112,7 +112,7 @@ class PanelsController extends DebugKitController
             ->select(['id'])
             ->first();
         if (!$historyPanel) {
-            throw new NotFoundException();
+            throw new NotFoundException('History Panel from latest request not found');
         }
 
         return $this->redirect([

--- a/src/Controller/PanelsController.php
+++ b/src/Controller/PanelsController.php
@@ -83,11 +83,7 @@ class PanelsController extends DebugKitController
     public function view($id = null)
     {
         $this->set('sort', $this->request->getCookie('debugKit_sort'));
-        $panel = $this->Panels->get($id);
-        if ($panel->title === 'History') {
-            $request = $this->Panels->Requests->get($panel->request_id);
-            $this->set('currentRequest', $request);
-        }
+        $panel = $this->Panels->get($id, ['contain' => ['Requests']]);
 
         $this->set('panel', $panel);
         // @codingStandardsIgnoreStart
@@ -121,9 +117,6 @@ class PanelsController extends DebugKitController
 
         return $this->redirect([
             'action' => 'view', $historyPanel['id'],
-            '?' => [
-                'include-request' => 1,
-            ],
         ]);
     }
 }

--- a/src/Controller/PanelsController.php
+++ b/src/Controller/PanelsController.php
@@ -108,7 +108,7 @@ class PanelsController extends DebugKitController
         }
         /** @var array{id:string}|null $historyPanel */
         $historyPanel = $this->Panels->find('byRequest', ['requestId' => $request['id']])
-            ->where(['Panel' => 'History'])
+            ->where(['title' => 'History'])
             ->select(['id'])
             ->first();
         if (!$historyPanel) {

--- a/src/Controller/PanelsController.php
+++ b/src/Controller/PanelsController.php
@@ -84,6 +84,10 @@ class PanelsController extends DebugKitController
     {
         $this->set('sort', $this->request->getCookie('debugKit_sort'));
         $panel = $this->Panels->get($id);
+        if ($panel->title === 'History') {
+            $request = $this->Panels->Requests->get($panel->request_id);
+            $this->set('currentRequest', $request);
+        }
 
         $this->set('panel', $panel);
         // @codingStandardsIgnoreStart
@@ -117,6 +121,9 @@ class PanelsController extends DebugKitController
 
         return $this->redirect([
             'action' => 'view', $historyPanel['id'],
+            '?' => [
+                'include-request' => 1,
+            ],
         ]);
     }
 }

--- a/src/Controller/PanelsController.php
+++ b/src/Controller/PanelsController.php
@@ -90,4 +90,33 @@ class PanelsController extends DebugKitController
         $this->set(@unserialize($panel->content));
         // @codingStandardsIgnoreEnd
     }
+
+    /**
+     * Get Latest request history panel
+     *
+     * @return \Cake\Http\Response|null
+     */
+    public function latestHistory()
+    {
+        /** @var array{id:string}|null $request */
+        $request = $this->Panels->Requests->find('recent')
+            ->select(['id'])
+            ->disableHydration()
+            ->first();
+        if (!$request) {
+            throw new NotFoundException();
+        }
+        /** @var array{id:string}|null $historyPanel */
+        $historyPanel = $this->Panels->find('byRequest', ['requestId' => $request['id']])
+            ->where(['Panel' => 'History'])
+            ->select(['id'])
+            ->first();
+        if (!$historyPanel) {
+            throw new NotFoundException();
+        }
+
+        return $this->redirect([
+            'action' => 'view', $historyPanel['id'],
+        ]);
+    }
 }

--- a/src/Model/Entity/Panel.php
+++ b/src/Model/Entity/Panel.php
@@ -23,6 +23,8 @@ use Cake\ORM\Entity;
  * @property string $title
  * @property string $element
  * @property string $content
+ *
+ * @property \DebugKit\Model\Entity\Request $request
  */
 class Panel extends Entity
 {

--- a/src/Model/Table/PanelsTable.php
+++ b/src/Model/Table/PanelsTable.php
@@ -21,6 +21,7 @@ use Cake\ORM\Table;
  * The panels table collects the information for each panel on
  * each request.
  *
+ * @property \DebugKit\Model\Table\RequestsTable&\Cake\ORM\Association\BelongsTo $Requests
  * @method \DebugKit\Model\Entity\Panel get($primaryKey, $options = [])
  * @method \DebugKit\Model\Entity\Panel newEntity($data = null, array $options = [])
  * @method \DebugKit\Model\Entity\Panel[] newEntities(array $data, array $options = [])

--- a/src/ToolbarService.php
+++ b/src/ToolbarService.php
@@ -231,7 +231,7 @@ class ToolbarService
     public function saveData(ServerRequest $request, ResponseInterface $response)
     {
         $path = $request->getUri()->getPath();
-        $dashboardUrl = '/debug-kit/dashboard';
+        $dashboardUrl = '/debug-kit';
         if (strpos($path, 'debug_kit') !== false || strpos($path, 'debug-kit') !== false) {
             if (!($path === $dashboardUrl || $path === $dashboardUrl . '/')) {
                 // internal debug-kit request

--- a/src/ToolbarService.php
+++ b/src/ToolbarService.php
@@ -230,19 +230,23 @@ class ToolbarService
      */
     public function saveData(ServerRequest $request, ResponseInterface $response)
     {
-        $ignorePathsPattern = $this->getConfig('ignorePathsPattern');
         $path = $request->getUri()->getPath();
-        $statusCode = $response->getStatusCode();
+        $dashboardUrl = '/debug-kit/dashboard';
+        if (strpos($path, 'debug_kit') !== false || strpos($path, 'debug-kit') !== false) {
+            if (!($path === $dashboardUrl || $path === $dashboardUrl . '/')) {
+                // internal debug-kit request
+                return false;
+            }
+            // debug-kit dashboard, save request and show toolbar
+        }
 
+        $ignorePathsPattern = $this->getConfig('ignorePathsPattern');
+        $statusCode = $response->getStatusCode();
         if (
-            strpos($path, 'debug_kit') !== false ||
-            strpos($path, 'debug-kit') !== false ||
-            (
-                $ignorePathsPattern &&
-                $statusCode >= 200 &&
-                $statusCode <= 299 &&
-                preg_match($ignorePathsPattern, $path)
-            )
+            $ignorePathsPattern &&
+            $statusCode >= 200 &&
+            $statusCode <= 299 &&
+            preg_match($ignorePathsPattern, $path)
         ) {
             return false;
         }

--- a/templates/element/history_panel.php
+++ b/templates/element/history_panel.php
@@ -11,10 +11,10 @@
  * @since         DebugKit 1.1
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-
 /**
  * @var \DebugKit\View\AjaxView $this
  * @var \DebugKit\Model\Entity\Panel $panel
+ * @var \DebugKit\Model\Entity\Request $currentRequest
  * @var array $requests
  */
 ?>
@@ -31,11 +31,14 @@
     </p>
     <ul class="history-list">
         <li>
-            <?= $this->Html->link(
-                __d('debug_kit', 'Back to current request'),
-                ['plugin' => 'DebugKit', 'controller' => 'Panels', 'action' => 'index', $panel->request_id],
-                ['class' => 'history-link', 'data-request' => $panel->request_id]
-            ) ?>
+            <?php $url = ['plugin' => 'DebugKit', 'controller' => 'Panels', 'action' => 'index', $currentRequest->id] ?>
+            <a class="history-link" data-request="<?= $currentRequest->id ?>" href="<?= $this->Url->build($url) ?>">
+                <span class="history-time"><?= h($currentRequest->requested_at) ?></span>
+                <span class="history-bubble"><?= h($currentRequest->method) ?></span>
+                <span class="history-bubble"><?= h($currentRequest->status_code) ?></span>
+                <span class="history-bubble"><?= h($currentRequest->content_type) ?></span>
+                <span class="history-url"><?= h($currentRequest->url) ?></span>
+            </a>
         </li>
         <?php foreach ($requests as $request): ?>
             <?php $url = ['plugin' => 'DebugKit', 'controller' => 'Panels', 'action' => 'index', $request->id] ?>
@@ -53,13 +56,19 @@
 <?php endif; ?>
 </div>
 <script type="text/html" id="list-template">
+    <p>
+        <button type="button" onclick="toolbar.loadPanel('latest-history')"><?= __d('debug_kit', 'Reload') ?></button>
+    </p>
     <ul class="history-list">
         <li>
-            <?= $this->Html->link(
-                __d('debug_kit', 'Back to current request'),
-                ['plugin' => 'DebugKit', 'controller' => 'Panels', 'action' => 'index', $panel->request_id],
-                ['class' => 'history-link', 'data-request' => $panel->request_id]
-            ) ?>
+            <?php $url = ['plugin' => 'DebugKit', 'controller' => 'Panels', 'action' => 'index', $currentRequest->id] ?>
+            <a class="history-link" data-request="<?= $currentRequest->id ?>" href="<?= $this->Url->build($url) ?>">
+                <span class="history-time"><?= h($currentRequest->requested_at) ?></span>
+                <span class="history-bubble"><?= h($currentRequest->method) ?></span>
+                <span class="history-bubble"><?= h($currentRequest->status_code) ?></span>
+                <span class="history-bubble"><?= h($currentRequest->content_type) ?></span>
+                <span class="history-url"><?= h($currentRequest->url) ?></span>
+            </a>
         </li>
     </ul>
 </script>

--- a/templates/element/history_panel.php
+++ b/templates/element/history_panel.php
@@ -20,12 +20,12 @@
 <div id="request-history">
 <?php if (empty($requests)): ?>
     <p class="warning">
-        <?= __d('debug_kit', 'No previous requests logged.') ?>
+        <?= __d('debug_kit', 'No requests logged.') ?>
         <button type="button" onclick="toolbar.loadPanel('latest-history')"><?= __d('debug_kit', 'Reload') ?></button>
     </p>
 <?php else: ?>
     <p>
-        <?= count($requests) ?> <?= __d('debug_kit', 'previous requests available') ?>
+        <?= count($requests) ?> <?= __d('debug_kit', 'requests available') ?>
         <button type="button" onclick="toolbar.loadPanel('latest-history')"><?= __d('debug_kit', 'Reload') ?></button>
     </p>
     <ul class="history-list">

--- a/templates/element/history_panel.php
+++ b/templates/element/history_panel.php
@@ -20,9 +20,15 @@
 ?>
 <div id="request-history">
 <?php if (empty($requests)): ?>
-    <p class="warning"><?= __d('debug_kit', 'No previous requests logged.') ?></p>
+    <p class="warning">
+        <?= __d('debug_kit', 'No previous requests logged.') ?>
+        <button type="button" onclick="toolbar.loadPanel('latest-history')"><?= __d('debug_kit', 'Reload') ?></button>
+    </p>
 <?php else: ?>
-    <p><?= count($requests) ?> <?= __d('debug_kit', 'previous requests available') ?></p>
+    <p>
+        <?= count($requests) ?> <?= __d('debug_kit', 'previous requests available') ?>
+        <button type="button" onclick="toolbar.loadPanel('latest-history')"><?= __d('debug_kit', 'Reload') ?></button>
+    </p>
     <ul class="history-list">
         <li>
             <?= $this->Html->link(

--- a/templates/element/history_panel.php
+++ b/templates/element/history_panel.php
@@ -14,7 +14,6 @@
 /**
  * @var \DebugKit\View\AjaxView $this
  * @var \DebugKit\Model\Entity\Panel $panel
- * @var \DebugKit\Model\Entity\Request $currentRequest
  * @var array $requests
  */
 ?>
@@ -31,13 +30,13 @@
     </p>
     <ul class="history-list">
         <li>
-            <?php $url = ['plugin' => 'DebugKit', 'controller' => 'Panels', 'action' => 'index', $currentRequest->id] ?>
-            <a class="history-link" data-request="<?= $currentRequest->id ?>" href="<?= $this->Url->build($url) ?>">
-                <span class="history-time"><?= h($currentRequest->requested_at) ?></span>
-                <span class="history-bubble"><?= h($currentRequest->method) ?></span>
-                <span class="history-bubble"><?= h($currentRequest->status_code) ?></span>
-                <span class="history-bubble"><?= h($currentRequest->content_type) ?></span>
-                <span class="history-url"><?= h($currentRequest->url) ?></span>
+            <?php $url = ['plugin' => 'DebugKit', 'controller' => 'Panels', 'action' => 'index', $panel->request_id] ?>
+            <a class="history-link" data-request="<?= $panel->request_id ?>" href="<?= $this->Url->build($url) ?>">
+                <span class="history-time"><?= h($panel->request->requested_at) ?></span>
+                <span class="history-bubble"><?= h($panel->request->method) ?></span>
+                <span class="history-bubble"><?= h($panel->request->status_code) ?></span>
+                <span class="history-bubble"><?= h($panel->request->content_type) ?></span>
+                <span class="history-url"><?= h($panel->request->url) ?></span>
             </a>
         </li>
         <?php foreach ($requests as $request): ?>
@@ -61,13 +60,13 @@
     </p>
     <ul class="history-list">
         <li>
-            <?php $url = ['plugin' => 'DebugKit', 'controller' => 'Panels', 'action' => 'index', $currentRequest->id] ?>
-            <a class="history-link" data-request="<?= $currentRequest->id ?>" href="<?= $this->Url->build($url) ?>">
-                <span class="history-time"><?= h($currentRequest->requested_at) ?></span>
-                <span class="history-bubble"><?= h($currentRequest->method) ?></span>
-                <span class="history-bubble"><?= h($currentRequest->status_code) ?></span>
-                <span class="history-bubble"><?= h($currentRequest->content_type) ?></span>
-                <span class="history-url"><?= h($currentRequest->url) ?></span>
+            <?php $url = ['plugin' => 'DebugKit', 'controller' => 'Panels', 'action' => 'index', $panel->request_id] ?>
+            <a class="history-link" data-request="<?= $panel->request_id ?>" href="<?= $this->Url->build($url) ?>">
+                <span class="history-time"><?= h($panel->request->requested_at) ?></span>
+                <span class="history-bubble"><?= h($panel->request->method) ?></span>
+                <span class="history-bubble"><?= h($panel->request->status_code) ?></span>
+                <span class="history-bubble"><?= h($panel->request->content_type) ?></span>
+                <span class="history-url"><?= h($panel->request->url) ?></span>
             </a>
         </li>
     </ul>

--- a/tests/TestCase/Controller/PanelsControllerTest.php
+++ b/tests/TestCase/Controller/PanelsControllerTest.php
@@ -95,4 +95,21 @@ class PanelsControllerTest extends IntegrationTestCase
         $this->assertResponseError();
         $this->assertResponseContains('Error page');
     }
+
+    /**
+     * @return void
+     */
+    public function testLatestHistory()
+    {
+        $request = $this->makeRequest();
+        $panel = $this->makePanel($request, 'History');
+
+        $this->get('/debug-kit/panels/view/latest-history');
+        $this->assertRedirect([
+            'action' => 'view', $panel->id,
+            '?' => [
+                'include-request' => 1,
+            ],
+        ]);
+    }
 }

--- a/tests/TestCase/Controller/PanelsControllerTest.php
+++ b/tests/TestCase/Controller/PanelsControllerTest.php
@@ -107,9 +107,6 @@ class PanelsControllerTest extends IntegrationTestCase
         $this->get('/debug-kit/panels/view/latest-history');
         $this->assertRedirect([
             'action' => 'view', $panel->id,
-            '?' => [
-                'include-request' => 1,
-            ],
         ]);
     }
 }

--- a/tests/TestCase/Controller/PanelsControllerTest.php
+++ b/tests/TestCase/Controller/PanelsControllerTest.php
@@ -101,7 +101,10 @@ class PanelsControllerTest extends IntegrationTestCase
      */
     public function testLatestHistory()
     {
-        $request = $this->makeRequest();
+        $request = $this->getTableLocator()->get('DebugKit.Requests')->find('recent')->first();
+        if (!$request) {
+            $request = $this->makeRequest();
+        }
         $panel = $this->makePanel($request, 'DebugKit.History', 'History');
 
         $this->get('/debug-kit/panels/view/latest-history');

--- a/tests/TestCase/Controller/PanelsControllerTest.php
+++ b/tests/TestCase/Controller/PanelsControllerTest.php
@@ -102,7 +102,7 @@ class PanelsControllerTest extends IntegrationTestCase
     public function testLatestHistory()
     {
         $request = $this->makeRequest();
-        $panel = $this->makePanel($request, 'History');
+        $panel = $this->makePanel($request, 'DebugKit.History', 'History');
 
         $this->get('/debug-kit/panels/view/latest-history');
         $this->assertRedirect([

--- a/tests/TestCase/ToolbarServiceTest.php
+++ b/tests/TestCase/ToolbarServiceTest.php
@@ -162,6 +162,19 @@ class ToolbarServiceTest extends TestCase
 
         $bar = new ToolbarService($this->events, []);
         $this->assertFalse($bar->saveData($request, $response));
+
+        $request = new Request([
+            'url' => '/debug-kit',
+            'params' => [],
+        ]);
+        $response = new Response([
+            'statusCode' => 200,
+            'type' => 'text/html',
+            'body' => '<html><title>test</title><body><p>some text</p></body>',
+        ]);
+
+        $bar = new ToolbarService($this->events, []);
+        $this->assertNotEmpty($bar->saveData($request, $response));
     }
 
     /**


### PR DESCRIPTION
Closes #834

With the added Reload button, the "back to current request" will never be the same. Should I add some logic to keep the request id ?

Also, any hint about how should I test this will be appreciated