### PR TITLE
4.next - Switch to `doctrine/sql-formatter`.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "cakephp/cakephp": "^4.4.0",
         "cakephp/chronos": "^2.0",
         "composer/composer": "^1.3 | ^2.0",
-        "jdorn/sql-formatter": "^1.2"
+        "doctrine/sql-formatter": "^1.1.3"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^4.0",

--- a/src/DebugSql.php
+++ b/src/DebugSql.php
@@ -18,7 +18,10 @@ namespace DebugKit;
 use Cake\Core\Configure;
 use Cake\Database\Query;
 use Cake\Error\Debugger;
-use SqlFormatter;
+use Doctrine\SqlFormatter\CliHighlighter;
+use Doctrine\SqlFormatter\HtmlHighlighter;
+use Doctrine\SqlFormatter\NullHighlighter;
+use Doctrine\SqlFormatter\SqlFormatter;
 
 /**
  * Contains methods for dumping well formatted SQL queries.
@@ -93,10 +96,8 @@ TEXT;
         }
 
         $template = self::$templateHtml;
-        $sqlHighlight = true;
-        if ((PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') || $showHtml === false) {
+        if (static::isCli() || $showHtml === false) {
             $template = self::$templateText;
-            $sqlHighlight = false;
             if ($file && $line) {
                 $lineInfo = sprintf('%s (line %s)', $file, $line);
             }
@@ -105,12 +106,29 @@ TEXT;
             $showHtml = true;
         }
 
-        $var = $showHtml ? SqlFormatter::format($sql, $sqlHighlight) : $sql;
-        $var = str_replace(
-            '<span >:</span> <span style="color: #333;">',
-            '<span >:</span><span style="color: #333;">',
-            $var
-        );
+        if (static::isCli() && !$showHtml) {
+            $highlighter = new CliHighlighter([
+                CliHighlighter::HIGHLIGHT_QUOTE => "\x1b[33;1m",
+                CliHighlighter::HIGHLIGHT_WORD => "\x1b[36;1m",
+                CliHighlighter::HIGHLIGHT_VARIABLE => "\x1b[33;1m",
+            ]);
+        } elseif ($showHtml) {
+            $highlighter = new HtmlHighlighter(
+                [
+                    HtmlHighlighter::HIGHLIGHT_QUOTE => 'style="color: #004d40;"',
+                    HtmlHighlighter::HIGHLIGHT_BACKTICK_QUOTE => 'style="color: #26a69a;"',
+                    HtmlHighlighter::HIGHLIGHT_NUMBER => 'style="color: #ec407a;"',
+                    HtmlHighlighter::HIGHLIGHT_WORD => 'style="color: #9c27b0;"',
+                    HtmlHighlighter::HIGHLIGHT_PRE => 'style="color: #222; background-color: transparent;"',
+                ],
+                false
+            );
+        } else {
+            $highlighter = new NullHighlighter();
+        }
+
+        $var = (new SqlFormatter($highlighter))->format($sql);
+        $var = trim($var);
 
         if ($showHtml) {
             $template = self::$templateHtml;
@@ -141,6 +159,16 @@ TEXT;
     {
         static::sql($query, $showValues, $showHtml, $stackDepth);
         die(1);
+    }
+
+    /**
+     * Checks whether the current environment is CLI based.
+     *
+     * @return bool
+     */
+    protected static function isCli()
+    {
+        return PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg';
     }
 
     /**

--- a/templates/element/sql_log_panel.php
+++ b/templates/element/sql_log_panel.php
@@ -21,14 +21,11 @@
  * @var array $tables
  * @var \DebugKit\Database\Log\DebugLog[] $loggers
  */
-$noOutput = true;
 
-// Configure sqlformatter colours.
-SqlFormatter::$quote_attributes = 'style="color: #004d40;"';
-SqlFormatter::$backtick_quote_attributes = 'style="color: #26a69a;"';
-SqlFormatter::$number_attributes = 'style="color: #ec407a;"';
-SqlFormatter::$word_attributes = 'style="color: #9c27b0;"';
-SqlFormatter::$pre_attributes = 'style="color: #222; background-color: transparent;"';
+use Doctrine\SqlFormatter\HtmlHighlighter;
+use Doctrine\SqlFormatter\SqlFormatter;
+
+$noOutput = true;
 ?>
 
 <div class="c-sql-log-panel">
@@ -81,7 +78,20 @@ SqlFormatter::$pre_attributes = 'style="color: #222; background-color: transpare
                     <tbody>
                         <?php foreach ($queries as $query) : ?>
                         <tr>
-                            <td><?= SqlFormatter::format($query['query']) ?></td>
+                            <td>
+                                <?=
+                                    (new SqlFormatter(
+                                        new HtmlHighlighter([
+                                            HtmlHighlighter::HIGHLIGHT_QUOTE => 'style="color: #004d40;"',
+                                            HtmlHighlighter::HIGHLIGHT_BACKTICK_QUOTE => 'style="color: #26a69a;"',
+                                            HtmlHighlighter::HIGHLIGHT_NUMBER => 'style="color: #ec407a;"',
+                                            HtmlHighlighter::HIGHLIGHT_WORD => 'style="color: #9c27b0;"',
+                                            HtmlHighlighter::HIGHLIGHT_PRE => 'style="color: #222; background-color: transparent;"',
+                                        ])
+                                    ))
+                                    ->format($query['query'])
+                                ?>
+                            </td>
                             <td><?= h($query['rows']) ?></td>
                             <td><?= h($query['took']) ?></td>
                         </tr>

--- a/tests/test_app/Stub/DebugSqlStub.php
+++ b/tests/test_app/Stub/DebugSqlStub.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace DebugKit\TestApp\Stub;
+
+use DebugKit\DebugSql;
+
+class DebugSqlStub extends DebugSql
+{
+    public static $isCli = true;
+
+    protected static function isCli()
+    {
+        return static::$isCli;
+    }
+}


### PR DESCRIPTION
There's no updates anymore for `jdorn/sql-formatter`, PRs aren't getting merged, it's dead. `doctrine/sql-formatter` is a fork with additional functionality such as CLI highlighting, also I've added support for common table expressions and window functions to it.

I've opted to test for Sqlite only for the output tests, because accounting for the different quote characters is just very annoying, and it's not really overly important.

# HTML before:

![html-before](https://user-images.githubusercontent.com/5031606/189498600-36e7e96b-4e39-4847-8eca-9b47dc00a0ab.png)

# HTML after:

![html-after](https://user-images.githubusercontent.com/5031606/189498606-c859dc94-7c93-4ef1-ad80-5ea9caf83f29.png)

# CLI after:

![cli](https://user-images.githubusercontent.com/5031606/189498611-6443c2a1-41a4-4799-addb-e1910db20f64.png)