### PR TITLE
5.x: remove turbolinks support

### DIFF
--- a/webroot/js/inject-iframe.js
+++ b/webroot/js/inject-iframe.js
@@ -93,23 +93,14 @@ if (elem) {
     };
   };
 
-  // Bind on ready callbacks to DOMContentLoaded (native js) and turbolinks:load
-  // Turbolinks replaces the body and merges the head of an HTML page.
+  // Bind on ready callbacks to DOMContentLoaded (native js)
   // Since the body is already loaded (DOMContentLoaded), the event is not triggered.
   if (doc.addEventListener) {
     // This ensures that all event listeners get applied only once.
     if (!win.debugKitListenersApplied) {
-      // The DOMContentLoaded is for all pages that do not have Turbolinks
       doc.addEventListener('DOMContentLoaded', onReady, false);
       doc.addEventListener('DOMContentLoaded', proxyAjaxOpen, false);
       doc.addEventListener('DOMContentLoaded', proxyAjaxSend, false);
-
-      // turbolinks:load is the alternative DOMContentLoaded Event of Turbolinks
-      // https://github.com/turbolinks/turbolinks
-      // https://github.com/cakephp/debug_kit/pull/664
-      doc.addEventListener('turbolinks:load', onReady, false);
-      doc.addEventListener('turbolinks:load', proxyAjaxOpen, false);
-      doc.addEventListener('turbolinks:load', proxyAjaxSend, false);
       win.debugKitListenersApplied = true;
     }
   } else {


### PR DESCRIPTION
refs: https://github.com/cakephp/debug_kit/issues/758