### PR TITLE
Add doc section to explain how to use toolbar with an api only project

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -291,6 +291,20 @@ to include the panel::
 The above would load all the default panels as well as the ``AppPanel``, and
 ``MyCustomPanel`` panel from ``MyPlugin``.
 
+Accessing Toolbar without a frontend
+====================================
+
+If you have an application which only provides an API (and therefore no frontend)
+the usual way of accessing the toolbar can't be used.
+
+Instead you have to call http://localhost/debug-kit/toolbar/``<debugkit-id>``
+
+The ``<debugkit-id>`` can be found inside the HTTP headers of your API response. It should look something like that::
+
+    X-DEBUGKIT-ID: 5ef39604-ad5d-4ca4-85d8-8595e52373bb
+
+So you would have to call http://localhost/debug-kit/toolbar/5ef39604-ad5d-4ca4-85d8-8595e52373bb
+
 Helper Functions
 ================
 


### PR DESCRIPTION
As mentioned by @cnizzardini its currently not clear how to use the DebugKit Toolbar with an API only project due to the fact, that we only mention the automatically present toolbar in the frontend.

This new section inside the doc should clarify that using the DebugKit is also possible for API only projects, just a little bit more tedious because one has to manually call the URL from the iframe.