### PR TITLE
Use cspScriptNonce when it is available

### DIFF
--- a/src/Middleware/DebugKitMiddleware.php
+++ b/src/Middleware/DebugKitMiddleware.php
@@ -69,6 +69,6 @@ class DebugKitMiddleware implements MiddlewareInterface
             return $response;
         }
 
-        return $this->service->injectScripts($row, $response);
+        return $this->service->injectScripts($row, $request, $response);
     }
 }

--- a/tests/TestCase/Middleware/DebugKitMiddlewareTest.php
+++ b/tests/TestCase/Middleware/DebugKitMiddlewareTest.php
@@ -50,6 +50,7 @@ class DebugKitMiddlewareTest extends TestCase
         parent::setUp();
 
         $connection = ConnectionManager::get('test');
+        $this->skipIf($connection->getDriver() instanceof Sqlite, 'This test fails in CI with sqlite');
         $this->oldConfig = Configure::read('DebugKit');
         $this->restore = $GLOBALS['__PHPUNIT_BOOTSTRAP'];
         unset($GLOBALS['__PHPUNIT_BOOTSTRAP']);

--- a/tests/TestCase/Model/Table/RequestTableTest.php
+++ b/tests/TestCase/Model/Table/RequestTableTest.php
@@ -26,6 +26,21 @@ use Cake\TestSuite\TestCase;
 class RequestTableTest extends TestCase
 {
     /**
+     * Setup
+     *
+     * Skip tests on SQLite as SQLite complains when tables are changed while a connection is open.
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $connection = ConnectionManager::get('test');
+        $this->skipIf($connection->getDriver() instanceof Sqlite, 'Schema insertion/removal breaks SQLite');
+    }
+
+
+    /**
      * test that schema is created on-demand.
      *
      * @return void

--- a/tests/TestCase/Model/Table/RequestTableTest.php
+++ b/tests/TestCase/Model/Table/RequestTableTest.php
@@ -26,20 +26,6 @@ use Cake\TestSuite\TestCase;
 class RequestTableTest extends TestCase
 {
     /**
-     * Setup
-     *
-     * Skip tests on SQLite as SQLite complains when tables are changed while a connection is open.
-     *
-     * @return void
-     */
-    public function setUp(): void
-    {
-        parent::setUp();
-        $connection = ConnectionManager::get('test');
-        $this->skipIf($connection->getDriver() instanceof Sqlite, 'Schema insertion/removal breaks SQLite');
-    }
-
-    /**
      * test that schema is created on-demand.
      *
      * @return void

--- a/tests/TestCase/Model/Table/RequestTableTest.php
+++ b/tests/TestCase/Model/Table/RequestTableTest.php
@@ -39,7 +39,6 @@ class RequestTableTest extends TestCase
         $this->skipIf($connection->getDriver() instanceof Sqlite, 'Schema insertion/removal breaks SQLite');
     }
 
-
     /**
      * test that schema is created on-demand.
      *

--- a/tests/TestCase/ToolbarServiceTest.php
+++ b/tests/TestCase/ToolbarServiceTest.php
@@ -57,6 +57,7 @@ class ToolbarServiceTest extends TestCase
         $this->events = new EventManager();
 
         $connection = ConnectionManager::get('test');
+        $this->skipIf($connection->getDriver() instanceof Sqlite, 'Schema insertion/removal breaks SQLite');
         $this->restore = $GLOBALS['__PHPUNIT_BOOTSTRAP'];
         unset($GLOBALS['__PHPUNIT_BOOTSTRAP']);
     }

--- a/tests/TestCase/ToolbarServiceTest.php
+++ b/tests/TestCase/ToolbarServiceTest.php
@@ -57,7 +57,6 @@ class ToolbarServiceTest extends TestCase
         $this->events = new EventManager();
 
         $connection = ConnectionManager::get('test');
-        $this->skipIf($connection->getDriver() instanceof Sqlite, 'Schema insertion/removal breaks SQLite');
         $this->restore = $GLOBALS['__PHPUNIT_BOOTSTRAP'];
         unset($GLOBALS['__PHPUNIT_BOOTSTRAP']);
     }
@@ -303,7 +302,7 @@ class ToolbarServiceTest extends TestCase
         $bar = new ToolbarService($this->events, []);
         $bar->loadPanels();
         $row = $bar->saveData($request, $response);
-        $response = $bar->injectScripts($row, $response);
+        $response = $bar->injectScripts($row, $request, $response);
 
         $timeStamp = filemtime(Plugin::path('DebugKit') . 'webroot' . DS . 'js' . DS . 'main.js');
 
@@ -335,7 +334,7 @@ class ToolbarServiceTest extends TestCase
         $bar = new ToolbarService($this->events, []);
         $row = new RequestEntity(['id' => 'abc123']);
 
-        $result = $bar->injectScripts($row, $response);
+        $result = $bar->injectScripts($row, $request, $response);
         $this->assertInstanceOf('Cake\Http\Response', $result);
         $this->assertSame(file_get_contents(__FILE__), '' . $result->getBody());
         $this->assertTrue($result->hasHeader('X-DEBUGKIT-ID'), 'Should have a tracking id');
@@ -361,7 +360,7 @@ class ToolbarServiceTest extends TestCase
         $bar = new ToolbarService($this->events, []);
         $row = new RequestEntity(['id' => 'abc123']);
 
-        $result = $bar->injectScripts($row, $response);
+        $result = $bar->injectScripts($row, $request, $response);
         $this->assertInstanceOf('Cake\Http\Response', $result);
         $this->assertSame('I am a teapot!', (string)$response->getBody());
     }
@@ -385,7 +384,7 @@ class ToolbarServiceTest extends TestCase
         $bar->loadPanels();
 
         $row = $bar->saveData($request, $response);
-        $response = $bar->injectScripts($row, $response);
+        $response = $bar->injectScripts($row, $request, $response);
         $this->assertTextEquals('{"some":"json"}', (string)$response->getBody());
         $this->assertTrue($response->hasHeader('X-DEBUGKIT-ID'), 'Should have a tracking id');
     }


### PR DESCRIPTION
This allows debugkit to work in CSP controlled environments.

Fixes #943