### PR TITLE
5.x: reimplement #574 in Cake5

### DIFF
--- a/src/Model/Table/PanelsTable.php
+++ b/src/Model/Table/PanelsTable.php
@@ -34,6 +34,7 @@ use RuntimeException;
 class PanelsTable extends Table
 {
     use LazyTableTrait;
+    use SqlTraceTrait;
 
     /**
      * initialize method

--- a/src/Model/Table/RequestsTable.php
+++ b/src/Model/Table/RequestsTable.php
@@ -36,6 +36,7 @@ use PDOException;
 class RequestsTable extends Table
 {
     use LazyTableTrait;
+    use SqlTraceTrait;
 
     /**
      * initialize method

--- a/src/Model/Table/SqlTraceTrait.php
+++ b/src/Model/Table/SqlTraceTrait.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         5.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace DebugKit\Model\Table;
+
+use Cake\Core\Configure;
+use Cake\Error\Debugger;
+use Cake\ORM\Query\DeleteQuery;
+use Cake\ORM\Query\SelectQuery;
+use Cake\ORM\Query\UpdateQuery;
+
+/**
+ * Add this trait to your Table class to append the file reference of where a Query object was created.
+ *
+ * @mixin \Cake\ORM\Table
+ */
+trait SqlTraceTrait
+{
+    /**
+     * Overwrite parent table method to inject SQL comment
+     */
+    public function selectQuery(): SelectQuery
+    {
+        return $this->fileStamp(parent::selectQuery());
+    }
+
+    /**
+     * Overwrite parent table method to inject SQL comment
+     */
+    public function updateQuery(): UpdateQuery
+    {
+        return $this->fileStamp(parent::updateQuery());
+    }
+
+    /**
+     * Overwrite parent table method to inject SQL comment
+     */
+    public function deleteQuery(): DeleteQuery
+    {
+        return $this->fileStamp(parent::deleteQuery());
+    }
+
+    /**
+     * Applies a comment to a query about which file created it.
+     *
+     * @template T of \Cake\ORM\Query\SelectQuery|\Cake\ORM\Query\UpdateQuery|\Cake\ORM\Query\DeleteQuery
+     * @param \Cake\ORM\Query\SelectQuery|\Cake\ORM\Query\UpdateQuery|\Cake\ORM\Query\DeleteQuery $query The Query to insert a comment into.
+     * @psalm-param T $query
+     * @param int $start How many entries in the stack trace to skip.
+     * @param bool $debugOnly False to always stamp queries with a comment.
+     * @return \Cake\ORM\Query\SelectQuery|\Cake\ORM\Query\UpdateQuery|\Cake\ORM\Query\DeleteQuery
+     * @psalm-return T
+     */
+    protected function fileStamp(
+        SelectQuery|UpdateQuery|DeleteQuery $query,
+        int $start = 1,
+        bool $debugOnly = true
+    ): SelectQuery|UpdateQuery|DeleteQuery {
+        if (!Configure::read('debug') && $debugOnly === true) {
+            return $query;
+        }
+
+        $traces = Debugger::trace(['start' => $start, 'format' => 'array']);
+        $file = '[unknown]';
+        $line = '??';
+
+        if (is_array($traces)) {
+            foreach ($traces as $trace) {
+                $path = $trace['file'];
+                $line = $trace['line'];
+                $file = Debugger::trimPath($path);
+                if ($path === '[internal]') {
+                    continue;
+                }
+                if (defined('CAKE_CORE_INCLUDE_PATH') && strpos($path, CAKE_CORE_INCLUDE_PATH) !== 0) {
+                    break;
+                }
+            }
+        }
+
+        return $query->modifier(sprintf('/* %s (line %s) */', $file, $line));
+    }
+}

--- a/src/Model/Table/SqlTraceTrait.php
+++ b/src/Model/Table/SqlTraceTrait.php
@@ -90,6 +90,6 @@ trait SqlTraceTrait
             }
         }
 
-        return $query->modifier(sprintf('/* %s (line %s) */', $file, $line));
+        return $query->comment(sprintf('%s (line %s)', $file, $line));
     }
 }

--- a/tests/TestCase/Model/Table/SqlTraceTraitTest.php
+++ b/tests/TestCase/Model/Table/SqlTraceTraitTest.php
@@ -1,0 +1,106 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         5.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace DebugKit\Test\TestCase\Model\Table;
+
+use Cake\Core\Configure;
+use Cake\ORM\Locator\LocatorAwareTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Tests for SqlTraceTrait debugging comments.
+ */
+class SqlTraceTraitTest extends TestCase
+{
+    use LocatorAwareTrait;
+
+    /**
+     * Fixtures
+     */
+    public array $fixtures = [
+        'plugin.DebugKit.Requests',
+        'plugin.DebugKit.Panels',
+    ];
+
+    /**
+     * Table names.
+     */
+    public array $tables = [
+        'DebugKit.Panels',
+        'DebugKit.Requests',
+    ];
+
+    protected bool $debug;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->debug = Configure::read('App.debug', true);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        Configure::write('App.debug', $this->debug);
+    }
+
+    /**
+     * Verify file name when calling find()
+     */
+    public function testFind()
+    {
+        foreach ($this->tables as $table) {
+            $table = $this->fetchTable($table);
+            $sql = $table->find()->select(['id'])->sql();
+            $this->assertTrue(str_contains($sql, basename(__FILE__)), 'Expected file: ' . $sql);
+        }
+    }
+
+    /**
+     * Verify file name when calling query()/select()
+     */
+    public function testQuery()
+    {
+        foreach ($this->tables as $table) {
+            $table = $this->fetchTable($table);
+            $sql = $table->query()->sql();
+            $this->assertTrue(str_contains($sql, basename(__FILE__)), 'Expected file: ' . $sql);
+        }
+    }
+
+    /**
+     * Verify file name when calling update()
+     */
+    public function testUpdate()
+    {
+        foreach ($this->tables as $table) {
+            $table = $this->fetchTable($table);
+            $sql = $table->updateQuery()->set(['title' => 'fooBar'])->sql();
+            $this->assertTrue(str_contains($sql, basename(__FILE__)), 'Expected file: ' . $sql);
+        }
+    }
+
+    /**
+     * Verify file name when calling delete()
+     */
+    public function testDelete()
+    {
+        foreach ($this->tables as $table) {
+            $table = $this->fetchTable($table);
+            $sql = $table->deleteQuery()->where(['title' => 'fooBar'])->sql();
+            $this->assertTrue(str_contains($sql, basename(__FILE__)), 'Expected file: ' . $sql);
+        }
+    }
+}


### PR DESCRIPTION
Reimplements #574
Closes #573

I really liked this idea and reimplemented it for the Cake5 branch.
Kudos definitely go to @thinkingmedia for implementing it in the first place but for some reason it didn't get finished.

The only thing that we could maybe adjust is the position of the SQL comment. Does someone else maybe have a better idea of placing it in the query?

Currently it would look like this:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/9105243/212464373-6db1e075-8336-4d23-9997-055eb1af8480.png">
