### PR TITLE
Improve layout of copy buttons in environment panel

### DIFF
--- a/webroot/css/style.css
+++ b/webroot/css/style.css
@@ -277,6 +277,15 @@ strong {
     text-align: left;
 }
 
+/* Override styles in cake's default css */
+.c-debug-table .cake-debug-string {
+    margin-right: 48px;
+}
+/* correct height to fit with environment panel */
+.c-debug-table .cake-debug-copy {
+    padding: 5px 6px;
+}
+
 .c-debug-table .duplicate-route td {
     background: var(--duplicate-route);
 }


### PR DESCRIPTION
Don't overflow single line of text items.

### Before
![before from 2024-05-26 22-48-02](https://github.com/cakephp/debug_kit/assets/24086/2eb2e243-56be-4a83-a8d3-d60305385590)

### After

![after from 2024-05-26 22-57-52](https://github.com/cakephp/debug_kit/assets/24086/dfa55785-8e6a-4cba-8f23-935be9a65e61)
