### PR TITLE
add ability to filter plugin routes in routes tab

### DIFF
--- a/templates/element/routes_panel.php
+++ b/templates/element/routes_panel.php
@@ -33,10 +33,13 @@ foreach (CorePlugin::loaded() as $plugin_name) {
 ?>
 <div class="debugkit-plugin-routes-button-wrapper">
     <button type="button" class="btn-primary js-debugkit-toggle-plugin-route" data-plugin=".route-entry--app">
-        <?= __d('debug_kit', 'App') ?><?= (!empty($amount_of_routes_per_group['app'])) ? ' (' . $amount_of_routes_per_group['app'] . ')' : '' ?>
+        <?= __d('debug_kit', 'App') ?>
+        <?= (!empty($amount_of_routes_per_group['app'])) ? ' (' . $amount_of_routes_per_group['app'] . ')' : '' ?>
     </button>
     <?php foreach($plugin_names as $plugin_name => $parsed_name): ?>
-        <button type="button" class="btn-primary js-debugkit-toggle-plugin-route<?= (strpos($plugin_name, 'DebugKit') === 0) ? ' is-active' : '' ?>" data-plugin=".route-entry--plugin-<?= $parsed_name ?>">
+        <button type="button" class="btn-primary js-debugkit-toggle-plugin-route
+            <?= (strpos($plugin_name, 'DebugKit') === 0) ? ' is-active' : '' ?>"
+            data-plugin=".route-entry--plugin-<?= $parsed_name ?>">
             <?= $plugin_name ?>
         </button>
     <?php endforeach; ?>
@@ -56,7 +59,8 @@ foreach (CorePlugin::loaded() as $plugin_name) {
         if (empty($route->defaults['plugin'])):
             $class = 'route-entry route-entry--app';
         else:
-            $class = 'route-entry route-entry--plugin route-entry--plugin-' . preg_replace('/\W+/','',strtolower($route->defaults['plugin']));
+            $class = 'route-entry route-entry--plugin route-entry--plugin-' .
+                preg_replace('/\W+/','',strtolower($route->defaults['plugin']));
 
             // Hide DebugKit internal routes by default
             if($route->defaults['plugin'] === 'DebugKit') $class .= ' hidden';

--- a/templates/element/routes_panel.php
+++ b/templates/element/routes_panel.php
@@ -6,6 +6,7 @@
 
 use Cake\Core\Plugin as CorePlugin;
 use Cake\Utility\Hash;
+use Cake\Utility\Text;
 
 $routes = Cake\Routing\Router::routes();
 
@@ -22,7 +23,7 @@ $pluginNames = [];
 foreach (CorePlugin::loaded() as $pluginName) {
     if (!empty($amountOfRoutesPerGroup[$pluginName])) {
         $name = sprintf('%s (%s)', $pluginName, $amountOfRoutesPerGroup[$pluginName]);
-        $pluginNames[$name] = preg_replace('/\W+/', '', strtolower($pluginName));
+        $pluginNames[$name] = Text::slug($pluginName);
     }
 }
 
@@ -56,7 +57,7 @@ foreach (CorePlugin::loaded() as $pluginName) {
             $class = 'route-entry route-entry--app';
         else :
             $class = 'route-entry route-entry--plugin route-entry--plugin-' .
-                preg_replace('/\W+/', '', strtolower($route->defaults['plugin']));
+                Text::slug($route->defaults['plugin']);
 
             // Hide DebugKit internal routes by default
             if ($route->defaults['plugin'] === 'DebugKit') {

--- a/templates/element/routes_panel.php
+++ b/templates/element/routes_panel.php
@@ -33,7 +33,7 @@ foreach (CorePlugin::loaded() as $plugin_name) {
 ?>
 <div class="debugkit-plugin-routes-button-wrapper">
     <button type="button" class="btn-primary js-debugkit-toggle-plugin-route" data-plugin=".route-entry--app">
-        <?= __d('debug_kit', 'App') ?><?= (!empty($amount_of_routes_per_group['app'])) ? '(' . $amount_of_routes_per_group['app'] . ')' : '' ?>
+        <?= __d('debug_kit', 'App') ?><?= (!empty($amount_of_routes_per_group['app'])) ? ' (' . $amount_of_routes_per_group['app'] . ')' : '' ?>
     </button>
     <?php foreach($plugin_names as $plugin_name => $parsed_name): ?>
         <button type="button" class="btn-primary js-debugkit-toggle-plugin-route<?= (strpos($plugin_name, 'DebugKit') === 0) ? ' is-active' : '' ?>" data-plugin=".route-entry--plugin-<?= $parsed_name ?>">

--- a/templates/element/routes_panel.php
+++ b/templates/element/routes_panel.php
@@ -11,17 +11,11 @@ $routes = Cake\Routing\Router::routes();
 
 $amountOfRoutesPerGroup = [];
 foreach ($routes as $route) {
-    if (empty($route->defaults['plugin'])) {
-        if (!array_key_exists('app', $amountOfRoutesPerGroup)) {
-            $amountOfRoutesPerGroup['app'] = 0;
-        }
-        $amountOfRoutesPerGroup['app']++;
-    } else {
-        if (!array_key_exists($route->defaults['plugin'], $amountOfRoutesPerGroup)) {
-            $amountOfRoutesPerGroup[$route->defaults['plugin']] = 0;
-        }
-        $amountOfRoutesPerGroup[$route->defaults['plugin']]++;
+    $group = $route->defaults['plugin'] ?? 'app';
+    if (!array_key_exists($group, $amountOfRoutesPerGroup)) {
+        $amountOfRoutesPerGroup[$group] = 0;
     }
+    $amountOfRoutesPerGroup[$group]++;
 }
 
 $pluginNames = [];

--- a/templates/element/routes_panel.php
+++ b/templates/element/routes_panel.php
@@ -26,7 +26,7 @@ foreach ($routes as $route) {
 
 $pluginNames = [];
 foreach (CorePlugin::loaded() as $pluginName) {
-    if (!empty( $amountOfRoutesPerGroup[$pluginName])) {
+    if (!empty($amountOfRoutesPerGroup[$pluginName])) {
         $name = sprintf('%s (%s)', $pluginName, $amountOfRoutesPerGroup[$pluginName]);
         $pluginNames[$name] = preg_replace('/\W+/', '', strtolower($pluginName));
     }

--- a/templates/element/routes_panel.php
+++ b/templates/element/routes_panel.php
@@ -24,11 +24,11 @@ foreach ($routes as $route) {
     }
 }
 
-$plugin_names = [];
-foreach (CorePlugin::loaded() as $plugin_name) {
-    if (!empty($amountOfRoutesPerGroup[$plugin_name])) {
-        $name = sprintf('%s (%s)', $plugin_name, $amountOfRoutesPerGroup[$plugin_name]);
-        $plugin_names[$name] = preg_replace('/\W+/', '', strtolower($plugin_name));
+$pluginNames = [];
+foreach (CorePlugin::loaded() as $pluginName) {
+    if (!empty( $amountOfRoutesPerGroup[$pluginName])) {
+        $name = sprintf('%s (%s)', $pluginName, $amountOfRoutesPerGroup[$pluginName]);
+        $pluginNames[$name] = preg_replace('/\W+/', '', strtolower($pluginName));
     }
 }
 
@@ -38,11 +38,11 @@ foreach (CorePlugin::loaded() as $plugin_name) {
         <?= __d('debug_kit', 'App') ?>
         <?= !empty($amountOfRoutesPerGroup['app']) ? ' (' . $amountOfRoutesPerGroup['app'] . ')' : '' ?>
     </button>
-    <?php foreach ($plugin_names as $plugin_name => $parsed_name) : ?>
+    <?php foreach ($pluginNames as $pluginName => $parsedName) : ?>
         <button type="button" class="btn-primary js-debugkit-toggle-plugin-route
-            <?= strpos($plugin_name, 'DebugKit') === 0 ? ' is-active' : '' ?>"
-            data-plugin=".route-entry--plugin-<?= $parsed_name ?>">
-            <?= $plugin_name ?>
+            <?= strpos($pluginName, 'DebugKit') === 0 ? ' is-active' : '' ?>"
+                data-plugin=".route-entry--plugin-<?= $parsedName ?>">
+            <?= $pluginName ?>
         </button>
     <?php endforeach; ?>
 </div>

--- a/templates/element/routes_panel.php
+++ b/templates/element/routes_panel.php
@@ -10,12 +10,14 @@ use Cake\Utility\Hash;
 $routes = Cake\Routing\Router::routes();
 
 $amount_of_routes_per_group = [];
-foreach($routes as $route){
-    if(empty($route->defaults['plugin'])) {
-        if(!array_key_exists('app', $amount_of_routes_per_group)) $amount_of_routes_per_group['app'] = 0;
+foreach ($routes as $route) {
+    if (empty($route->defaults['plugin'])) {
+        if (!array_key_exists('app', $amount_of_routes_per_group)) {
+            $amount_of_routes_per_group['app'] = 0;
+        }
         $amount_of_routes_per_group['app']++;
     } else {
-        if(!array_key_exists($route->defaults['plugin'], $amount_of_routes_per_group)) {
+        if (!array_key_exists($route->defaults['plugin'], $amount_of_routes_per_group)) {
             $amount_of_routes_per_group[$route->defaults['plugin']] = 0;
         }
         $amount_of_routes_per_group[$route->defaults['plugin']]++;
@@ -24,19 +26,19 @@ foreach($routes as $route){
 
 $plugin_names = [];
 foreach (CorePlugin::loaded() as $plugin_name) {
-    if(!empty($amount_of_routes_per_group[$plugin_name])){
+    if (!empty($amount_of_routes_per_group[$plugin_name])) {
         $name = sprintf('%s (%s)', $plugin_name, $amount_of_routes_per_group[$plugin_name]);
-        $plugin_names[$name] = preg_replace('/\W+/','',strtolower($plugin_name));
+        $plugin_names[$name] = preg_replace('/\W+/', '', strtolower($plugin_name));
     }
 }
 
 ?>
 <div class="debugkit-plugin-routes-button-wrapper">
     <button type="button" class="btn-primary js-debugkit-toggle-plugin-route" data-plugin=".route-entry--app">
-        <?= __d('debug_kit', 'App') ?><?= (!empty($amount_of_routes_per_group['app'])) ? ' (' . $amount_of_routes_per_group['app'] . ')' : '' ?>
+        <?= __d('debug_kit', 'App') ?><?= !empty($amount_of_routes_per_group['app']) ? ' (' . $amount_of_routes_per_group['app'] . ')' : '' ?>
     </button>
-    <?php foreach($plugin_names as $plugin_name => $parsed_name): ?>
-        <button type="button" class="btn-primary js-debugkit-toggle-plugin-route<?= (strpos($plugin_name, 'DebugKit') === 0) ? ' is-active' : '' ?>" data-plugin=".route-entry--plugin-<?= $parsed_name ?>">
+    <?php foreach ($plugin_names as $plugin_name => $parsed_name) : ?>
+        <button type="button" class="btn-primary js-debugkit-toggle-plugin-route<?= strpos($plugin_name, 'DebugKit') === 0 ? ' is-active' : '' ?>" data-plugin=".route-entry--plugin-<?= $parsed_name ?>">
             <?= $plugin_name ?>
         </button>
     <?php endforeach; ?>
@@ -50,20 +52,24 @@ foreach (CorePlugin::loaded() as $plugin_name) {
     </tr>
     </thead>
     <tbody>
-    <?php foreach ($routes as $route): ?>
+    <?php foreach ($routes as $route) : ?>
         <?php
         $class = '';
-        if (empty($route->defaults['plugin'])):
+        if (empty($route->defaults['plugin'])) :
             $class = 'route-entry route-entry--app';
-        else:
-            $class = 'route-entry route-entry--plugin route-entry--plugin-' . preg_replace('/\W+/','',strtolower($route->defaults['plugin']));
+        else :
+            $class = 'route-entry route-entry--plugin route-entry--plugin-' . preg_replace('/\W+/', '', strtolower($route->defaults['plugin']));
 
             // Hide DebugKit internal routes by default
-            if($route->defaults['plugin'] === 'DebugKit') $class .= ' hidden';
+            if ($route->defaults['plugin'] === 'DebugKit') {
+                $class .= ' hidden';
+            }
         endif;
 
         // Highlight current route
-        if ($matchedRoute === $route->template) $class .= ' highlighted';
+        if ($matchedRoute === $route->template) {
+            $class .= ' highlighted';
+        }
 
         ?>
         <tr class="<?= $class ?>">

--- a/templates/element/routes_panel.php
+++ b/templates/element/routes_panel.php
@@ -3,13 +3,44 @@
  * @var \Cake\Routing\Route\Route[] $routes
  * @var string $matchedRoute
  */
+
+use Cake\Core\Plugin as CorePlugin;
 use Cake\Utility\Hash;
 
 $routes = Cake\Routing\Router::routes();
+
+$amount_of_routes_per_group = [];
+foreach($routes as $route){
+    if(empty($route->defaults['plugin'])) {
+        if(!array_key_exists('app', $amount_of_routes_per_group)) $amount_of_routes_per_group['app'] = 0;
+        $amount_of_routes_per_group['app']++;
+    } else {
+        if(!array_key_exists($route->defaults['plugin'], $amount_of_routes_per_group)) {
+            $amount_of_routes_per_group[$route->defaults['plugin']] = 0;
+        }
+        $amount_of_routes_per_group[$route->defaults['plugin']]++;
+    }
+}
+
+$plugin_names = [];
+foreach (CorePlugin::loaded() as $plugin_name) {
+    if(!empty($amount_of_routes_per_group[$plugin_name])){
+        $name = sprintf('%s (%s)', $plugin_name, $amount_of_routes_per_group[$plugin_name]);
+        $plugin_names[$name] = preg_replace('/\W+/','',strtolower($plugin_name));
+    }
+}
+
 ?>
-<button type="button" class="btn-primary" id="toggle-debugkit-routes">
-    <?= __d('debug_kit', 'Toggle debugkit internal routes') ?>
-</button>
+<div class="debugkit-plugin-routes-button-wrapper">
+    <button type="button" class="btn-primary js-debugkit-toggle-plugin-route" data-plugin=".route-entry--app">
+        <?= __d('debug_kit', 'App') ?><?= (!empty($amount_of_routes_per_group['app'])) ? '(' . $amount_of_routes_per_group['app'] . ')' : '' ?>
+    </button>
+    <?php foreach($plugin_names as $plugin_name => $parsed_name): ?>
+        <button type="button" class="btn-primary js-debugkit-toggle-plugin-route<?= (strpos($plugin_name, 'DebugKit') === 0) ? ' is-active' : '' ?>" data-plugin=".route-entry--plugin-<?= $parsed_name ?>">
+            <?= $plugin_name ?>
+        </button>
+    <?php endforeach; ?>
+</div>
 <table cellspacing="0" cellpadding="0" class="debug-table">
     <thead>
     <tr>
@@ -20,13 +51,20 @@ $routes = Cake\Routing\Router::routes();
     </thead>
     <tbody>
     <?php foreach ($routes as $route): ?>
-        <?php 
+        <?php
         $class = '';
-        if ($matchedRoute === $route->template):
-            $class = 'highlighted';
-        elseif ($route->defaults['plugin'] === 'DebugKit'):
-            $class = 'debugkit-route hidden';
+        if (empty($route->defaults['plugin'])):
+            $class = 'route-entry route-entry--app';
+        else:
+            $class = 'route-entry route-entry--plugin route-entry--plugin-' . preg_replace('/\W+/','',strtolower($route->defaults['plugin']));
+
+            // Hide DebugKit internal routes by default
+            if($route->defaults['plugin'] === 'DebugKit') $class .= ' hidden';
         endif;
+
+        // Highlight current route
+        if ($matchedRoute === $route->template) $class .= ' highlighted';
+
         ?>
         <tr class="<?= $class ?>">
             <td><?= h(Hash::get($route->options, '_name', $route->getName())) ?></td>
@@ -38,11 +76,25 @@ $routes = Cake\Routing\Router::routes();
 </table>
 
 <script>
-$(document).ready(function() {
-    $('#toggle-debugkit-routes').on('click', function (event) {
-        event.preventDefault();
-        var routes = $('.debugkit-route');
-        routes.toggleClass('hidden');
+    $(document).ready(function() {
+        $('#toggle-debugkit-routes').on('click', function (event) {
+            event.preventDefault();
+            var routes = $('.debugkit-route');
+            routes.toggleClass('hidden');
+        });
+
+        $('.js-debugkit-toggle-plugin-route').on('click', function (event) {
+            var $this = $(this);
+            var plugin = $this.attr('data-plugin');
+
+            if($this.hasClass('is-active')) {
+                $this.removeClass('is-active');
+                $('.route-entry' + plugin).removeClass('hidden');
+            } else {
+                $this.addClass('is-active');
+                $('.route-entry' + plugin).addClass('hidden');
+            }
+
+        });
     });
-});
 </script>

--- a/templates/element/routes_panel.php
+++ b/templates/element/routes_panel.php
@@ -34,7 +34,7 @@ foreach (CorePlugin::loaded() as $pluginName) {
     </button>
     <?php foreach ($pluginNames as $pluginName => $parsedName) : ?>
         <button type="button" class="btn-primary js-debugkit-toggle-plugin-route
-            <?= strpos($pluginName, 'DebugKit') === 0 ? ' is-active' : '' ?>"
+            <?= strpos($pluginName, 'DebugKit') === 0 ? ' toggle-plugin-route-active' : '' ?>"
                 data-plugin=".route-entry--plugin-<?= $parsedName ?>">
             <?= $pluginName ?>
         </button>
@@ -91,11 +91,11 @@ foreach (CorePlugin::loaded() as $pluginName) {
             var $this = $(this);
             var plugin = $this.attr('data-plugin');
 
-            if($this.hasClass('is-active')) {
-                $this.removeClass('is-active');
+            if($this.hasClass('toggle-plugin-route-active')) {
+                $this.removeClass('toggle-plugin-route-active');
                 $('.route-entry' + plugin).removeClass('hidden');
             } else {
-                $this.addClass('is-active');
+                $this.addClass('toggle-plugin-route-active');
                 $('.route-entry' + plugin).addClass('hidden');
             }
 

--- a/templates/element/routes_panel.php
+++ b/templates/element/routes_panel.php
@@ -26,7 +26,7 @@ foreach ($routes as $route) {
 
 $plugin_names = [];
 foreach (CorePlugin::loaded() as $plugin_name) {
-    if (!empty( $amountOfRoutesPerGroup[$plugin_name])) {
+    if (!empty($amountOfRoutesPerGroup[$plugin_name])) {
         $name = sprintf('%s (%s)', $plugin_name, $amountOfRoutesPerGroup[$plugin_name]);
         $plugin_names[$name] = preg_replace('/\W+/', '', strtolower($plugin_name));
     }
@@ -36,11 +36,11 @@ foreach (CorePlugin::loaded() as $plugin_name) {
 <div class="debugkit-plugin-routes-button-wrapper">
     <button type="button" class="btn-primary js-debugkit-toggle-plugin-route" data-plugin=".route-entry--app">
         <?= __d('debug_kit', 'App') ?>
-        <?= (!empty( $amountOfRoutesPerGroup['app'])) ? ' (' . $amountOfRoutesPerGroup['app'] . ')' : '' ?>
+        <?= !empty($amountOfRoutesPerGroup['app']) ? ' (' . $amountOfRoutesPerGroup['app'] . ')' : '' ?>
     </button>
     <?php foreach ($plugin_names as $plugin_name => $parsed_name) : ?>
         <button type="button" class="btn-primary js-debugkit-toggle-plugin-route
-            <?= (strpos($plugin_name, 'DebugKit') === 0) ? ' is-active' : '' ?>"
+            <?= strpos($plugin_name, 'DebugKit') === 0 ? ' is-active' : '' ?>"
             data-plugin=".route-entry--plugin-<?= $parsed_name ?>">
             <?= $plugin_name ?>
         </button>
@@ -62,7 +62,7 @@ foreach (CorePlugin::loaded() as $plugin_name) {
             $class = 'route-entry route-entry--app';
         else :
             $class = 'route-entry route-entry--plugin route-entry--plugin-' .
-                preg_replace('/\W+/','',strtolower($route->defaults['plugin']));
+                preg_replace('/\W+/', '', strtolower($route->defaults['plugin']));
 
             // Hide DebugKit internal routes by default
             if ($route->defaults['plugin'] === 'DebugKit') {

--- a/webroot/css/toolbar.css
+++ b/webroot/css/toolbar.css
@@ -512,9 +512,12 @@ pre,
   position: relative;
   top: 2px;
 }
-
 .btn-primary:hover {
   cursor:pointer;
+}
+.btn-primary.is-active {
+    background-color: #fff;
+    color: #2a6496;
 }
 
 #loader {
@@ -612,4 +615,15 @@ pre,
 
 .terminal .success-message {
   color: #42bd41;
+}
+
+.debugkit-plugin-routes-button-wrapper {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin: 0 -5px;
+}
+
+.debugkit-plugin-routes-button-wrapper button {
+    margin: 5px;
 }

--- a/webroot/css/toolbar.css
+++ b/webroot/css/toolbar.css
@@ -515,9 +515,9 @@ pre,
 .btn-primary:hover {
   cursor:pointer;
 }
-.btn-primary.is-active {
-    background-color: #fff;
-    color: #2a6496;
+.toggle-plugin-route-active {
+  background-color: #fff;
+  color: #2a6496;
 }
 
 #loader {
@@ -618,12 +618,12 @@ pre,
 }
 
 .debugkit-plugin-routes-button-wrapper {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    margin: 0 -5px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin: 0 -5px;
 }
 
 .debugkit-plugin-routes-button-wrapper button {
-    margin: 5px;
+  margin: 5px;
 }


### PR DESCRIPTION
![2021-12-11_17-20-51 (1)](https://user-images.githubusercontent.com/9105243/145683861-4cc8933a-4bee-4e49-b952-14a8c028712e.gif)

This PR refactors the routes tab in that sense that you are now able to filter routes per plugin.

Also you can see how many routes are loaded for that specific plugin next to the filter button.

Activating the button will **hide** the routes for that selected plugin.

The DebugKit routes are hidden by default as they have been before as well.

Fixes #850