### PR TITLE
Drop DebugLog::totalRows().

### DIFF
--- a/src/Database/Log/DebugLog.php
+++ b/src/Database/Log/DebugLog.php
@@ -58,13 +58,6 @@ class DebugLog extends AbstractLogger
     protected float $_totalTime = 0;
 
     /**
-     * Total rows of all queries
-     *
-     * @var int
-     */
-    protected int $_totalRows = 0;
-
-    /**
      * Set to true to capture schema reflection queries
      * in the SQL log panel.
      *
@@ -130,16 +123,6 @@ class DebugLog extends AbstractLogger
     }
 
     /**
-     * Get the total rows
-     *
-     * @return int
-     */
-    public function totalRows(): int
-    {
-        return $this->_totalRows;
-    }
-
-    /**
      * @inheritDoc
      */
     public function log($level, string|Stringable $message, array $context = []): void
@@ -157,7 +140,6 @@ class DebugLog extends AbstractLogger
         $data = $query->jsonSerialize();
 
         $this->_totalTime += $data['took'];
-        $this->_totalRows += $data['numRows'];
 
         $this->_queries[] = [
             'query' => (string)$query,

--- a/src/Panel/PanelRegistry.php
+++ b/src/Panel/PanelRegistry.php
@@ -26,20 +26,24 @@ use RuntimeException;
  * Registry object for panels.
  *
  * @extends \Cake\Core\ObjectRegistry<\DebugKit\DebugPanel>
+ * @implements \Cake\Event\EventDispatcherInterface<object>
  */
 class PanelRegistry extends ObjectRegistry implements EventDispatcherInterface
 {
+    /**
+     * @use \Cake\Event\EventDispatcherTrait<object>
+     */
     use EventDispatcherTrait;
 
     /**
      * Constructor
      *
-     * @param \Cake\Event\EventManager $events Event Manager that panels should bind to.
+     * @param \Cake\Event\EventManager $eventManager Event Manager that panels should bind to.
      *   Typically this is the global manager.
      */
-    public function __construct(EventManager $events)
+    public function __construct(EventManager $eventManager)
     {
-        $this->setEventManager($events);
+        $this->setEventManager($eventManager);
     }
 
     /**

--- a/templates/element/sql_log_panel.php
+++ b/templates/element/sql_log_panel.php
@@ -59,10 +59,9 @@ $noOutput = true;
                 <h5>
                 <?= __d(
                     'debug_kit',
-                    'Total Time: {0} ms &mdash; Total Queries: {1} &mdash; Total Rows: {2}',
+                    'Total Time: {0} ms &mdash; Total Queries: {1}',
                     $logger->totalTime(),
-                    count($queries),
-                    $logger->totalRows()
+                    count($queries)
                 );
                 ?>
                 </h5>

--- a/tests/TestCase/Database/Log/DebugLogTest.php
+++ b/tests/TestCase/Database/Log/DebugLogTest.php
@@ -60,12 +60,10 @@ class DebugLogTest extends TestCase
         $this->logger->log(LogLevel::DEBUG, (string)$query, ['query' => $query]);
         $this->assertCount(1, $this->logger->queries());
         $this->assertSame(10.0, $this->logger->totalTime());
-        $this->assertSame(5, $this->logger->totalRows());
 
         $this->logger->log(LogLevel::DEBUG, (string)$query, ['query' => $query]);
         $this->assertCount(2, $this->logger->queries());
         $this->assertSame(20.0, $this->logger->totalTime());
-        $this->assertSame(10, $this->logger->totalRows());
     }
 
     /**


### PR DESCRIPTION
Ttotal count of rows affected in separate queries isn't practically useful. Closes #762.