### PR TITLE
4.x: show debug_kit iframe error nicely

### DIFF
--- a/webroot/css/style.css
+++ b/webroot/css/style.css
@@ -574,6 +574,10 @@ strong {
     display: block;
 }
 
+.c-panel-content-container__content {
+    height: 100%;
+}
+
 .c-panel-content-container__content .o-loader {
     display: none;
 }

--- a/webroot/js/inject-iframe.js
+++ b/webroot/js/inject-iframe.js
@@ -27,6 +27,11 @@ if (elem) {
       iframe.height = '100%';
       doc.body.style.overflow = 'hidden';
     }
+    if (event.data === 'error') {
+      iframe.width = '40%';
+      iframe.height = '40%';
+      doc.body.style.overflow = bodyOverflow;
+    }
   };
 
   const onReady = () => {

--- a/webroot/js/modules/Toolbar.js
+++ b/webroot/js/modules/Toolbar.js
@@ -152,7 +152,14 @@ export default class Toolbar {
       // This initializes the panel specific JS logic (if there is any)
       document.dispatchEvent(new CustomEvent('initPanel', { detail: `panel${panelType}` }));
       that.bindDebugBlock();
-    });
+    })
+      .fail((response) => {
+        clearTimeout(timer);
+        contentArea.html(response.responseText);
+        $('.o-loader').removeClass('is-loading');
+        $('.c-panel-content-container').addClass('is-active');
+        window.parent.postMessage('error', window.location.origin);
+      });
   }
 
   // This re-inits the collapsible Debugger::exportVar() content of the Variables tab


### PR DESCRIPTION
Refs https://github.com/cakephp/debug_kit/issues/857

This adds a nice catch when a panel can't be loaded due to some error on the server side.

![2022-11-11_17-10-26 (1)](https://user-images.githubusercontent.com/9105243/201383048-f233eb99-f85c-4416-8ef5-012ee7b9b83e.gif)

This behavior can be reproduced if you add a syntax error inside the `vendor/cakephp/debug_kit/src/Controller/PanelsController.php` view method.