### PR TITLE
4.next: Introspect resultsets in variables panel

### DIFF
--- a/src/Panel/VariablesPanel.php
+++ b/src/Panel/VariablesPanel.php
@@ -16,6 +16,7 @@ namespace DebugKit\Panel;
 
 use Cake\Core\Configure;
 use Cake\Datasource\EntityInterface;
+use Cake\Datasource\ResultSetDecorator;
 use Cake\Error\Debugger;
 use Cake\Event\EventInterface;
 use Cake\Form\Form;
@@ -102,6 +103,8 @@ class VariablesPanel extends DebugPanel
                 if ($formErrors) {
                     $errors[$k] = $formErrors;
                 }
+            } elseif ($v instanceof ResultSetDecorator) {
+                $v = $v->toArray();
             }
             $content[$k] = Debugger::exportVarAsNodes($v, $varsMaxDepth);
         }


### PR DESCRIPTION
Closes https://github.com/cakephp/debug_kit/issues/928

This will transform a variables panel like this
<img width="787" alt="image" src="https://user-images.githubusercontent.com/9105243/235311517-93669e2e-3f23-4a6e-8cab-5d082519e577.png">

to this
<img width="777" alt="image" src="https://user-images.githubusercontent.com/9105243/235311593-cc3c3773-253e-436f-8345-6794167fc18f.png">
