### PR TITLE
5.x nesting depth

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -64,6 +64,9 @@ Configuration
 
 * ``DebugKit.ignoreAuthorization`` - Set to true to ignore Cake Authorization plugin for DebugKit requests. Disabled by default.
 
+* ``DebugKit.maxDepth`` - Defines how many levels of nested data should be shown in general for debug output. Default is 5.
+  WARNING: Increasing the max depth level can lead to an out of memory error.::
+
 * ``DebugKit.variablesPanelMaxDepth`` - Defines how many levels of nested data should be shown in the variables tab. Default is 5.
   WARNING: Increasing the max depth level can lead to an out of memory error.::
 

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -67,6 +67,9 @@ Configuration
 * ``DebugKit.maxDepth`` - Defines how many levels of nested data should be shown in general for debug output. Default is 5.
   WARNING: Increasing the max depth level can lead to an out of memory error.::
 
+    // Show more levels
+    Configure::write('DebugKit.maxDepth', 8);
+
 * ``DebugKit.variablesPanelMaxDepth`` - Defines how many levels of nested data should be shown in the variables tab. Default is 5.
   WARNING: Increasing the max depth level can lead to an out of memory error.::
 

--- a/src/Panel/RequestPanel.php
+++ b/src/Panel/RequestPanel.php
@@ -36,6 +36,7 @@ class RequestPanel extends DebugPanel
         /** @var \Cake\Controller\Controller $controller */
         $controller = $event->getSubject();
         $request = $controller->getRequest();
+        $maxDepth = Configure::read('DebugKit.maxDepth', 5);
 
         $attributes = [];
         foreach ($request->getAttributes() as $attr => $value) {
@@ -44,15 +45,15 @@ class RequestPanel extends DebugPanel
             } catch (Exception $e) {
                 $value = "Could not serialize `{$attr}`. It failed with {$e->getMessage()}";
             }
-            $attributes[$attr] = Debugger::exportVarAsNodes($value, Configure::read('DebugKit.maxDepth', 5));
+            $attributes[$attr] = Debugger::exportVarAsNodes($value, $maxDepth);
         }
 
         $this->_data = [
             'attributes' => $attributes,
-            'query' => Debugger::exportVarAsNodes($request->getQueryParams(), Configure::read('DebugKit.maxDepth', 5)),
-            'data' => Debugger::exportVarAsNodes($request->getData(), Configure::read('DebugKit.maxDepth', 5)),
-            'cookie' => Debugger::exportVarAsNodes($request->getCookieParams(), Configure::read('DebugKit.maxDepth', 5)),
-            'get' => Debugger::exportVarAsNodes($_GET, Configure::read('DebugKit.maxDepth', 5)),
+            'query' => Debugger::exportVarAsNodes($request->getQueryParams(), $maxDepth),
+            'data' => Debugger::exportVarAsNodes($request->getData(), $maxDepth),
+            'cookie' => Debugger::exportVarAsNodes($request->getCookieParams(), $maxDepth),
+            'get' => Debugger::exportVarAsNodes($_GET, $maxDepth),
             'matchedRoute' => $request->getParam('_matchedRoute'),
             'headers' => [
                 'response' => headers_sent($file, $line),

--- a/src/Panel/RequestPanel.php
+++ b/src/Panel/RequestPanel.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 namespace DebugKit\Panel;
 
+use Cake\Core\Configure;
 use Cake\Error\Debugger;
 use Cake\Event\EventInterface;
 use DebugKit\DebugPanel;
@@ -43,15 +44,15 @@ class RequestPanel extends DebugPanel
             } catch (Exception $e) {
                 $value = "Could not serialize `{$attr}`. It failed with {$e->getMessage()}";
             }
-            $attributes[$attr] = Debugger::exportVarAsNodes($value);
+            $attributes[$attr] = Debugger::exportVarAsNodes($value, Configure::read('DebugKit.maxDepth', 5));
         }
 
         $this->_data = [
             'attributes' => $attributes,
-            'query' => Debugger::exportVarAsNodes($request->getQueryParams()),
-            'data' => Debugger::exportVarAsNodes($request->getData()),
-            'cookie' => Debugger::exportVarAsNodes($request->getCookieParams()),
-            'get' => Debugger::exportVarAsNodes($_GET),
+            'query' => Debugger::exportVarAsNodes($request->getQueryParams(), Configure::read('DebugKit.maxDepth', 5)),
+            'data' => Debugger::exportVarAsNodes($request->getData(), Configure::read('DebugKit.maxDepth', 5)),
+            'cookie' => Debugger::exportVarAsNodes($request->getCookieParams(), Configure::read('DebugKit.maxDepth', 5)),
+            'get' => Debugger::exportVarAsNodes($_GET, Configure::read('DebugKit.maxDepth', 5)),
             'matchedRoute' => $request->getParam('_matchedRoute'),
             'headers' => [
                 'response' => headers_sent($file, $line),

--- a/src/Panel/SessionPanel.php
+++ b/src/Panel/SessionPanel.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 namespace DebugKit\Panel;
 
+use Cake\Core\Configure;
 use Cake\Error\Debugger;
 use Cake\Event\EventInterface;
 use DebugKit\DebugPanel;
@@ -34,7 +35,7 @@ class SessionPanel extends DebugPanel
         /** @var \Cake\Http\ServerRequest|null $request */
         $request = $event->getSubject()->getRequest();
         if ($request) {
-            $content = Debugger::exportVarAsNodes($request->getSession()->read());
+            $content = Debugger::exportVarAsNodes($request->getSession()->read(), Configure::read('DebugKit.maxDepth', 5));
             $this->_data = compact('content');
         }
     }

--- a/src/Panel/SessionPanel.php
+++ b/src/Panel/SessionPanel.php
@@ -35,7 +35,8 @@ class SessionPanel extends DebugPanel
         /** @var \Cake\Http\ServerRequest|null $request */
         $request = $event->getSubject()->getRequest();
         if ($request) {
-            $content = Debugger::exportVarAsNodes($request->getSession()->read(), Configure::read('DebugKit.maxDepth', 5));
+            $maxDepth = Configure::read('DebugKit.maxDepth', 5);
+            $content = Debugger::exportVarAsNodes($request->getSession()->read(), $maxDepth);
             $this->_data = compact('content');
         }
     }


### PR DESCRIPTION
This has been annoying the heck out of me for the last months

All the time, the default level of 3 for the other tabs (not Variables, which is already 5) is usually never enough, especially for session

    Auth.User.Profile.Image.id

etc

Fun fact: current level 3 doesnt even show content of Profile, so the count seems to be cut off already on level 2...

For now I always have to either
- hack the debug kit by putting a change into the Panel code inside vendor/, to increase to e.g. 5, bad idea
- workaround it using dd() or other debugging tools in the end
 
 not being able to trust debug kit to give me the details after clicking through the tree of elements only to find `[maximum depth reached]`

So I recommend we default to 5 here in general, and allow the other tabs to be configured as well.
I on purpose used a different key, as VariablesPanel is sure different as it contains really a LOT of data, compared to the others, So keeping that one at 5 while allowing the others to be safely used on e.g. 8 makes sense to me.

