### PR TITLE
Fix overflow in small viewports

### DIFF
--- a/webroot/css/style.css
+++ b/webroot/css/style.css
@@ -605,7 +605,7 @@ strong {
 .is-active .c-toolbar {
     width: 100%;
     border-radius: 0;
-    overflow: auto;
+    overflow: hidden;
     padding-right: 40px;
 }
 


### PR DESCRIPTION
Fix the horizontal and possible vertical scrollbars from showing in the toolbar on small viewports.

Fixes #888