### PR TITLE
Fix for deprecation warning in SimpleGraphHelper::bar()

### DIFF
--- a/src/View/Helper/SimpleGraphHelper.php
+++ b/src/View/Helper/SimpleGraphHelper.php
@@ -47,12 +47,12 @@ class SimpleGraphHelper extends Helper
     /**
      * bar method
      *
-     * @param float $value Value to be graphed
-     * @param int $offset how much indentation
+     * @param float|int $value Value to be graphed
+     * @param float|int $offset how much indentation
      * @param array $options Graph options
      * @return string Html graph
      */
-    public function bar(float $value, int $offset, array $options = []): string
+    public function bar(float|int $value, float|int $offset, array $options = []): string
     {
         $settings = array_merge($this->_defaultSettings, $options);
         $max = $settings['max'];

--- a/tests/TestCase/View/Helper/SimpleGraphHelperTest.php
+++ b/tests/TestCase/View/Helper/SimpleGraphHelperTest.php
@@ -138,5 +138,4 @@ class SimpleGraphHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $output);
     }
-
 }

--- a/tests/TestCase/View/Helper/SimpleGraphHelperTest.php
+++ b/tests/TestCase/View/Helper/SimpleGraphHelperTest.php
@@ -113,4 +113,30 @@ class SimpleGraphHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $output);
     }
+
+    /**
+     * Test bar() using float offset values
+     *
+     * @return void
+     */
+    public function testBarWithFloat()
+    {
+        $output = $this->Graph->bar(10.5, 10.5);
+        $expected = [
+            ['div' => [
+                'class' => 'c-graph-bar',
+                'style' => 'width: 350px',
+            ]],
+            ['div' => [
+                'class' => 'c-graph-bar__value',
+                'style' => 'margin-left: 37px; width: 37px',
+                'title' => 'Starting 10.5ms into the request, taking 10.5ms',
+            ]],
+            ' ',
+            '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $output);
+    }
+
 }


### PR DESCRIPTION
When using DebugKit, on the Timer tab the bar graphs all display an error message:

`Deprecated (8192): Implicit conversion from float 126.51705741882324 to int loses precision [in /var/cake/vendor/cakephp/debug_kit/src/View/Helper/SimpleGraphHelper.php, line 55]`

The bar() function currently uses these parameters like this:
`$value`:
`$graphValue = $value / $max * $width;`

`$offset`:
`$graphOffset = $offset / $max * $width;`

Both new `$graph*` values are then provided to round(), which handles conversion to int.  The raw values are then only used in displaying the message. From what I can tell, this function can handle float as well as int values, and this fix updates the type hint to allow the actual consumers of the function to use it as they have historically. 

Added a new test to cover the explicit case. All test cases pass.