### PR TITLE
highlight duplicate routes in routes panel

### DIFF
--- a/templates/element/routes_panel.php
+++ b/templates/element/routes_panel.php
@@ -10,13 +10,19 @@ use Cake\Utility\Text;
 
 $routes = Cake\Routing\Router::routes();
 
-$amountOfRoutesPerGroup = [];
+$amountOfRoutesPerGroup = $duplicateRoutes = [];
 foreach ($routes as $route) {
+    // Count the amount
     $group = $route->defaults['plugin'] ?? 'app';
     if (!array_key_exists($group, $amountOfRoutesPerGroup)) {
         $amountOfRoutesPerGroup[$group] = 0;
     }
     $amountOfRoutesPerGroup[$group]++;
+
+    if (!array_key_exists($route->template, $duplicateRoutes)) {
+        $duplicateRoutes[$route->template] = 0;
+    }
+    $duplicateRoutes[$route->template]++;
 }
 
 $pluginNames = [];
@@ -68,6 +74,11 @@ foreach (CorePlugin::loaded() as $pluginName) {
         // Highlight current route
         if ($matchedRoute === $route->template) {
             $class .= ' highlighted';
+        }
+
+        // Mark duplicate routes
+        if ($duplicateRoutes[$route->template] > 1) {
+            $class .= ' duplicate-route';
         }
 
         ?>

--- a/webroot/css/toolbar.css
+++ b/webroot/css/toolbar.css
@@ -630,16 +630,16 @@ pre,
 }
 
 .color-info-type {
-    display: flex;
     align-items: center;
+    display: flex;
 }
 
 .color-info-type:before {
     content: '';
     display: inline-block;
-    width: 20px;
     height: 20px;
     margin-right: 10px;
+    width: 20px;
 }
 
 .color-info-type--current-route:before {

--- a/webroot/css/toolbar.css
+++ b/webroot/css/toolbar.css
@@ -270,6 +270,9 @@ pre,
 .debug-table td.left {
     text-align: left;
 }
+.debug-table .duplicate-route td {
+    background: #ffea96;
+}
 .debug-table .highlighted td {
   background: #e7e9fd;
 }
@@ -624,4 +627,25 @@ pre,
   gap: 5px;
   flex-wrap: wrap;
   margin: 0 -5px;
+}
+
+.color-info-type {
+    display: flex;
+    align-items: center;
+}
+
+.color-info-type:before {
+    content: '';
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    margin-right: 10px;
+}
+
+.color-info-type--current-route:before {
+    background: #e7e9fd;
+}
+
+.color-info-type--duplicate-route:before {
+    background: #ffea96;
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9105243/146596763-4b36335c-c866-42a2-bda5-fd0fe92220cd.png)

This PR adds functionality which will show the user if duplicate route definitions are present.

In this example I didn't even notice till now that my custom tools plugin (AlfredTools) had a route collision with the tools plugin from dereuromark.

Due to the fact that there are now 2 colors representing either the *current route*  or a *duplicate route* I also added a little legend bellow the filter buttons to visualize that.

![image](https://user-images.githubusercontent.com/9105243/146597335-97ca4619-44f0-4346-b56e-3391c11c76ad.png)

As you see in this screenshot it doesn't affect the current route highlighting.