### PR TITLE
Fix Reload button in History panel

### DIFF
--- a/webroot/js/modules/Toolbar.js
+++ b/webroot/js/modules/Toolbar.js
@@ -173,7 +173,7 @@ export default class Toolbar {
     $(document).on('click', '.js-toolbar-scroll-right', () => {
       that.scroll('right');
     });
-    $(document).on('click', '.js-toolbar-load-panel', () => {
+    $(document).on('click', '.js-toolbar-load-panel', function () {
       const panelId = $(this).attr('data-panel-id');
       that.loadPanel(panelId, 'panelhistory');
     });


### PR DESCRIPTION
After JS+CSS refactor, button stopped working.

It got wrong `this` with short syntax.

I'm bit outdated on JS, so I don't know difference between syntaxes. I thought its just shorter syntax.