### PR TITLE
Fixed ReflectionProperty::setValue() deprecation warning when working on PHP 8.3

### DIFF
--- a/src/Panel/MailPanel.php
+++ b/src/Panel/MailPanel.php
@@ -67,7 +67,7 @@ class MailPanel extends DebugPanel
 
             $configs[$name] = $transport;
         }
-        $property->setValue($configs);
+        $reflection->setStaticPropertyValue('_config', $configs);
     }
 
     /**


### PR DESCRIPTION
On PHP 8.3 you get this deprecation warning:

<img width="1292" alt="image" src="https://github.com/cakephp/debug_kit/assets/1457444/59917256-fb57-4a7c-b297-a20753538377">

I've changed the deprecated method out with the correct method. All tests (non -skipped) pass, and I can't see any issues.