### PR TITLE
Improve log integration for elasticearch

### DIFF
--- a/src/Database/Log/DebugLog.php
+++ b/src/Database/Log/DebugLog.php
@@ -144,7 +144,7 @@ class DebugLog extends AbstractLogger
                     'path' => $context['request']['path'],
                     'data' => $context['request']['data'],
                 ], JSON_PRETTY_PRINT),
-                'took' => $took ?: 0,
+                'took' => 0,
                 'rows' => $context['response']['hits']['total']['value'] ?? $context['response']['hits']['total'] ?? 0,
             ];
 

--- a/src/Database/Log/DebugLog.php
+++ b/src/Database/Log/DebugLog.php
@@ -144,7 +144,7 @@ class DebugLog extends AbstractLogger
                     'path' => $context['request']['path'],
                     'data' => $context['request']['data'],
                 ], JSON_PRETTY_PRINT),
-                'took' => 0,
+                'took' => $took,
                 'rows' => $context['response']['hits']['total']['value'] ?? $context['response']['hits']['total'] ?? 0,
             ];
 

--- a/src/Database/Log/DebugLog.php
+++ b/src/Database/Log/DebugLog.php
@@ -135,7 +135,8 @@ class DebugLog extends AbstractLogger
 
         // This specific to Elastic Search
         if (!$query instanceof LoggedQuery && isset($context['request']) && isset($context['response'])) {
-            $this->_totalTime += $context['response']['took'];
+            $took = $context['response']['took'] ?? 0;
+            $this->_totalTime += $took;
 
             $this->_queries[] = [
                 'query' => json_encode([
@@ -143,7 +144,7 @@ class DebugLog extends AbstractLogger
                     'path' => $context['request']['path'],
                     'data' => $context['request']['data'],
                 ], JSON_PRETTY_PRINT),
-                'took' => $context['response']['took'] ?: 0,
+                'took' => $took ?: 0,
                 'rows' => $context['response']['hits']['total']['value'] ?? $context['response']['hits']['total'] ?? 0,
             ];
 

--- a/tests/TestCase/Database/Log/DebugLogTest.php
+++ b/tests/TestCase/Database/Log/DebugLogTest.php
@@ -73,9 +73,6 @@ class DebugLogTest extends TestCase
      */
     public function testLogElastic()
     {
-        $query = [
-        ];
-
         $this->assertCount(0, $this->logger->queries());
 
         $this->logger->log(LogLevel::DEBUG, 'title:Good', [

--- a/tests/TestCase/Database/Log/DebugLogTest.php
+++ b/tests/TestCase/Database/Log/DebugLogTest.php
@@ -67,6 +67,50 @@ class DebugLogTest extends TestCase
     }
 
     /**
+     * Test logs being stored.
+     *
+     * @return void
+     */
+    public function testLogElastic()
+    {
+        $query = [
+        ];
+
+        $this->assertCount(0, $this->logger->queries());
+
+        $this->logger->log(LogLevel::DEBUG, 'title:Good', [
+            'query' => 'title:Good',
+            'request' => [
+                'method' => 'GET',
+                'path' => '/articles/_search',
+                'data' => '',
+            ],
+            'response' => [
+                'took' => 10,
+                'hits' => [
+                    'total' => 15,
+                ],
+            ],
+        ]);
+        $this->assertCount(1, $this->logger->queries());
+        $this->assertEquals(10, $this->logger->totalTime());
+
+        $this->logger->log(LogLevel::DEBUG, 'title:Best', [
+            'query' => 'title:Best',
+            'request' => [
+                'method' => 'GET',
+                'path' => '/articles/_search',
+                'data' => '',
+            ],
+            'response' => [
+                'lol' => 'nope',
+            ],
+        ]);
+        $this->assertCount(2, $this->logger->queries());
+        $this->assertEquals(10, $this->logger->totalTime());
+    }
+
+    /**
      * Test log ignores schema reflection
      *
      * @dataProvider schemaQueryProvider


### PR DESCRIPTION
Not all queries have 'took'. Account for that and use defaults values.

Fixes #989