### PR TITLE
4.x: fix copying text from debug_kit not working

### DIFF
--- a/webroot/js/modules/Keyboard.js
+++ b/webroot/js/modules/Keyboard.js
@@ -34,7 +34,7 @@ export default (($) => {
           return toolbar.loadPanel(id, panelType);
         }
       }
-      return false;
+      return;
     });
   };
 


### PR DESCRIPTION
`return false;` inside a `$(document).on('keydown'` prevents something like `Ctrl + C` to work at all.

Instead returning nothing fixes this issue so one can copy text from the debug kit again.

This was introduced when I did the whole CSS/JS refactor.