### PR TITLE
5.x: fix type error if no sort is set for variables tab

### DIFF
--- a/templates/element/variables_panel.php
+++ b/templates/element/variables_panel.php
@@ -14,7 +14,7 @@
 /**
  * @var \DebugKit\View\AjaxView $this
  * @var string $error
- * @var bool $sort
+ * @var bool|null $sort
  * @var array $variables
  * @var array $content
  * @var array $errors

--- a/templates/element/variables_panel.php
+++ b/templates/element/variables_panel.php
@@ -62,7 +62,7 @@
             </label>
         </div>
         <?php
-        $this->Toolbar->setSort($sort);
+        $this->Toolbar->setSort($sort ?? false);
         echo $this->Toolbar->dumpNodes($variables);
     endif;
 


### PR DESCRIPTION
This error happens with the current beta state of cakephp/app:5.0.0-beta1 when trying to open the `Variables` tab on the default homepage.

```
2022-12-20 18:55:33 error: [TypeError] DebugKit\View\Helper\ToolbarHelper::setSort(): Argument #1 ($sort) must be of type bool, null given, called in <my-app-path>/vendor/cakephp/debug_kit/templates/element/variables_panel.php on line 65 in <my-app-path>/vendor/cakephp/debug_kit/src/View/Helper/ToolbarHelper.php on line 55
Stack Trace:
- <my-app-path>/vendor/cakephp/debug_kit/templates/element/variables_panel.php:65
- <my-app-path>/vendor/cakephp/cakephp/src/View/View.php:1185
- <my-app-path>/vendor/cakephp/cakephp/src/View/View.php:1142
- <my-app-path>/vendor/cakephp/cakephp/src/View/View.php:1689
- <my-app-path>/vendor/cakephp/cakephp/src/View/View.php:673
- <my-app-path>/vendor/cakephp/debug_kit/templates/Panels/view.php:9
- <my-app-path>/vendor/cakephp/cakephp/src/View/View.php:1185
- <my-app-path>/vendor/cakephp/cakephp/src/View/View.php:1142
- <my-app-path>/vendor/cakephp/cakephp/src/View/View.php:782
- <my-app-path>/vendor/cakephp/cakephp/src/Controller/Controller.php:690
- <my-app-path>/vendor/cakephp/cakephp/src/Controller/Controller.php:494
- <my-app-path>/vendor/cakephp/cakephp/src/Controller/ControllerFactory.php:139
- <my-app-path>/vendor/cakephp/cakephp/src/Controller/ControllerFactory.php:114
- <my-app-path>/vendor/cakephp/cakephp/src/Http/BaseApplication.php:329
- <my-app-path>/vendor/cakephp/cakephp/src/Http/Runner.php:77
- <my-app-path>/vendor/cakephp/cakephp/src/Http/Middleware/CsrfProtectionMiddleware.php:168
- <my-app-path>/vendor/cakephp/cakephp/src/Http/Runner.php:73
- <my-app-path>/vendor/cakephp/cakephp/src/Http/Middleware/BodyParserMiddleware.php:157
- <my-app-path>/vendor/cakephp/cakephp/src/Http/Runner.php:73
- <my-app-path>/vendor/cakephp/cakephp/src/Routing/Middleware/RoutingMiddleware.php:116
- <my-app-path>/vendor/cakephp/cakephp/src/Http/Runner.php:73
- <my-app-path>/vendor/cakephp/cakephp/src/Routing/Middleware/AssetMiddleware.php:68
- <my-app-path>/vendor/cakephp/cakephp/src/Http/Runner.php:73
- <my-app-path>/vendor/cakephp/cakephp/src/Error/Middleware/ErrorHandlerMiddleware.php:100
- <my-app-path>/vendor/cakephp/cakephp/src/Http/Runner.php:73
- <my-app-path>/vendor/cakephp/debug_kit/src/Middleware/DebugKitMiddleware.php:60
- <my-app-path>/vendor/cakephp/cakephp/src/Http/Runner.php:73
- <my-app-path>/vendor/cakephp/cakephp/src/Http/Runner.php:58
- <my-app-path>/vendor/cakephp/cakephp/src/Http/Server.php:89
- <my-app-path>/webroot/index.php:37
- [main]:

Request URL: /debug-kit/panels/view/cd48819b-2a38-4e68-aeb5-320fc83bbab7
Referer URL: http://localhost:8765/debug-kit/toolbar/b9175884-57d1-4cb0-bab1-cb06be23a650
```

we could of course set the default value for `setSort(bool $sort = false)` as well.