### PR TITLE
Add external panel info

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,7 @@ requests](https://help.github.com/articles/using-pull-requests) or open
 
 Documentation for DebugKit can be found in the
 [CakePHP documentation](https://book.cakephp.org/debugkit/5/en/index.html).
+
+## Panels
+Panels by other plugins:
+- `L10n` by [Setup plugin](https://github.com/dereuromark/cakephp-setup) to show current localization for Date, DateTime, Time objects/values.


### PR DESCRIPTION
See https://github.com/dereuromark/cakephp-setup/blob/master/docs/Panel/L10nPanel.md

![L10n](https://github.com/cakephp/debug_kit/assets/39854/8afa9a71-400f-4a57-a10d-bf58b06db92d)


Do we want to add here other external panels for easier showcasing and people being able to pull them in?