### PR TITLE
add ability to change variables panel max depth via config + add notice in panel

### DIFF
--- a/src/Panel/VariablesPanel.php
+++ b/src/Panel/VariablesPanel.php
@@ -92,7 +92,7 @@ class VariablesPanel extends DebugPanel
         $errors = [];
         $content = [];
         $vars = $controller->viewBuilder()->getVars();
-        $varsMaxDepth = (int)Configure::read('DebugKit.variablesPanelMaxDepth') ?: 5;
+        $varsMaxDepth = (int)Configure::read('DebugKit.variablesPanelMaxDepth', 5);
 
         foreach ($vars as $k => $v) {
             // Get the validation errors for Entity

--- a/src/Panel/VariablesPanel.php
+++ b/src/Panel/VariablesPanel.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 namespace DebugKit\Panel;
 
+use Cake\Core\Configure;
 use Cake\Datasource\EntityInterface;
 use Cake\Error\Debugger;
 use Cake\Event\EventInterface;
@@ -91,6 +92,7 @@ class VariablesPanel extends DebugPanel
         $errors = [];
         $content = [];
         $vars = $controller->viewBuilder()->getVars();
+        $varsMaxDepth = (int)Configure::read('DebugKit.variablesPanelMaxDepth') ?: 5;
 
         foreach ($vars as $k => $v) {
             // Get the validation errors for Entity
@@ -102,12 +104,13 @@ class VariablesPanel extends DebugPanel
                     $errors[$k] = $formErrors;
                 }
             }
-            $content[$k] = Debugger::exportVarAsNodes($v, 5);
+            $content[$k] = Debugger::exportVarAsNodes($v, $varsMaxDepth);
         }
 
         $this->_data = [
             'variables' => $content,
             'errors' => $errors,
+            'varsMaxDepth' => $varsMaxDepth,
         ];
     }
 

--- a/templates/element/variables_panel.php
+++ b/templates/element/variables_panel.php
@@ -24,7 +24,7 @@ if (isset($error)) :
     printf('<p class="warning">%s</p>', $error);
 endif;
 
-if(isset($varsMaxDepth)){
+if (isset($varsMaxDepth)) {
     printf('<p class="info">%s</p>', sprintf(__d('debug_kit', 'This view does not show very deep associations! Currently %s levels are being shown. You can overwrite this via the config key %s'), $varsMaxDepth, '<strong>DebugKit.variablesPanelMaxDepth</strong>'));
 }
 

--- a/templates/element/variables_panel.php
+++ b/templates/element/variables_panel.php
@@ -25,7 +25,7 @@ if (isset($error)) :
 endif;
 
 if (isset($varsMaxDepth)) {
-    $msg = sprintf(__d('debug_kit', '%s levels visible. You can overwrite this via the config key'), $varsMaxDepth);
+    $msg = sprintf(__d('debug_kit', '%s levels of nested arrays shown. Overwrite this via the config key'), $varsMaxDepth);
     $msg .= ' <strong>DebugKit.variablesPanelMaxDepth</strong>';
     $msg .= ' | Be aware that increasing the level depth can lead to an out of memory error.';
     printf('<p class="info">%s</p>', $msg);

--- a/templates/element/variables_panel.php
+++ b/templates/element/variables_panel.php
@@ -25,9 +25,10 @@ if (isset($error)) :
 endif;
 
 if (isset($varsMaxDepth)) {
-    $msg = sprintf(__d('debug_kit', '%s levels of nested arrays shown. Overwrite this via the config key'), $varsMaxDepth);
+    $msg = sprintf(__d('debug_kit', '%s levels of nested arrays shown.'), $varsMaxDepth);
+    $msg .= __d('debug_kit', 'You can overwrite this via the config key');
     $msg .= ' <strong>DebugKit.variablesPanelMaxDepth</strong>';
-    $msg .= ' | Be aware that increasing the level depth can lead to an out of memory error.';
+    $msg .= __d('debug_kit',' | Be aware that increasing the level depth can lead to an out of memory error.');
     printf('<p class="info">%s</p>', $msg);
 }
 

--- a/templates/element/variables_panel.php
+++ b/templates/element/variables_panel.php
@@ -25,7 +25,7 @@ if (isset($error)) :
 endif;
 
 if (isset($varsMaxDepth)) {
-    $msg = sprintf(__d('debug_kit', '%s levels of nested arrays shown.'), $varsMaxDepth);
+    $msg = sprintf(__d('debug_kit', '%s levels of nested data shown.'), $varsMaxDepth);
     $msg .= __d('debug_kit', 'You can overwrite this via the config key');
     $msg .= ' <strong>DebugKit.variablesPanelMaxDepth</strong>';
     $msg .= __d('debug_kit', ' | Be aware that increasing the level depth can lead to an out of memory error.');

--- a/templates/element/variables_panel.php
+++ b/templates/element/variables_panel.php
@@ -28,7 +28,7 @@ if (isset($varsMaxDepth)) {
     $msg = sprintf(__d('debug_kit', '%s levels of nested arrays shown.'), $varsMaxDepth);
     $msg .= __d('debug_kit', 'You can overwrite this via the config key');
     $msg .= ' <strong>DebugKit.variablesPanelMaxDepth</strong>';
-    $msg .= __d('debug_kit',' | Be aware that increasing the level depth can lead to an out of memory error.');
+    $msg .= __d('debug_kit', ' | Be aware that increasing the level depth can lead to an out of memory error.');
     printf('<p class="info">%s</p>', $msg);
 }
 

--- a/templates/element/variables_panel.php
+++ b/templates/element/variables_panel.php
@@ -25,7 +25,8 @@ if (isset($error)) :
 endif;
 
 if (isset($varsMaxDepth)) {
-    $msg = sprintf(__d('debug_kit', 'Currently %s levels are being shown. You can overwrite this via the config key %s'), $varsMaxDepth, '<strong>DebugKit.variablesPanelMaxDepth</strong>');
+    $msg = sprintf(__d('debug_kit', '%s levels visible. You can overwrite this via the config key'), $varsMaxDepth);
+    $msg .= ' <strong>DebugKit.variablesPanelMaxDepth</strong>';
     $msg .= ' | Be aware that increasing the level depth can lead to an out of memory error.';
     printf('<p class="info">%s</p>', $msg);
 }

--- a/templates/element/variables_panel.php
+++ b/templates/element/variables_panel.php
@@ -28,7 +28,7 @@ if (isset($varsMaxDepth)) {
     $msg = sprintf(__d('debug_kit', '%s levels of nested arrays shown.'), $varsMaxDepth);
     $msg .= __d('debug_kit', 'You can overwrite this via the config key');
     $msg .= ' <strong>DebugKit.variablesPanelMaxDepth</strong>';
-    $msg .= __d('debug_kit', ' | Be aware that increasing the level depth can lead to an out of memory error.');
+    $msg .= __d('debug_kit', ' | Increasing the depth value can lead to an out of memory error.');
     printf('<p class="info">%s</p>', $msg);
 }
 

--- a/templates/element/variables_panel.php
+++ b/templates/element/variables_panel.php
@@ -25,7 +25,9 @@ if (isset($error)) :
 endif;
 
 if (isset($varsMaxDepth)) {
-    printf('<p class="info">%s</p>', sprintf(__d('debug_kit', 'This view does not show very deep associations! Currently %s levels are being shown. You can overwrite this via the config key %s'), $varsMaxDepth, '<strong>DebugKit.variablesPanelMaxDepth</strong>'));
+    $msg = sprintf(__d('debug_kit', 'Currently %s levels are being shown. You can overwrite this via the config key %s'), $varsMaxDepth, '<strong>DebugKit.variablesPanelMaxDepth</strong>');
+    $msg .= ' | Be aware that increasing the level depth can lead to an out of memory error.';
+    printf('<p class="info">%s</p>', $msg);
 }
 
 // Backwards compatibility for old debug kit data.

--- a/templates/element/variables_panel.php
+++ b/templates/element/variables_panel.php
@@ -26,9 +26,9 @@ endif;
 
 if (isset($varsMaxDepth)) {
     $msg = sprintf(__d('debug_kit', '%s levels of nested data shown.'), $varsMaxDepth);
-    $msg .= __d('debug_kit', 'You can overwrite this via the config key');
-    $msg .= ' <strong>DebugKit.variablesPanelMaxDepth</strong>';
-    $msg .= __d('debug_kit', ' | Increasing the depth value can lead to an out of memory error.');
+    $msg .= ' ' . __d('debug_kit', 'You can overwrite this via the config key');
+    $msg .= ' <strong>DebugKit.variablesPanelMaxDepth</strong><br>';
+    $msg .= __d('debug_kit', 'Increasing the depth value can lead to an out of memory error.');
     printf('<p class="info">%s</p>', $msg);
 }
 

--- a/templates/element/variables_panel.php
+++ b/templates/element/variables_panel.php
@@ -24,6 +24,10 @@ if (isset($error)) :
     printf('<p class="warning">%s</p>', $error);
 endif;
 
+if(isset($varsMaxDepth)){
+    printf('<p class="info">%s</p>', sprintf(__d('debug_kit', 'This view does not show very deep associations! Currently %s levels are being shown. You can overwrite this via the config key %s'), $varsMaxDepth, '<strong>DebugKit.variablesPanelMaxDepth</strong>'));
+}
+
 // Backwards compatibility for old debug kit data.
 if (!empty($content)) :
     printf('<label class="toggle-checkbox"><input type="checkbox" class="neat-array-sort"%s>%s</label>', $sort ? ' checked="checked"' : '', __d('debug_kit', 'Sort variables by name'));

--- a/webroot/css/toolbar.css
+++ b/webroot/css/toolbar.css
@@ -451,7 +451,8 @@ pre,
  */
 .warning,
 .info {
-	padding: 10px 10px 10px 20px;
+    position: relative;
+	padding: 10px 10px 10px 50px;
 	font-size: 14px;
 }
 
@@ -477,8 +478,10 @@ pre,
 	text-align: center;
 	vertical-align: middle;
 	display: inline-block;
-	position: relative;
-	left: -11px;
+	position: absolute;
+	left: 10px;
+    top: 50%;
+    transform: translate(0, -50%);
 
 	background-color: #fff;
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9105243/143718773-041cbd21-c5a9-4bb5-bc58-f8e5b5584ee7.png)

Someone recently in the Slack support channel thought that his associations were not working.

After some time we found out, that he only looked into the variables panel of the debug kit but never outputted his variable via e.g. `pr()` or `var_dump()`.

He was just expecting that the variables tab shows all available data (including theoretically infinite associations) which is not the case.

But the panel doesn't inform users about that limitation. Also this limitation was "hardcoded" in the plugin and therefore couldn't be increased (if e.g. one has more resources available and really needs it)

Therefore this PR

* adds the ability to overwrite the default 5 levels of depth via the Config key `DebugKit.variablesPanelMaxDepth` and
* adds a notice in the variables tab to show the current amount of max levels + how the user can overwrite it if he wants to