### PR TITLE
Fix request panel data saving with authentication

### DIFF
--- a/src/Panel/RequestPanel.php
+++ b/src/Panel/RequestPanel.php
@@ -16,6 +16,7 @@ namespace DebugKit\Panel;
 
 use Cake\Event\EventInterface;
 use DebugKit\DebugPanel;
+use Exception;
 
 /**
  * Provides debug information on the Current request params.
@@ -33,8 +34,19 @@ class RequestPanel extends DebugPanel
         /** @var \Cake\Controller\Controller $controller */
         $controller = $event->getSubject();
         $request = $controller->getRequest();
+
+        $attributes = [];
+        foreach ($request->getAttributes() as $attr => $value) {
+            try {
+                serialize($value);
+            } catch (Exception $e) {
+                $value = "Could not serialize `{$attr}`. It failed with {$e->getMessage()}";
+            }
+            $attributes[$attr] = $value;
+        }
+
         $this->_data = [
-            'attributes' => $request->getAttributes(),
+            'attributes' => $attributes,
             'query' => $request->getQueryParams(),
             'data' => $request->getData(),
             'cookie' => $request->getCookieParams(),

--- a/tests/TestCase/Panel/RequestPanelTest.php
+++ b/tests/TestCase/Panel/RequestPanelTest.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ **/
+namespace DebugKit\Test\TestCase\Panel;
+
+use Cake\Controller\Controller;
+use Cake\Event\Event;
+use Cake\Http\ServerRequest;
+use Cake\TestSuite\TestCase;
+use DebugKit\Panel\RequestPanel;
+
+/**
+ * Class RequestPanelTest
+ */
+class RequestPanelTest extends TestCase
+{
+    /**
+     * @var RequestPanel
+     */
+    protected $panel;
+
+    /**
+     * set up
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->panel = new RequestPanel();
+    }
+
+    /**
+     * Test that shutdown will skip unserializable attributes.
+     *
+     * @return void
+     */
+    public function testShutdownSkipAttributes()
+    {
+        $request = new ServerRequest([
+            'url' => '/',
+            'post' => ['name' => 'bob'],
+            'query' => ['page' => 1],
+        ]);
+        $request = $request
+            ->withAttribute('ok', 'string')
+            ->withAttribute('closure', function () {
+            });
+
+        $controller = new Controller($request);
+        $event = new Event('Controller.shutdown', $controller);
+        $this->panel->shutdown($event);
+
+        $data = $this->panel->data();
+        $this->assertArrayHasKey('attributes', $data);
+        $this->assertEquals('string', $data['attributes']['ok']);
+        $this->assertStringContainsString('Could not serialize `closure`', $data['attributes']['closure']);
+    }
+}


### PR DESCRIPTION
When the authentication plugin is in use it *could* have closures buried in its configuration. When this happens the entire request panel will be blank. With this change only the attributes that contain unserializable content.

Fixes cakephp/authentication#595