### PR TITLE
fix PHP8.0+ deprecation warning showing Cake/Core/functions.php as source of deprecation

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -95,13 +95,12 @@ class Plugin extends BasePlugin
             $previousHandler = set_error_handler(
                 function ($code, $message, $file, $line, $context = null) use (&$previousHandler) {
                     if ($code == E_USER_DEPRECATED || $code == E_DEPRECATED) {
-
                         // In PHP 8.0+ the $context variable has been removed from the set_error_handler callback
                         // Therefore we need to fetch the correct file and line string ourselves
                         if (version_compare(PHP_VERSION, '8.0.0') >= 0) {
                             $trace = debug_backtrace();
-                            foreach($trace as $idx => $traceEntry) {
-                                if($traceEntry['function'] !== 'trigger_error') {
+                            foreach ($trace as $idx => $traceEntry) {
+                                if ($traceEntry['function'] !== 'trigger_error') {
                                     continue;
                                 }
                                 $file = $trace[$idx + 2]['file'];

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -104,8 +104,8 @@ class Plugin extends BasePlugin
                                 if($traceEntry['function'] !== 'trigger_error') {
                                     continue;
                                 }
-                                $file = $trace[$idx + 1]['file'];
-                                $line = $trace[$idx + 1]['line'];
+                                $file = $trace[$idx + 2]['file'];
+                                $line = $trace[$idx + 2]['line'];
                                 break;
                             }
                         }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -97,7 +97,7 @@ class Plugin extends BasePlugin
                     if ($code == E_USER_DEPRECATED || $code == E_DEPRECATED) {
                         // In PHP 8.0+ the $context variable has been removed from the set_error_handler callback
                         // Therefore we need to fetch the correct file and line string ourselves
-                        if (version_compare(PHP_VERSION, '8.0.0') >= 0) {
+                        if (PHP_VERSION_ID >= 80000) {
                             $trace = debug_backtrace();
                             foreach ($trace as $idx => $traceEntry) {
                                 if ($traceEntry['function'] !== 'trigger_error') {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -95,6 +95,20 @@ class Plugin extends BasePlugin
             $previousHandler = set_error_handler(
                 function ($code, $message, $file, $line, $context = null) use (&$previousHandler) {
                     if ($code == E_USER_DEPRECATED || $code == E_DEPRECATED) {
+
+                        // In PHP 8.0+ the $context variable has been removed from the set_error_handler callback
+                        // Therefore we need to fetch the correct file and line string ourselves
+                        if (version_compare(PHP_VERSION, '8.0.0') >= 0) {
+                            $trace = debug_backtrace();
+                            foreach($trace as $idx => $traceEntry) {
+                                if($traceEntry['function'] !== 'trigger_error') {
+                                    continue;
+                                }
+                                $file = $trace[$idx + 1]['file'];
+                                $line = $trace[$idx + 1]['line'];
+                                break;
+                            }
+                        }
                         DeprecationsPanel::addDeprecatedError(compact('code', 'message', 'file', 'line', 'context'));
 
                         return;


### PR DESCRIPTION
Fixes #845 

With this PR the following deprecation warnings

![image](https://user-images.githubusercontent.com/9105243/146692959-ddb956e5-4960-48e5-918a-80d19799d9d5.png)

will transform into these deprecation warnings in PHP 8.0+

![image](https://user-images.githubusercontent.com/9105243/146692972-01ccf8e6-0a26-49d0-aa73-d339a4e284c9.png)

(I had to manually add a `deprecationWarning('Use LocatorAwareTrait::fetchTable() instead.');` into the `ModelAwareTrait::loadModel()` function since it currently has none, only a PHPDoc)

This of course also works inside custom plugins

![image](https://user-images.githubusercontent.com/9105243/146693178-525d45ea-f048-4c51-a606-cafcea1fde9e.png)

or vendor plugins

![image](https://user-images.githubusercontent.com/9105243/146693225-2499f165-e9b2-47f6-9f65-b54bc94ed90a.png)

In all 3 examples I added

```
    $test = $this->loadModel('StaffMembers');

    $test = new QueryExpression();
    $test->addCase([1], 2);
```

as some deprecation test methods.

Basically all I did was to get the current `debug_backtrace()`, iterate over it till I hit a `trigger_error` function, skip one item (it is the `deprecationWarning()` function) and fetch the next items `file` and `line` variables to overwrite the wrong ones coming from the `set_error_handler()` callback.

This is only needed in PHP >= 8.0 as far as I have seen.