### PR TITLE
fix deprecation line php8.0+

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -104,6 +104,7 @@ class Plugin extends BasePlugin
                                     continue;
                                 }
                                 $offset = 1;
+                                // ['args'][1] refers to index of $stackFrame argument in deprecationWarning()
                                 if (isset($traceEntry['args'][1])) {
                                     $offset = $traceEntry['args'][1];
                                 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -100,11 +100,15 @@ class Plugin extends BasePlugin
                         if (PHP_VERSION_ID >= 80000) {
                             $trace = debug_backtrace();
                             foreach ($trace as $idx => $traceEntry) {
-                                if ($traceEntry['function'] !== 'trigger_error') {
+                                if ($traceEntry['function'] !== 'deprecationWarning') {
                                     continue;
                                 }
-                                $file = $trace[$idx + 2]['file'];
-                                $line = $trace[$idx + 2]['line'];
+                                $offset = 1;
+                                if (isset($traceEntry['args'][1])) {
+                                    $offset = $traceEntry['args'][1];
+                                }
+                                $file = $trace[$idx + $offset]['file'];
+                                $line = $trace[$idx + $offset]['line'];
                                 break;
                             }
                         }

--- a/tests/TestCase/PluginTest.php
+++ b/tests/TestCase/PluginTest.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace DebugKit\Test\TestCase;
+
+use Cake\Event\Event;
+use Cake\Event\EventManager;
+use Cake\TestSuite\TestCase;
+use DebugKit\Panel\DeprecationsPanel;
+use DebugKit\Plugin;
+use DebugKit\ToolbarService;
+
+/**
+ * Test the Plugin
+ */
+class PluginTest extends TestCase
+{
+    /**
+     * Test setDeprecationHandler.
+     *
+     * @return void
+     */
+    public function testSetDeprecationHandler()
+    {
+        DeprecationsPanel::clearDeprecatedErrors();
+        $service = new ToolbarService(new EventManager(), []);
+        $plugin = new Plugin();
+        $plugin->setDeprecationHandler($service);
+        $event = new Event('');
+        $panel = new DeprecationsPanel();
+
+        //Without setting the $stackFrame
+        deprecationWarning('setDeprecationHandler');
+        //Setting the $stackFrame
+        deprecationWarning('setDeprecationHandler_2', 2);
+        //Raw error
+        $line = __LINE__ + 1;
+        trigger_error('raw_error', E_USER_DEPRECATED);
+
+        $panel->shutdown($event);
+        $data = $panel->data()['plugins']['DebugKit'];
+
+        $this->assertCount(3, $data);
+
+        //test first two deprecationWarning()
+        foreach ([$data[0], $data[1]] as $value) {
+            $this->assertStringContainsString($value['file'], $value['message']);
+            $this->assertStringContainsString("line: {$value['line']}", $value['message']);
+        }
+        //test raw error
+        $this->assertSame($line, $data[2]['line']);
+    }
+}


### PR DESCRIPTION
this lets us to use other value than `1` in second argument of `deprecationWarning()`
also checking `deprecationWarning` instead of `trigger_error` lets to works as before for deprecations that triggered out of  `deprecationWarning()`