### PR TITLE
927 - Fix DebugEngine not using fallback config

### DIFF
--- a/src/Panel/CachePanel.php
+++ b/src/Panel/CachePanel.php
@@ -55,9 +55,17 @@ class CachePanel extends DebugPanel
             if (isset($config['className']) && $config['className'] instanceof DebugEngine) {
                 $instance = $config['className'];
             } elseif (isset($config['className'])) {
-                Cache::drop($name);
-                $instance = new DebugEngine($config, $name, $this->logger);
+                /** @var \Cake\Cache\CacheEngine $engine */
+                $engine = Cache::pool($name);
+                // Unload from the cache registry so that subsequence calls to
+                // Cache::pool($name) use the new config with DebugEngine instance set below.
+                Cache::getRegistry()->unload($name);
+
+                $instance = new DebugEngine($engine, $name, $this->logger);
+                $instance->init();
                 $config['className'] = $instance;
+
+                Cache::drop($name);
                 Cache::setConfig($name, $config);
             }
             if (isset($instance)) {


### PR DESCRIPTION
Fixes #927 

@ADmad I have tested your code and fixed call to init to ensure `$this->_engine` is initialised properly. Please feel free to close this MR and push the code yourself since most of it is yours. 