### PR TITLE
fix middleware also being inserted in phpunit tests

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -33,7 +33,7 @@ use DebugKit\Panel\DeprecationsPanel;
 class Plugin extends BasePlugin
 {
     /**
-     * @var \DebugKit\ToolbarService
+     * @var \DebugKit\ToolbarService|null
      */
     protected $service;
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -66,7 +66,10 @@ class Plugin extends BasePlugin
      */
     public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
     {
-        $middlewareQueue->insertAt(0, new DebugKitMiddleware($this->service));
+        // Only insert middleware if Toolbar Service is available (not in phpunit run)
+        if ($this->service) {
+            $middlewareQueue->insertAt(0, new DebugKitMiddleware($this->service));
+        }
 
         return $middlewareQueue;
     }


### PR DESCRIPTION
fix #871

The ToolbarService is only available on a web request.
PHPUnit runs don't have a ToolbarService, therefore we shouldn't inject the DebugKitMiddleware on PHPUnit runs.