### PR TITLE
Update database schema generation to not rely on fixtures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "jdorn/sql-formatter": "^1.2"
     },
     "require-dev": {
+        "cakephp/authorization": "dev-cake5",
         "cakephp/cakephp-codesniffer": "5.x-dev",
         "phpunit/phpunit": "^9.5.19"
     },

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,7 @@
     },
     "autoload": {
         "psr-4": {
-            "DebugKit\\": "src/",
-            "DebugKit\\Test\\Fixture\\": "tests/Fixture/"
+            "DebugKit\\": "src/"
         }
     },
     "autoload-dev": {

--- a/src/Controller/MailPreviewController.php
+++ b/src/Controller/MailPreviewController.php
@@ -103,7 +103,7 @@ class MailPreviewController extends DebugKitController
      * @param string $method The mailer preview method
      * @return \Psr\Http\Message\ResponseInterface|null
      */
-    public function email(string $name, string $method): ResponseInterface|null
+    public function email(string $name, string $method): ?ResponseInterface
     {
         $restore = Router::getRequest();
         // Clear the plugin attribute from the request instance

--- a/src/Model/Table/LazyTableTrait.php
+++ b/src/Model/Table/LazyTableTrait.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  */
 namespace DebugKit\Model\Table;
 
-use Cake\Core\App;
+use Cake\Database\Schema\TableSchema;
 use PDOException;
 use RuntimeException;
 
@@ -55,18 +55,25 @@ trait LazyTableTrait
         }
 
         try {
-            foreach ($fixtures as $name) {
-                $class = App::className($name, 'Test/Fixture', 'Fixture');
-                if ($class === null) {
-                    throw new RuntimeException("Unknown fixture '$name'.");
-                }
-
-                /** @var \Cake\TestSuite\Fixture\TestFixture $fixture */
-                $fixture = new $class($connection->configName());
-                if (in_array($fixture->table, $existing)) {
+            $config = require dirname(dirname(__DIR__)) . '/schema.php';
+            $driver = $connection->getDriver();
+            foreach ($config as $table) {
+                if (in_array($table['table'], $existing, true)) {
                     continue;
                 }
-                $fixture->create($connection);
+                if (!in_array($table['table'], $fixtures, true)) {
+                    continue;
+                }
+
+                // Use Database/Schema primitives to generate dialect specific
+                // CREATE TABLE statements and run them.
+                $schema = new TableSchema($name, $config['columns']);
+                foreach ($config['constraints'] as $name => $itemConfig) {
+                    $schema->addConstraint($name, $itemConfig);
+                }
+                foreach ($schema->createSql($connection) as $sql) {
+                    $driver->execute($sql);
+                }
             }
         } catch (PDOException $e) {
             if (strpos($e->getMessage(), 'unable to open')) {

--- a/src/Model/Table/LazyTableTrait.php
+++ b/src/Model/Table/LazyTableTrait.php
@@ -67,8 +67,8 @@ trait LazyTableTrait
 
                 // Use Database/Schema primitives to generate dialect specific
                 // CREATE TABLE statements and run them.
-                $schema = new TableSchema($name, $config['columns']);
-                foreach ($config['constraints'] as $name => $itemConfig) {
+                $schema = new TableSchema($table['table'], $table['columns']);
+                foreach ($table['constraints'] as $name => $itemConfig) {
                     $schema->addConstraint($name, $itemConfig);
                 }
                 foreach ($schema->createSql($connection) as $sql) {

--- a/src/Model/Table/PanelsTable.php
+++ b/src/Model/Table/PanelsTable.php
@@ -44,7 +44,7 @@ class PanelsTable extends Table
     public function initialize(array $config): void
     {
         $this->belongsTo('DebugKit.Requests');
-        $this->ensureTables(['DebugKit.Requests', 'DebugKit.Panels']);
+        $this->ensureTables(['requests', 'panels']);
     }
 
     /**

--- a/src/Model/Table/RequestsTable.php
+++ b/src/Model/Table/RequestsTable.php
@@ -53,7 +53,7 @@ class RequestsTable extends Table
                 'Model.beforeSave' => ['requested_at' => 'new'],
             ],
         ]);
-        $this->ensureTables(['DebugKit.Requests', 'DebugKit.Panels']);
+        $this->ensureTables(['requests', 'panels']);
     }
 
     /**

--- a/src/schema.php
+++ b/src/schema.php
@@ -25,8 +25,8 @@ return [
         'constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id']],
         ],
-    ],
-    [
+     ],
+     [
         'table' => 'panels',
         'columns' => [
             'id' => ['type' => 'uuid'],
@@ -46,5 +46,5 @@ return [
                 'references' => ['requests', 'id'],
             ],
         ],
-    ]
+     ],
 ];

--- a/src/schema.php
+++ b/src/schema.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+use Cake\Database\Schema\TableSchema;
+
+/**
+ * Runtime plugin schema for DebugKit toolbar
+ *
+ * This schema data is used to generate the tables
+ * that DebugKit store persistent data in. We're using
+ * the Cake\Database abstract types so that we can
+ * generate SQL for any SQL dialect that CakePHP supports.
+ */
+return [
+     [
+        'table' => 'requests',
+        'columns' => [
+            'id' => ['type' => 'uuid', 'null' => false],
+            'url' => ['type' => 'text', 'null' => false],
+            'content_type' => ['type' => 'string'],
+            'status_code' => ['type' => 'integer'],
+            'method' => ['type' => 'string'],
+            'requested_at' => ['type' => 'datetime', 'null' => false],
+        ],
+        'constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id']],
+        ],
+    ],
+    [
+        'table' => 'panels',
+        'columns' => [
+            'id' => ['type' => 'uuid'],
+            'request_id' => ['type' => 'uuid', 'null' => false],
+            'panel' => ['type' => 'string'],
+            'title' => ['type' => 'string'],
+            'element' => ['type' => 'string'],
+            'summary' => ['type' => 'string'],
+            'content' => ['type' => 'binary', 'length' => TableSchema::LENGTH_LONG],
+        ],
+        'constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id']],
+            'unique_panel' => ['type' => 'unique', 'columns' => ['request_id', 'panel']],
+            'request_id_fk' => [
+                'type' => 'foreign',
+                'columns' => ['request_id'],
+                'references' => ['requests', 'id'],
+            ],
+        ],
+    ]
+];

--- a/tests/Fixture/PanelsFixture.php
+++ b/tests/Fixture/PanelsFixture.php
@@ -12,7 +12,6 @@
  */
 namespace DebugKit\Test\Fixture;
 
-use Cake\Database\Schema\TableSchema;
 use Cake\TestSuite\Fixture\TestFixture;
 
 /**

--- a/tests/TestCase/Controller/DebugKitControllerTest.php
+++ b/tests/TestCase/Controller/DebugKitControllerTest.php
@@ -57,8 +57,6 @@ class DebugKitControllerTest extends TestCase
      */
     private function _buildController()
     {
-        $this->markTestSkipped('Waiting for Authorization plugin to be updated for 5.x');
-
         $request = new ServerRequest(['url' => '/debug-kit/']);
 
         $resolver = new OrmResolver();
@@ -66,7 +64,7 @@ class DebugKitControllerTest extends TestCase
 
         $request = $request->withAttribute('authorization', $authorization);
 
-        return new DebugKitController($request, new Response());
+        return new DebugKitController($request);
     }
 
     /**

--- a/tests/TestCase/Controller/DebugKitControllerTest.php
+++ b/tests/TestCase/Controller/DebugKitControllerTest.php
@@ -19,7 +19,6 @@ use Authorization\AuthorizationService;
 use Authorization\Policy\OrmResolver;
 use Cake\Core\Configure;
 use Cake\Event\Event;
-use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;

--- a/tests/TestCase/DebugKitPluginTest.php
+++ b/tests/TestCase/DebugKitPluginTest.php
@@ -27,7 +27,7 @@ use DebugKit\ToolbarService;
 /**
  * Test the Plugin
  */
-class PluginTest extends TestCase
+class DebugKitPluginTest extends TestCase
 {
     /**
      * Test setDeprecationHandler.

--- a/tests/TestCase/Panel/SqlLogPanelTest.php
+++ b/tests/TestCase/Panel/SqlLogPanelTest.php
@@ -122,6 +122,6 @@ class SqlLogPanelTest extends TestCase
         $articles->findById(1)->first();
 
         $result = $this->panel->summary();
-        $this->assertMatchesRegularExpression('/\d+ \\/ \d+ ms/', $result);
+        $this->assertMatchesRegularExpression('/\d+ \\/ \d+(\.\d+)? ms/', $result);
     }
 }

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -22,7 +22,7 @@ $testTables = [
                 'columns' => ['id'],
             ],
         ],
-    ]
+    ],
 ];
 
 return array_merge($tables, $testTables);

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -1,47 +1,12 @@
 <?php
 declare(strict_types=1);
 
-use Cake\Database\Schema\TableSchema;
+$tables = require dirname(__DIR__) . '/src/schema.php';
 
 /**
- * Abstract schema for Debugkit tests.
+ * Additional tables used for tests.
  */
-return [
-    [
-        'table' => 'requests',
-        'columns' => [
-            'id' => ['type' => 'uuid', 'null' => false],
-            'url' => ['type' => 'text', 'null' => false],
-            'content_type' => ['type' => 'string'],
-            'status_code' => ['type' => 'integer'],
-            'method' => ['type' => 'string'],
-            'requested_at' => ['type' => 'datetime', 'null' => false],
-        ],
-        'constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id']],
-        ],
-    ],
-    [
-        'table' => 'panels',
-        'columns' => [
-            'id' => ['type' => 'uuid'],
-            'request_id' => ['type' => 'uuid', 'null' => false],
-            'panel' => ['type' => 'string'],
-            'title' => ['type' => 'string'],
-            'element' => ['type' => 'string'],
-            'summary' => ['type' => 'string'],
-            'content' => ['type' => 'binary', 'length' => TableSchema::LENGTH_LONG],
-        ],
-        'constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id']],
-            'unique_panel' => ['type' => 'unique', 'columns' => ['request_id', 'panel']],
-            'request_id_fk' => [
-                'type' => 'foreign',
-                'columns' => ['request_id'],
-                'references' => ['requests', 'id'],
-            ],
-        ],
-    ],
+$testTables = [
     [
         'table' => 'articles',
         'columns' => [
@@ -57,5 +22,7 @@ return [
                 'columns' => ['id'],
             ],
         ],
-    ],
+    ]
 ];
+
+return array_merge($tables, $testTables);


### PR DESCRIPTION
Remove the need to load/use fixture code in debug kit. Instead we can
use the same schema data format as the internal test schema loader and
duplicate a small passage to ensure we have stability.