### PR TITLE
Read cspScriptNonce from latest request

### DIFF
--- a/src/Middleware/DebugKitMiddleware.php
+++ b/src/Middleware/DebugKitMiddleware.php
@@ -69,6 +69,6 @@ class DebugKitMiddleware implements MiddlewareInterface
             return $response;
         }
 
-        return $this->service->injectScripts($row, $request, $response);
+        return $this->service->injectScripts($row, $response);
     }
 }

--- a/src/ToolbarService.php
+++ b/src/ToolbarService.php
@@ -25,7 +25,6 @@ use Cake\Routing\Router;
 use DebugKit\Panel\PanelRegistry;
 use PDOException;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Used to create the panels and inject a toolbar into
@@ -338,11 +337,10 @@ class ToolbarService
      * contains HTML and there is a </body> tag.
      *
      * @param \DebugKit\Model\Entity\Request $row The request data to inject.
-     * @param \Psr\Http\Message\ServerRequestInterface $request The request to augment.
      * @param \Psr\Http\Message\ResponseInterface $response The response to augment.
      * @return \Psr\Http\Message\ResponseInterface The modified response
      */
-    public function injectScripts($row, ServerRequestInterface $request, ResponseInterface $response)
+    public function injectScripts($row, ResponseInterface $response)
     {
         $response = $response->withHeader('X-DEBUGKIT-ID', (string)$row->id);
         if (strpos($response->getHeaderLine('Content-Type'), 'html') === false) {
@@ -359,9 +357,14 @@ class ToolbarService
         if ($pos === false) {
             return $response;
         }
-        $nonce = $request->getAttribute('cspScriptNonce');
-        if ($nonce) {
-            $nonce = sprintf(' nonce="%s"', $nonce);
+        // Use Router to get the request so that we can see the
+        // state after other middleware have been applied.
+        $request = Router::getRequest();
+        if ($request) {
+            $nonce = $request->getAttribute('cspScriptNonce');
+            if ($nonce) {
+                $nonce = sprintf(' nonce="%s"', $nonce);
+            }
         }
 
         $url = Router::url('/', true);

--- a/src/ToolbarService.php
+++ b/src/ToolbarService.php
@@ -360,11 +360,9 @@ class ToolbarService
         // Use Router to get the request so that we can see the
         // state after other middleware have been applied.
         $request = Router::getRequest();
-        if ($request) {
-            $nonce = $request->getAttribute('cspScriptNonce');
-            if ($nonce) {
-                $nonce = sprintf(' nonce="%s"', $nonce);
-            }
+        $nonce = '';
+        if ($request && $request->getAttribute('cspScriptNonce')) {
+            $nonce = sprintf(' nonce="%s"', $request->getAttribute('cspScriptNonce'));
         }
 
         $url = Router::url('/', true);

--- a/tests/TestCase/Middleware/DebugKitMiddlewareTest.php
+++ b/tests/TestCase/Middleware/DebugKitMiddlewareTest.php
@@ -21,6 +21,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\Http\CallbackStream;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
+use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use DebugKit\Middleware\DebugKitMiddleware;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -122,7 +123,7 @@ class DebugKitMiddlewareTest extends TestCase
         $this->assertNotNull($result->panels[11]->summary);
         $this->assertSame('Sql Log', $result->panels[11]->title);
 
-        $timeStamp = filemtime(Plugin::path('DebugKit') . 'webroot' . DS . 'js' . DS . 'main.js');
+        $timeStamp = filemtime(Plugin::path('DebugKit') . 'webroot' . DS . 'js' . DS . 'inject-iframe.js');
 
         $expected = '<html><title>test</title><body><p>some text</p>' .
             '<script id="__debug_kit_script" data-id="' . $result->id . '" ' .
@@ -144,6 +145,7 @@ class DebugKitMiddlewareTest extends TestCase
             'environment' => ['REQUEST_METHOD' => 'GET'],
         ]);
         $request = $request->withAttribute('cspScriptNonce', 'csp-nonce');
+        Router::setRequest($request);
 
         $response = new Response([
             'statusCode' => 200,

--- a/tests/TestCase/ToolbarServiceTest.php
+++ b/tests/TestCase/ToolbarServiceTest.php
@@ -22,6 +22,7 @@ use Cake\Event\EventManager;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest as Request;
 use Cake\Log\Log;
+use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use DebugKit\Model\Entity\Request as RequestEntity;
 use DebugKit\ToolbarService;
@@ -294,6 +295,7 @@ class ToolbarServiceTest extends TestCase
             'url' => '/articles',
             'environment' => ['REQUEST_METHOD' => 'GET'],
         ]);
+        Router::setRequest($request);
         $response = new Response([
             'statusCode' => 200,
             'type' => 'text/html',
@@ -303,7 +305,7 @@ class ToolbarServiceTest extends TestCase
         $bar = new ToolbarService($this->events, []);
         $bar->loadPanels();
         $row = $bar->saveData($request, $response);
-        $response = $bar->injectScripts($row, $request, $response);
+        $response = $bar->injectScripts($row, response);
 
         $timeStamp = filemtime(Plugin::path('DebugKit') . 'webroot' . DS . 'js' . DS . 'main.js');
 
@@ -322,10 +324,6 @@ class ToolbarServiceTest extends TestCase
      */
     public function testInjectScriptsFileBodies()
     {
-        $request = new Request([
-            'url' => '/articles',
-            'params' => ['plugin' => null],
-        ]);
         $response = new Response([
             'statusCode' => 200,
             'type' => 'text/html',
@@ -335,7 +333,7 @@ class ToolbarServiceTest extends TestCase
         $bar = new ToolbarService($this->events, []);
         $row = new RequestEntity(['id' => 'abc123']);
 
-        $result = $bar->injectScripts($row, $request, $response);
+        $result = $bar->injectScripts($row, $response);
         $this->assertInstanceOf('Cake\Http\Response', $result);
         $this->assertSame(file_get_contents(__FILE__), '' . $result->getBody());
         $this->assertTrue($result->hasHeader('X-DEBUGKIT-ID'), 'Should have a tracking id');
@@ -348,10 +346,6 @@ class ToolbarServiceTest extends TestCase
      */
     public function testInjectScriptsStreamBodies()
     {
-        $request = new Request([
-            'url' => '/articles',
-            'params' => ['plugin' => null],
-        ]);
         $response = new Response([
             'statusCode' => 200,
             'type' => 'text/html',
@@ -361,7 +355,7 @@ class ToolbarServiceTest extends TestCase
         $bar = new ToolbarService($this->events, []);
         $row = new RequestEntity(['id' => 'abc123']);
 
-        $result = $bar->injectScripts($row, $request, $response);
+        $result = $bar->injectScripts($row, $response);
         $this->assertInstanceOf('Cake\Http\Response', $result);
         $this->assertSame('I am a teapot!', (string)$response->getBody());
     }
@@ -373,8 +367,6 @@ class ToolbarServiceTest extends TestCase
      */
     public function testInjectScriptsNoModifyResponse()
     {
-        $request = new Request(['url' => '/articles']);
-
         $response = new Response([
             'statusCode' => 200,
             'type' => 'application/json',
@@ -385,7 +377,7 @@ class ToolbarServiceTest extends TestCase
         $bar->loadPanels();
 
         $row = $bar->saveData($request, $response);
-        $response = $bar->injectScripts($row, $request, $response);
+        $response = $bar->injectScripts($row, $response);
         $this->assertTextEquals('{"some":"json"}', (string)$response->getBody());
         $this->assertTrue($response->hasHeader('X-DEBUGKIT-ID'), 'Should have a tracking id');
     }

--- a/tests/TestCase/ToolbarServiceTest.php
+++ b/tests/TestCase/ToolbarServiceTest.php
@@ -305,9 +305,9 @@ class ToolbarServiceTest extends TestCase
         $bar = new ToolbarService($this->events, []);
         $bar->loadPanels();
         $row = $bar->saveData($request, $response);
-        $response = $bar->injectScripts($row, response);
+        $response = $bar->injectScripts($row, $response);
 
-        $timeStamp = filemtime(Plugin::path('DebugKit') . 'webroot' . DS . 'js' . DS . 'main.js');
+        $timeStamp = filemtime(Plugin::path('DebugKit') . 'webroot' . DS . 'js' . DS . 'inject-iframe.js');
 
         $expected = '<html><title>test</title><body><p>some text</p>' .
             '<script id="__debug_kit_script" data-id="' . $row->id . '" ' .
@@ -367,6 +367,10 @@ class ToolbarServiceTest extends TestCase
      */
     public function testInjectScriptsNoModifyResponse()
     {
+        $request = new Request([
+            'url' => '/articles/view/123',
+            'params' => [],
+        ]);
         $response = new Response([
             'statusCode' => 200,
             'type' => 'application/json',


### PR DESCRIPTION
Use Router::getRequest() to access the request from before controllers were dispatched and after middleware have been run. This should ensure that the CSP script nonce is present in the request.

Refs #943