### PR TITLE
Update deprecations panel to use new error handlers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.2', '8.0']
+        php-version: ['7.4', '8.0']
         db-type: [mysql, pgsql, sqlite]
         prefer-lowest: ['']
         include:
           - php-version: '8.1'
             db-type: 'sqlite'
-          - php-version: '7.2'
+          - php-version: '7.4'
             db-type: 'sqlite'
             prefer-lowest: 'prefer-lowest'
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": ">=7.2",
-        "cakephp/cakephp": "^4.3.0",
+        "cakephp/cakephp": "dev-4.next as 4.4.0",
         "cakephp/chronos": "^2.0",
         "composer/composer": "^1.3 | ^2.0",
         "jdorn/sql-formatter": "^1.2"
@@ -58,5 +58,10 @@
         "psalm": "psalm.phar --show-info=false",
         "psalm-setup": "cp composer.json composer.backup && composer require --dev psalm/phar:^4.10 && mv composer.backup composer.json"
     },
-    "prefer-stable": true
+    "prefer-stable": true,
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    }
 }

--- a/src/Panel/DeprecationsPanel.php
+++ b/src/Panel/DeprecationsPanel.php
@@ -59,10 +59,6 @@ class DeprecationsPanel extends DebugPanel
         foreach ($errors as $error) {
             $file = $error['file'];
             $line = $error['line'];
-            if (isset($error['context']['frame'])) {
-                $file = $error['context']['frame']['file'];
-                $line = $error['context']['frame']['line'];
-            }
 
             $errorData = [
                 'file' => $file,

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -93,7 +93,7 @@ class Plugin extends BasePlugin
     public function setDeprecationHandler($service)
     {
         if (!empty($service->getConfig('panels')['DebugKit.Deprecations'])) {
-            EventManager::instance()->on('Error.handled', function (EventInterface $event, PhpError $error) {
+            EventManager::instance()->on('Error.beforeRender', function (EventInterface $event, PhpError $error) {
                 $code = $error->getCode();
                 if ($code !== E_USER_DEPRECATED && $code !== E_DEPRECATED) {
                     return;
@@ -115,6 +115,7 @@ class Plugin extends BasePlugin
                     'file' => $file,
                     'line' => $line,
                 ]);
+                $event->stopPropagation();
             });
         }
     }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -19,6 +19,8 @@ use Cake\Console\CommandCollection;
 use Cake\Core\BasePlugin;
 use Cake\Core\Configure;
 use Cake\Core\PluginApplicationInterface;
+use Cake\Error\PhpError;
+use Cake\Event\EventInterface;
 use Cake\Event\EventManager;
 use Cake\Http\MiddlewareQueue;
 use DebugKit\Command\BenchmarkCommand;
@@ -50,7 +52,6 @@ class Plugin extends BasePlugin
         }
 
         $this->service = $service;
-
         $this->setDeprecationHandler($service);
 
         // will load `config/bootstrap.php`.
@@ -92,40 +93,29 @@ class Plugin extends BasePlugin
     public function setDeprecationHandler($service)
     {
         if (!empty($service->getConfig('panels')['DebugKit.Deprecations'])) {
-            $previousHandler = set_error_handler(
-                function ($code, $message, $file, $line, $context = null) use (&$previousHandler) {
-                    if ($code == E_USER_DEPRECATED || $code == E_DEPRECATED) {
-                        // In PHP 8.0+ the $context variable has been removed from the set_error_handler callback
-                        // Therefore we need to fetch the correct file and line string ourselves
-                        if (PHP_VERSION_ID >= 80000) {
-                            $trace = debug_backtrace();
-                            foreach ($trace as $idx => $traceEntry) {
-                                if ($traceEntry['function'] !== 'deprecationWarning') {
-                                    continue;
-                                }
-                                $offset = 1;
-                                // ['args'][1] refers to index of $stackFrame argument in deprecationWarning()
-                                if (isset($traceEntry['args'][1])) {
-                                    $offset = $traceEntry['args'][1];
-                                }
-                                $file = $trace[$idx + $offset]['file'];
-                                $line = $trace[$idx + $offset]['line'];
-                                break;
-                            }
-                        }
-                        DeprecationsPanel::addDeprecatedError(compact('code', 'message', 'file', 'line', 'context'));
-
-                        return;
-                    }
-                    if ($previousHandler) {
-                        $context['_trace_frame_offset'] = 1;
-
-                        return $previousHandler($code, $message, $file, $line, $context);
-                    }
-
-                    return false;
+            EventManager::instance()->on('Error.handled', function (EventInterface $event, PhpError $error) {
+                $code = $error->getCode();
+                if ($code !== E_USER_DEPRECATED && $code !== E_DEPRECATED) {
+                    return;
                 }
-            );
+                $file = $error->getFile();
+                $line = $error->getLine();
+
+                // Extract the line/file from the message as deprecationWarning
+                // will calculate the application frame when generating the message.
+                preg_match('/\\n([^\n,]+?), line: (\d+)\\n/', $error->getMessage(), $matches);
+                if ($matches) {
+                    $file = $matches[1];
+                    $line = $matches[2];
+                }
+
+                DeprecationsPanel::addDeprecatedError([
+                    'code' => $code,
+                    'message' => $error->getMessage(),
+                    'file' => $file,
+                    'line' => $line,
+                ]);
+            });
         }
     }
 }

--- a/tests/TestCase/PluginTest.php
+++ b/tests/TestCase/PluginTest.php
@@ -41,12 +41,12 @@ class PluginTest extends TestCase
         $panel = new DeprecationsPanel();
 
         $error = new PhpError(E_USER_WARNING, 'ignored', __FILE__, __LINE__, []);
-        $event = new Event('Error.handled', null, ['error' => $error]);
+        $event = new Event('Error.beforeRender', null, ['error' => $error]);
         EventManager::instance()->dispatch($event);
 
         // No file/line in message.
         $error = new PhpError(E_USER_DEPRECATED, 'going away', __FILE__, __LINE__, []);
-        $event = new Event('Error.handled', null, ['error' => $error]);
+        $event = new Event('Error.beforeRender', null, ['error' => $error]);
         EventManager::instance()->dispatch($event);
 
         // Formatted like deprecationWarning()
@@ -57,7 +57,7 @@ src/Plugin.php, line: 51
 You can disable all deprecation warnings by setting `Error.errorLevel` to `E_ALL & ~E_USER_DEPRECATED`.
 TEXT;
         $error = new PhpError(E_USER_DEPRECATED, $message, __FILE__, __LINE__, []);
-        $event = new Event('Error.handled', null, ['error' => $error]);
+        $event = new Event('Error.beforeRender', null, ['error' => $error]);
         EventManager::instance()->dispatch($event);
 
         $panel->shutdown($event);


### PR DESCRIPTION
Update deprecations panel to trap errors using the new events. Support for the old error handler is being dropped as it was awkward and didn't really work that well anymore.