### PR TITLE
5.x: remove deprecations

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,56 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.x-dev@">
+<files psalm-version="5.10.0@a5effd2d2dddd1a7ea7a0f6a051ce63ff979e356">
   <file src="src/DebugInclude.php">
-    <PossiblyNullArrayOffset occurrences="2">
-      <code>$this-&gt;_composerPaths</code>
-      <code>$this-&gt;_pluginPaths</code>
+    <PossiblyNullArrayOffset>
+      <code><![CDATA[$this->_composerPaths]]></code>
+      <code><![CDATA[$this->_pluginPaths]]></code>
     </PossiblyNullArrayOffset>
   </file>
   <file src="src/DebugSql.php">
-    <InternalMethod occurrences="1">
+    <InternalMethod>
       <code>bindings</code>
     </InternalMethod>
   </file>
   <file src="src/DebugTimer.php">
-    <PossiblyNullArrayOffset occurrences="1">
+    <PossiblyNullArrayOffset>
       <code>self::$_timers</code>
     </PossiblyNullArrayOffset>
   </file>
   <file src="src/Mailer/MailPreview.php">
-    <PossiblyFalseOperand occurrences="1">
+    <PossiblyFalseOperand>
       <code>$pos</code>
     </PossiblyFalseOperand>
   </file>
   <file src="src/Mailer/Transport/DebugKitTransport.php">
-    <InvalidReturnStatement occurrences="1">
+    <InvalidReturnStatement>
       <code>$result</code>
     </InvalidReturnStatement>
-    <MoreSpecificReturnType occurrences="1">
+    <MoreSpecificReturnType>
       <code>array</code>
     </MoreSpecificReturnType>
-    <PropertyTypeCoercion occurrences="1">
+    <PropertyTypeCoercion>
       <code>new $className($config)</code>
     </PropertyTypeCoercion>
   </file>
   <file src="src/Panel/PanelRegistry.php">
-    <LessSpecificImplementedReturnType occurrences="1">
+    <LessSpecificImplementedReturnType>
       <code>string|null</code>
     </LessSpecificImplementedReturnType>
-    <UnsafeInstantiation occurrences="1">
+    <UnsafeInstantiation>
       <code>new $class($this, $config)</code>
     </UnsafeInstantiation>
   </file>
   <file src="src/Panel/SqlLogPanel.php">
-    <UndefinedInterfaceMethod occurrences="1">
+    <UndefinedInterfaceMethod>
       <code>genericInstances</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/View/Helper/ToolbarHelper.php">
-    <InternalClass occurrences="1">
+    <InternalClass>
+      <code>new HtmlFormatter()</code>
       <code>new HtmlFormatter()</code>
     </InternalClass>
-    <InternalMethod occurrences="1">
+    <InternalMethod>
       <code>dump</code>
+      <code>dump</code>
+      <code>new HtmlFormatter()</code>
+      <code>new HtmlFormatter()</code>
     </InternalMethod>
   </file>
 </files>

--- a/src/Controller/PanelsController.php
+++ b/src/Controller/PanelsController.php
@@ -83,7 +83,7 @@ class PanelsController extends DebugKitController
     public function view(?string $id = null): void
     {
         $this->set('sort', $this->request->getCookie('debugKit_sort'));
-        $panel = $this->Panels->get($id, ['contain' => ['Requests']]);
+        $panel = $this->Panels->get($id, ...['contain' => ['Requests']]);
 
         $this->set('panel', $panel);
         // @codingStandardsIgnoreStart

--- a/src/Model/Table/PanelsTable.php
+++ b/src/Model/Table/PanelsTable.php
@@ -22,7 +22,7 @@ use Cake\ORM\Table;
  * each request.
  *
  * @property \DebugKit\Model\Table\RequestsTable&\Cake\ORM\Association\BelongsTo $Requests
- * @method \DebugKit\Model\Entity\Panel get($primaryKey, $options = [])
+ * @method \DebugKit\Model\Entity\Panel get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, ...$args)
  * @method \DebugKit\Model\Entity\Panel newEntity($data = null, array $options = [])
  * @method \DebugKit\Model\Entity\Panel[] newEntities(array $data, array $options = [])
  * @method \DebugKit\Model\Entity\Panel|false save(\Cake\Datasource\EntityInterface $entity, $options = [])

--- a/src/Model/Table/RequestsTable.php
+++ b/src/Model/Table/RequestsTable.php
@@ -25,7 +25,7 @@ use PDOException;
  * The requests table tracks basic information about each request.
  *
  * @property \DebugKit\Model\Table\PanelsTable $Panels
- * @method \DebugKit\Model\Entity\Request get($primaryKey, $options = [])
+ * @method \DebugKit\Model\Entity\Request get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, ...$args)
  * @method \DebugKit\Model\Entity\Request newEntity($data = null, array $options = [])
  * @method \DebugKit\Model\Entity\Request[] newEntities(array $data, array $options = [])
  * @method \DebugKit\Model\Entity\Request save(\Cake\Datasource\EntityInterface $entity, $options = [])

--- a/src/Panel/IncludePanel.php
+++ b/src/Panel/IncludePanel.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 namespace DebugKit\Panel;
 
+use Cake\Error\Debugger;
 use Cake\Event\EventInterface;
 use Cake\Utility\Hash;
 use DebugKit\DebugInclude;
@@ -83,6 +84,10 @@ class IncludePanel extends DebugPanel
 
         foreach ($return['plugins'] as &$plugin) {
             ksort($plugin);
+        }
+
+        foreach ($return as $k => $v) {
+            $return[$k] = Debugger::exportVarAsNodes($v);
         }
 
         return $return;

--- a/src/Panel/RequestPanel.php
+++ b/src/Panel/RequestPanel.php
@@ -48,10 +48,10 @@ class RequestPanel extends DebugPanel
 
         $this->_data = [
             'attributes' => $attributes,
-            'query' => [Debugger::exportVarAsNodes($request->getQueryParams())],
-            'data' => [Debugger::exportVarAsNodes($request->getData())],
-            'cookie' => [Debugger::exportVarAsNodes($request->getCookieParams())],
-            'get' => [Debugger::exportVarAsNodes($_GET)],
+            'query' => Debugger::exportVarAsNodes($request->getQueryParams()),
+            'data' => Debugger::exportVarAsNodes($request->getData()),
+            'cookie' => Debugger::exportVarAsNodes($request->getCookieParams()),
+            'get' => Debugger::exportVarAsNodes($_GET),
             'matchedRoute' => $request->getParam('_matchedRoute'),
             'headers' => [
                 'response' => headers_sent($file, $line),

--- a/src/Panel/RequestPanel.php
+++ b/src/Panel/RequestPanel.php
@@ -48,16 +48,16 @@ class RequestPanel extends DebugPanel
 
         $this->_data = [
             'attributes' => $attributes,
-            'query' => Debugger::exportVarAsNodes($request->getQueryParams()),
-            'data' => Debugger::exportVarAsNodes($request->getData()),
-            'cookie' => Debugger::exportVarAsNodes($request->getCookieParams()),
-            'get' => Debugger::exportVarAsNodes($_GET),
+            'query' => [Debugger::exportVarAsNodes($request->getQueryParams())],
+            'data' => [Debugger::exportVarAsNodes($request->getData())],
+            'cookie' => [Debugger::exportVarAsNodes($request->getCookieParams())],
+            'get' => [Debugger::exportVarAsNodes($_GET)],
             'matchedRoute' => $request->getParam('_matchedRoute'),
-            'headers' => Debugger::exportVarAsNodes([
+            'headers' => [
                 'response' => headers_sent($file, $line),
                 'file' => $file,
                 'line' => $line,
-            ]),
+            ],
         ];
     }
 }

--- a/src/Panel/RequestPanel.php
+++ b/src/Panel/RequestPanel.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 namespace DebugKit\Panel;
 
+use Cake\Error\Debugger;
 use Cake\Event\EventInterface;
 use DebugKit\DebugPanel;
 use Exception;
@@ -42,17 +43,21 @@ class RequestPanel extends DebugPanel
             } catch (Exception $e) {
                 $value = "Could not serialize `{$attr}`. It failed with {$e->getMessage()}";
             }
-            $attributes[$attr] = $value;
+            $attributes[$attr] = Debugger::exportVarAsNodes($value);
         }
 
         $this->_data = [
             'attributes' => $attributes,
-            'query' => $request->getQueryParams(),
-            'data' => $request->getData(),
-            'cookie' => $request->getCookieParams(),
-            'get' => $_GET,
+            'query' => Debugger::exportVarAsNodes($request->getQueryParams()),
+            'data' => Debugger::exportVarAsNodes($request->getData()),
+            'cookie' => Debugger::exportVarAsNodes($request->getCookieParams()),
+            'get' => Debugger::exportVarAsNodes($_GET),
             'matchedRoute' => $request->getParam('_matchedRoute'),
-            'headers' => ['response' => headers_sent($file, $line), 'file' => $file, 'line' => $line],
+            'headers' => Debugger::exportVarAsNodes([
+                'response' => headers_sent($file, $line),
+                'file' => $file,
+                'line' => $line,
+            ]),
         ];
     }
 }

--- a/src/Panel/SessionPanel.php
+++ b/src/Panel/SessionPanel.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 namespace DebugKit\Panel;
 
+use Cake\Error\Debugger;
 use Cake\Event\EventInterface;
 use DebugKit\DebugPanel;
 
@@ -33,7 +34,8 @@ class SessionPanel extends DebugPanel
         /** @var \Cake\Http\ServerRequest|null $request */
         $request = $event->getSubject()->getRequest();
         if ($request) {
-            $this->_data = ['content' => $request->getSession()->read()];
+            $content = Debugger::exportVarAsNodes($request->getSession()->read());
+            $this->_data = compact('content');
         }
     }
 }

--- a/src/Panel/SessionPanel.php
+++ b/src/Panel/SessionPanel.php
@@ -34,7 +34,7 @@ class SessionPanel extends DebugPanel
         /** @var \Cake\Http\ServerRequest|null $request */
         $request = $event->getSubject()->getRequest();
         if ($request) {
-            $content = [Debugger::exportVarAsNodes($request->getSession()->read())];
+            $content = Debugger::exportVarAsNodes($request->getSession()->read());
             $this->_data = compact('content');
         }
     }

--- a/src/Panel/SessionPanel.php
+++ b/src/Panel/SessionPanel.php
@@ -34,7 +34,7 @@ class SessionPanel extends DebugPanel
         /** @var \Cake\Http\ServerRequest|null $request */
         $request = $event->getSubject()->getRequest();
         if ($request) {
-            $content = Debugger::exportVarAsNodes($request->getSession()->read());
+            $content = [Debugger::exportVarAsNodes($request->getSession()->read())];
             $this->_data = compact('content');
         }
     }

--- a/src/Panel/VariablesPanel.php
+++ b/src/Panel/VariablesPanel.php
@@ -97,11 +97,11 @@ class VariablesPanel extends DebugPanel
         foreach ($vars as $k => $v) {
             // Get the validation errors for Entity
             if ($v instanceof EntityInterface) {
-                $errors[$k] = $this->_getErrors($v);
+                $errors[$k] = Debugger::exportVarAsNodes($this->_getErrors($v), $varsMaxDepth);
             } elseif ($v instanceof Form) {
                 $formErrors = $v->getErrors();
                 if ($formErrors) {
-                    $errors[$k] = $formErrors;
+                    $errors[$k] = Debugger::exportVarAsNodes($formErrors, $varsMaxDepth);
                 }
             }
             $content[$k] = Debugger::exportVarAsNodes($v, $varsMaxDepth);

--- a/src/View/Helper/ToolbarHelper.php
+++ b/src/View/Helper/ToolbarHelper.php
@@ -66,7 +66,6 @@ class ToolbarHelper extends Helper
      */
     public function dumpNodes(array $nodes): string
     {
-        /** @psalm-suppress InternalMethod */
         $formatter = new HtmlFormatter();
         if ($this->sort) {
             ksort($nodes);
@@ -92,7 +91,6 @@ class ToolbarHelper extends Helper
      */
     public function dumpNode(NodeInterface $node): string
     {
-        /** @psalm-suppress InternalMethod */
         $formatter = new HtmlFormatter();
 
         return implode([

--- a/src/View/Helper/ToolbarHelper.php
+++ b/src/View/Helper/ToolbarHelper.php
@@ -77,7 +77,7 @@ class ToolbarHelper extends Helper
         $root = new ArrayNode($items);
 
         return implode([
-            '<div class="cake-debug-output cake-debug" style="direction:ltr">',
+            '<div class="cake-debug-output" style="direction:ltr">',
             $formatter->dump($root),
             '</div>',
         ]);
@@ -94,7 +94,7 @@ class ToolbarHelper extends Helper
         $formatter = new HtmlFormatter();
 
         return implode([
-            '<div class="cake-debug-output cake-debug" style="direction:ltr">',
+            '<div class="cake-debug-output" style="direction:ltr">',
             $formatter->dump($node),
             '</div>',
         ]);

--- a/src/View/Helper/ToolbarHelper.php
+++ b/src/View/Helper/ToolbarHelper.php
@@ -18,6 +18,7 @@ namespace DebugKit\View\Helper;
 use Cake\Error\Debug\ArrayItemNode;
 use Cake\Error\Debug\ArrayNode;
 use Cake\Error\Debug\HtmlFormatter;
+use Cake\Error\Debug\NodeInterface;
 use Cake\Error\Debug\ScalarNode;
 use Cake\View\Helper;
 
@@ -79,6 +80,24 @@ class ToolbarHelper extends Helper
         return implode([
             '<div class="cake-debug-output cake-debug" style="direction:ltr">',
             $formatter->dump($root),
+            '</div>',
+        ]);
+    }
+
+    /**
+     * Dump an error node
+     *
+     * @param \Cake\Error\Debug\NodeInterface $node A error node containing dumped variables.
+     * @return string Formatted HTML
+     */
+    public function dumpNode(NodeInterface $node): string
+    {
+        /** @psalm-suppress InternalMethod */
+        $formatter = new HtmlFormatter();
+
+        return implode([
+            '<div class="cake-debug-output cake-debug" style="direction:ltr">',
+            $formatter->dump($node),
             '</div>',
         ]);
     }

--- a/src/View/Helper/ToolbarHelper.php
+++ b/src/View/Helper/ToolbarHelper.php
@@ -19,7 +19,6 @@ use Cake\Error\Debug\ArrayItemNode;
 use Cake\Error\Debug\ArrayNode;
 use Cake\Error\Debug\HtmlFormatter;
 use Cake\Error\Debug\ScalarNode;
-use Cake\Error\Debugger;
 use Cake\View\Helper;
 
 /**
@@ -80,39 +79,6 @@ class ToolbarHelper extends Helper
         return implode([
             '<div class="cake-debug-output cake-debug" style="direction:ltr">',
             $formatter->dump($root),
-            '</div>',
-        ]);
-    }
-
-    /**
-     * Dump the value in $value into an interactive HTML output.
-     *
-     * @param mixed $value The value to output.
-     * @return string Formatted HTML
-     * @deprecated 4.4.0
-     */
-    public function dump(mixed $value): string
-    {
-        $debugger = Debugger::getInstance();
-        $exportFormatter = $debugger->getConfig('exportFormatter');
-        $restore = false;
-        if ($exportFormatter !== HtmlFormatter::class) {
-            $restore = true;
-            $debugger->setConfig('exportFormatter', HtmlFormatter::class);
-        }
-
-        if ($this->sort && is_array($value)) {
-            ksort($value);
-        }
-
-        $contents = Debugger::exportVar($value, 25);
-        if ($restore) {
-            $debugger->setConfig('exportFormatter', $exportFormatter);
-        }
-
-        return implode([
-            '<div class="cake-debug-output cake-debug" style="direction:ltr">',
-            $contents,
             '</div>',
         ]);
     }

--- a/templates/element/include_panel.php
+++ b/templates/element/include_panel.php
@@ -14,12 +14,12 @@
 
 /**
  * @var \DebugKit\View\AjaxView $this
- * @var array $paths
- * @var array $app
- * @var array $cake
- * @var array $plugins
- * @var array $vendor
- * @var array $other
+ * @var array<\Cake\Error\Debug\NodeInterface> $paths
+ * @var array<\Cake\Error\Debug\NodeInterface> $app
+ * @var array<\Cake\Error\Debug\NodeInterface> $cake
+ * @var array<\Cake\Error\Debug\NodeInterface> $plugins
+ * @var array<\Cake\Error\Debug\NodeInterface> $vendor
+ * @var array<\Cake\Error\Debug\NodeInterface> $other
  */
 
 // Backwards compat for old DebugKit data.
@@ -29,8 +29,8 @@ if (!isset($cake) && isset($core)) {
 ?>
 <div class="c-include-panel">
     <h4>Include Paths</h4>
-    <?= $this->Toolbar->dump($paths) ?>
+    <?= $this->Toolbar->dumpNodes($paths) ?>
 
     <h4>Included Files</h4>
-    <?= $this->Toolbar->dump(compact('app', 'cake', 'plugins', 'vendor', 'other')) ?>
+    <?= $this->Toolbar->dumpNodes(compact('app', 'cake', 'plugins', 'vendor', 'other')) ?>
 </div>

--- a/templates/element/include_panel.php
+++ b/templates/element/include_panel.php
@@ -29,7 +29,7 @@ if (!isset($cake) && isset($core)) {
 ?>
 <div class="c-include-panel">
     <h4>Include Paths</h4>
-    <?= $this->Toolbar->dumpNodes($paths) ?>
+    <?= $this->Toolbar->dumpNodes(compact('paths')) ?>
 
     <h4>Included Files</h4>
     <?= $this->Toolbar->dumpNodes(compact('app', 'cake', 'plugins', 'vendor', 'other')) ?>

--- a/templates/element/request_panel.php
+++ b/templates/element/request_panel.php
@@ -20,9 +20,9 @@
  * @var \DebugKit\View\AjaxView $this
  * @var array $headers
  * @var array $attributes
- * @var array $data
- * @var array $query
- * @var array $cookie
+ * @var \Cake\Error\Debug\NodeInterface $data
+ * @var \Cake\Error\Debug\NodeInterface $query
+ * @var \Cake\Error\Debug\NodeInterface $cookie
  * @var string $matchedRoute
  */
 
@@ -55,7 +55,7 @@ use Cake\Error\Debugger;
     if (empty($data)) :
         echo '<p class="c-flash c-flash--info">No post data.</p>';
     else :
-        echo $this->Toolbar->dumpNodes($data);
+        echo $this->Toolbar->dumpNode($data);
     endif;
     ?>
 
@@ -64,19 +64,19 @@ use Cake\Error\Debugger;
     if (empty($query)) :
         echo '<p class="c-flash c-flash--info">No querystring data.</p>';
     else :
-        echo $this->Toolbar->dumpNodes($query);
+        echo $this->Toolbar->dumpNode($query);
     endif;
     ?>
 
     <h4>Cookie</h4>
     <?php if (isset($cookie)) : ?>
-        <?= $this->Toolbar->dumpNodes($cookie) ?>
+        <?= $this->Toolbar->dumpNode($cookie) ?>
     <?php else : ?>
         <p class="c-flash c-flash--info">No Cookie data.</p>
     <?php endif; ?>
 
     <?php if (!empty($matchedRoute)) : ?>
     <h4>Matched Route</h4>
-        <p><?= $this->Toolbar->dumpNodes([Debugger::exportVarAsNodes(['template' => $matchedRoute])]) ?></p>
+        <p><?= $this->Toolbar->dumpNode(Debugger::exportVarAsNodes(['template' => $matchedRoute])) ?></p>
     <?php endif; ?>
 </div>

--- a/templates/element/request_panel.php
+++ b/templates/element/request_panel.php
@@ -43,7 +43,7 @@
     if (empty($attributes)) :
         echo '<p class="c-flash c-flash--info">No attributes data.</p>';
     else :
-        echo $this->Toolbar->dump($attributes);
+        echo $this->Toolbar->dumpNodes($attributes);
     endif;
     ?>
 
@@ -52,7 +52,7 @@
     if (empty($data)) :
         echo '<p class="c-flash c-flash--info">No post data.</p>';
     else :
-        echo $this->Toolbar->dump($data);
+        echo $this->Toolbar->dumpNodes($data);
     endif;
     ?>
 
@@ -61,19 +61,19 @@
     if (empty($query)) :
         echo '<p class="c-flash c-flash--info">No querystring data.</p>';
     else :
-        echo $this->Toolbar->dump($query);
+        echo $this->Toolbar->dumpNodes($query);
     endif;
     ?>
 
     <h4>Cookie</h4>
     <?php if (isset($cookie)) : ?>
-        <?= $this->Toolbar->dump($cookie) ?>
+        <?= $this->Toolbar->dumpNodes($cookie) ?>
     <?php else : ?>
         <p class="c-flash c-flash--info">No Cookie data.</p>
     <?php endif; ?>
 
     <?php if (!empty($matchedRoute)) : ?>
     <h4>Matched Route</h4>
-        <p><?= $this->Toolbar->dump(['template' => $matchedRoute]) ?></p>
+        <p><?= $this->Toolbar->dumpNodes(['template' => $matchedRoute]) ?></p>
     <?php endif; ?>
 </div>

--- a/templates/element/request_panel.php
+++ b/templates/element/request_panel.php
@@ -25,6 +25,9 @@
  * @var array $cookie
  * @var string $matchedRoute
  */
+
+use Cake\Error\Debugger;
+
 ?>
 <div class="c-request-panel">
     <?php if (!empty($headers) && $headers['response']) : ?>
@@ -74,6 +77,6 @@
 
     <?php if (!empty($matchedRoute)) : ?>
     <h4>Matched Route</h4>
-        <p><?= $this->Toolbar->dumpNodes(['template' => $matchedRoute]) ?></p>
+        <p><?= $this->Toolbar->dumpNodes([Debugger::exportVarAsNodes(['template' => $matchedRoute])]) ?></p>
     <?php endif; ?>
 </div>

--- a/templates/element/session_panel.php
+++ b/templates/element/session_panel.php
@@ -14,9 +14,9 @@
 
 /**
  * @var \DebugKit\View\AjaxView $this
- * @var array $content
+ * @var array<\Cake\Error\Debug\NodeInterface> $content
  */
 ?>
 <div class="c-session-panel">
-    <?= $this->Toolbar->dump($content) ?>
+    <?= $this->Toolbar->dumpNodes($content) ?>
 </div>

--- a/templates/element/session_panel.php
+++ b/templates/element/session_panel.php
@@ -14,9 +14,9 @@
 
 /**
  * @var \DebugKit\View\AjaxView $this
- * @var array<\Cake\Error\Debug\NodeInterface> $content
+ * @var \Cake\Error\Debug\NodeInterface $content
  */
 ?>
 <div class="c-session-panel">
-    <?= $this->Toolbar->dumpNodes($content) ?>
+    <?= $this->Toolbar->dumpNode($content) ?>
 </div>

--- a/templates/element/variables_panel.php
+++ b/templates/element/variables_panel.php
@@ -16,7 +16,6 @@
  * @var string $error
  * @var bool|null $sort
  * @var array $variables
- * @var array $content
  * @var array $errors
  */
 ?>
@@ -33,22 +32,6 @@
         $msg .= 'Increasing the depth value can lead to an out of memory error.';
         printf('<p class="c-flash c-flash--info">%s</p>', $msg);
     }
-
-    // Backwards compatibility for old debug kit data.
-    if (!empty($content)) :?>
-        <div class="o-checkbox">
-            <label>
-                <input
-                    type="checkbox"
-                    class="js-debugkit-sort-variables"
-                    <?= $sort ? ' checked="checked"' : '' ?>>
-                    Sort variables by name
-            </label>
-        </div>
-        <?php
-        $this->Toolbar->setSort($sort);
-        echo $this->Toolbar->dump($content);
-    endif;
 
     // New node based data.
     if (!empty($variables)) :?>
@@ -68,7 +51,7 @@
 
     if (!empty($errors)) :
         echo '<h4>Validation errors</h4>';
-        echo $this->Toolbar->dump($errors);
+        echo $this->Toolbar->dumpNodes($errors);
     endif;
     ?>
 </div>

--- a/tests/TestCase/FixtureFactoryTrait.php
+++ b/tests/TestCase/FixtureFactoryTrait.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
  */
 namespace DebugKit\Test\TestCase;
 
+use Cake\Error\Debugger;
+
 trait FixtureFactoryTrait
 {
     protected function makeRequest()
@@ -33,19 +35,23 @@ trait FixtureFactoryTrait
         if ($content === null) {
             $content = [
                 'attributes' => [
-                    'params' => [
-                        'plugin' => null,
-                        'controller' => 'Tasks',
-                        'action' => 'add',
-                        '_ext' => null,
-                        'pass' => [],
-                    ],
+                    Debugger::exportVarAsNodes([
+                        'params' => [
+                            'plugin' => null,
+                            'controller' => 'Tasks',
+                            'action' => 'add',
+                            '_ext' => null,
+                            'pass' => [],
+                        ],
+                    ]),
                 ],
                 'query' => [],
                 'data' => [],
                 'get' => [],
                 'cookie' => [
-                    'toolbarDisplay' => 'show',
+                    Debugger::exportVarAsNodes([
+                        'toolbarDisplay' => 'show',
+                    ]),
                 ],
             ];
         }

--- a/tests/TestCase/FixtureFactoryTrait.php
+++ b/tests/TestCase/FixtureFactoryTrait.php
@@ -45,14 +45,12 @@ trait FixtureFactoryTrait
                         ],
                     ]),
                 ],
-                'query' => [],
-                'data' => [],
-                'get' => [],
-                'cookie' => [
-                    Debugger::exportVarAsNodes([
-                        'toolbarDisplay' => 'show',
-                    ]),
-                ],
+                'query' => Debugger::exportVarAsNodes([]),
+                'data' => Debugger::exportVarAsNodes([]),
+                'get' => Debugger::exportVarAsNodes([]),
+                'cookie' => Debugger::exportVarAsNodes([
+                    'toolbarDisplay' => 'show',
+                ]),
             ];
         }
         $panels = $this->getTableLocator()->get('DebugKit.Panels');

--- a/tests/TestCase/Panel/IncludePanelTest.php
+++ b/tests/TestCase/Panel/IncludePanelTest.php
@@ -51,13 +51,8 @@ class IncludePanelTest extends TestCase
         $data = $this->panel->data();
         $this->assertArrayHasKey('cake', $data);
         $this->assertArrayHasKey('app', $data);
-
         $this->assertArrayHasKey('plugins', $data);
-        $this->assertArrayHasKey('DebugKit', $data['plugins']);
-        $this->assertArrayHasKey('other', $data['plugins']['DebugKit']);
-
         $this->assertArrayHasKey('vendor', $data);
-
         $this->assertArrayHasKey('other', $data);
     }
 
@@ -69,6 +64,6 @@ class IncludePanelTest extends TestCase
     public function testSummary()
     {
         $total = $this->panel->summary();
-        $this->assertGreaterThan(50, $total);
+        $this->assertEquals(5, $total);
     }
 }

--- a/tests/TestCase/Panel/RequestPanelTest.php
+++ b/tests/TestCase/Panel/RequestPanelTest.php
@@ -64,7 +64,7 @@ class RequestPanelTest extends TestCase
 
         $data = $this->panel->data();
         $this->assertArrayHasKey('attributes', $data);
-        $this->assertEquals('string', $data['attributes']['ok']);
-        $this->assertStringContainsString('Could not serialize `closure`', $data['attributes']['closure']);
+        $this->assertEquals('string', $data['attributes']['ok']->getType());
+        $this->assertStringContainsString('Could not serialize `closure`', $data['attributes']['closure']->getValue());
     }
 }

--- a/tests/TestCase/Panel/SessionPanelTest.php
+++ b/tests/TestCase/Panel/SessionPanelTest.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
+ **/
+namespace DebugKit\Test\TestCase\Panel;
+
+use Cake\Controller\Controller;
+use Cake\Event\Event;
+use Cake\Http\ServerRequest;
+use Cake\Http\Session;
+use Cake\TestSuite\TestCase;
+use DebugKit\Panel\SessionPanel;
+
+/**
+ * Class RequestPanelTest
+ */
+class SessionPanelTest extends TestCase
+{
+    /**
+     * @var SessionPanel
+     */
+    protected $panel;
+
+    /**
+     * set up
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->panel = new SessionPanel();
+    }
+
+    /**
+     * Test that shutdown will skip unserializable attributes.
+     *
+     * @return void
+     */
+    public function testShutdownSkipAttributes()
+    {
+        $session = new Session();
+        $session->write('test', 123);
+        $request = new ServerRequest([
+            'session' => $session,
+        ]);
+
+        $controller = new Controller($request);
+        $event = new Event('Controller.shutdown', $controller);
+        $this->panel->shutdown($event);
+
+        $data = $this->panel->data();
+        $this->assertArrayHasKey('content', $data);
+        /** @var \Cake\Error\Debug\ArrayItemNode $content */
+        $content = $data['content']->getChildren()[0];
+        $this->assertEquals('test', $content->getKey()->getValue());
+        $this->assertEquals('123', $content->getValue()->getValue());
+    }
+}

--- a/tests/TestCase/Panel/VariablesPanelTest.php
+++ b/tests/TestCase/Panel/VariablesPanelTest.php
@@ -96,6 +96,7 @@ class VariablesPanelTest extends TestCase
             'string' => 'yes',
             'array' => ['some' => 'key'],
             'notSerializableForm' => new TestForm(),
+            'emptyEntity' => $requests->newEmptyEntity(),
         ];
         $controller->viewBuilder()->setVars($vars);
         $event = new Event('Controller.shutdown', $controller);


### PR DESCRIPTION
Haven't fully tried it with a test app but this removes the `ToolbarHelper::dump()` method which was marked as deprecated.

The tests working with `SimpleXmlElement` created some problems for me locally since the JS contained in the Debugger Header did not parse well as XML. Therfore I changed the test implementation to use `DOMDocument`.

Update: Nope, there are definitely some problems still present.