### PR TITLE
Merge request & session and environment & include panels

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,15 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.20.0@3f284e96c9d9be6fe6b15c79416e1d1903dcfef4">
-  <file src="src/Cache/Engine/DebugEngine.php">
-    <RiskyTruthyFalsyComparison>
-      <code>$key</code>
-    </RiskyTruthyFalsyComparison>
-  </file>
-  <file src="src/Controller/MailPreviewController.php">
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[$this->findPart($email, $partType)]]></code>
-    </RiskyTruthyFalsyComparison>
-  </file>
+<files psalm-version="5.13.1@086b94371304750d1c673315321a55d15fc59015">
   <file src="src/Database/Log/DebugLog.php">
     <InternalMethod>
       <code>jsonSerialize</code>
@@ -21,42 +11,20 @@
       <code><![CDATA[$this->_pluginPaths]]></code>
     </PossiblyNullArrayOffset>
   </file>
-  <file src="src/DebugMemory.php">
-    <RiskyTruthyFalsyComparison>
-      <code>!$message</code>
-    </RiskyTruthyFalsyComparison>
-  </file>
   <file src="src/DebugSql.php">
     <InternalMethod>
       <code>bindings</code>
     </InternalMethod>
-    <RiskyTruthyFalsyComparison>
-      <code>$file</code>
-      <code>$file</code>
-      <code>$file</code>
-      <code>$line</code>
-      <code>$line</code>
-    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/DebugTimer.php">
     <PossiblyNullArrayOffset>
       <code>self::$_timers</code>
     </PossiblyNullArrayOffset>
-    <RiskyTruthyFalsyComparison>
-      <code>!$message</code>
-      <code>!$name</code>
-      <code>!$name</code>
-    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Mailer/MailPreview.php">
     <PossiblyFalseOperand>
       <code>$pos</code>
     </PossiblyFalseOperand>
-  </file>
-  <file src="src/Mailer/PreviewResult.php">
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[!$mailer->viewBuilder()->getTemplate()]]></code>
-    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Mailer/Transport/DebugKitTransport.php">
     <InvalidReturnStatement>
@@ -65,31 +33,6 @@
     <MoreSpecificReturnType>
       <code>array</code>
     </MoreSpecificReturnType>
-    <NullArgument>
-      <code><![CDATA[$this->emailLog]]></code>
-    </NullArgument>
-  </file>
-  <file src="src/Model/Table/LazyTableTrait.php">
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[strpos($e->getMessage(), 'unable to open')]]></code>
-    </RiskyTruthyFalsyComparison>
-  </file>
-  <file src="src/Panel/DeprecationsPanel.php">
-    <RiskyTruthyFalsyComparison>
-      <code>$pluginName</code>
-      <code>$vendorName</code>
-    </RiskyTruthyFalsyComparison>
-  </file>
-  <file src="src/Panel/IncludePanel.php">
-    <RiskyTruthyFalsyComparison>
-      <code>$pluginName</code>
-      <code>$vendorName</code>
-    </RiskyTruthyFalsyComparison>
-  </file>
-  <file src="src/Panel/LogPanel.php">
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[Log::getConfig('debug_kit_log_panel')]]></code>
-    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Panel/PanelRegistry.php">
     <LessSpecificImplementedReturnType>
@@ -103,12 +46,6 @@
     <UndefinedInterfaceMethod>
       <code>genericInstances</code>
     </UndefinedInterfaceMethod>
-  </file>
-  <file src="src/ToolbarService.php">
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[!$GLOBALS['FORCE_DEBUGKIT_TOOLBAR']]]></code>
-      <code>$enabled</code>
-    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/View/Helper/ToolbarHelper.php">
     <InternalClass>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.13.1@086b94371304750d1c673315321a55d15fc59015">
+<files psalm-version="5.20.0@3f284e96c9d9be6fe6b15c79416e1d1903dcfef4">
+  <file src="src/Cache/Engine/DebugEngine.php">
+    <RiskyTruthyFalsyComparison>
+      <code>$key</code>
+    </RiskyTruthyFalsyComparison>
+  </file>
+  <file src="src/Controller/MailPreviewController.php">
+    <RiskyTruthyFalsyComparison>
+      <code><![CDATA[$this->findPart($email, $partType)]]></code>
+    </RiskyTruthyFalsyComparison>
+  </file>
   <file src="src/Database/Log/DebugLog.php">
     <InternalMethod>
       <code>jsonSerialize</code>
@@ -11,20 +21,42 @@
       <code><![CDATA[$this->_pluginPaths]]></code>
     </PossiblyNullArrayOffset>
   </file>
+  <file src="src/DebugMemory.php">
+    <RiskyTruthyFalsyComparison>
+      <code>!$message</code>
+    </RiskyTruthyFalsyComparison>
+  </file>
   <file src="src/DebugSql.php">
     <InternalMethod>
       <code>bindings</code>
     </InternalMethod>
+    <RiskyTruthyFalsyComparison>
+      <code>$file</code>
+      <code>$file</code>
+      <code>$file</code>
+      <code>$line</code>
+      <code>$line</code>
+    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/DebugTimer.php">
     <PossiblyNullArrayOffset>
       <code>self::$_timers</code>
     </PossiblyNullArrayOffset>
+    <RiskyTruthyFalsyComparison>
+      <code>!$message</code>
+      <code>!$name</code>
+      <code>!$name</code>
+    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Mailer/MailPreview.php">
     <PossiblyFalseOperand>
       <code>$pos</code>
     </PossiblyFalseOperand>
+  </file>
+  <file src="src/Mailer/PreviewResult.php">
+    <RiskyTruthyFalsyComparison>
+      <code><![CDATA[!$mailer->viewBuilder()->getTemplate()]]></code>
+    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Mailer/Transport/DebugKitTransport.php">
     <InvalidReturnStatement>
@@ -33,6 +65,37 @@
     <MoreSpecificReturnType>
       <code>array</code>
     </MoreSpecificReturnType>
+    <NullArgument>
+      <code><![CDATA[$this->emailLog]]></code>
+    </NullArgument>
+  </file>
+  <file src="src/Model/Table/LazyTableTrait.php">
+    <RiskyTruthyFalsyComparison>
+      <code><![CDATA[strpos($e->getMessage(), 'unable to open')]]></code>
+    </RiskyTruthyFalsyComparison>
+  </file>
+  <file src="src/Panel/DeprecationsPanel.php">
+    <RiskyTruthyFalsyComparison>
+      <code>$pluginName</code>
+      <code>$vendorName</code>
+    </RiskyTruthyFalsyComparison>
+  </file>
+  <file src="src/Panel/EnvironmentPanel.php">
+    <RiskyTruthyFalsyComparison>
+      <code>$pluginName</code>
+      <code>$vendorName</code>
+    </RiskyTruthyFalsyComparison>
+  </file>
+  <file src="src/Panel/IncludePanel.php">
+    <RiskyTruthyFalsyComparison>
+      <code>$pluginName</code>
+      <code>$vendorName</code>
+    </RiskyTruthyFalsyComparison>
+  </file>
+  <file src="src/Panel/LogPanel.php">
+    <RiskyTruthyFalsyComparison>
+      <code><![CDATA[Log::getConfig('debug_kit_log_panel')]]></code>
+    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Panel/PanelRegistry.php">
     <LessSpecificImplementedReturnType>
@@ -46,6 +109,12 @@
     <UndefinedInterfaceMethod>
       <code>genericInstances</code>
     </UndefinedInterfaceMethod>
+  </file>
+  <file src="src/ToolbarService.php">
+    <RiskyTruthyFalsyComparison>
+      <code><![CDATA[!$GLOBALS['FORCE_DEBUGKIT_TOOLBAR']]]></code>
+      <code>$enabled</code>
+    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/View/Helper/ToolbarHelper.php">
     <InternalClass>

--- a/src/Panel/EnvironmentPanel.php
+++ b/src/Panel/EnvironmentPanel.php
@@ -15,7 +15,9 @@ declare(strict_types=1);
 namespace DebugKit\Panel;
 
 use Cake\Core\Configure;
+use Cake\Error\Debugger;
 use Cake\Event\EventInterface;
+use DebugKit\DebugInclude;
 use DebugKit\DebugPanel;
 
 /**
@@ -23,6 +25,21 @@ use DebugKit\DebugPanel;
  */
 class EnvironmentPanel extends DebugPanel
 {
+    /**
+     * instance of DebugInclude
+     *
+     * @var \DebugKit\DebugInclude
+     */
+    protected DebugInclude $_debug;
+
+    /**
+     * construct
+     */
+    public function __construct()
+    {
+        $this->_debug = new DebugInclude();
+    }
+
     /**
      * Get necessary data about environment to pass back to controller
      *
@@ -75,6 +92,10 @@ class EnvironmentPanel extends DebugPanel
         $var = get_defined_constants(true);
         $return['app'] = array_diff_key($var['user'], $return['cake'], $hiddenCakeConstants);
 
+        // Included files data
+        $return['includePaths'] = $this->_debug->includePaths();
+        $return['includedFiles'] = $this->prepareIncludedFiles();
+
         return $return;
     }
 
@@ -87,5 +108,58 @@ class EnvironmentPanel extends DebugPanel
     public function shutdown(EventInterface $event): void
     {
         $this->_data = $this->_prepare();
+    }
+
+    /**
+     * Build the list of files segmented by app, cake, plugins, vendor and other
+     *
+     * @return array
+     */
+    protected function prepareIncludedFiles(): array
+    {
+        $return = ['cake' => [], 'app' => [], 'plugins' => [], 'vendor' => [], 'other' => []];
+
+        foreach (get_included_files() as $file) {
+            /** @var string|false $pluginName */
+            $pluginName = $this->_debug->getPluginName($file);
+
+            if ($pluginName) {
+                $return['plugins'][$pluginName][$this->_debug->getFileType($file)][] = $this->_debug->niceFileName(
+                    $file,
+                    'plugin',
+                    $pluginName
+                );
+            } elseif ($this->_debug->isAppFile($file)) {
+                $return['app'][$this->_debug->getFileType($file)][] = $this->_debug->niceFileName($file, 'app');
+            } elseif ($this->_debug->isCakeFile($file)) {
+                $return['cake'][$this->_debug->getFileType($file)][] = $this->_debug->niceFileName($file, 'cake');
+            } else {
+                /** @var string|false $vendorName */
+                $vendorName = $this->_debug->getComposerPackageName($file);
+
+                if ($vendorName) {
+                    $return['vendor'][$vendorName][] = $this->_debug->niceFileName($file, 'vendor', $vendorName);
+                } else {
+                    $return['other'][] = $this->_debug->niceFileName($file, 'root');
+                }
+            }
+        }
+
+        $return['paths'] = $this->_debug->includePaths();
+
+        ksort($return['app']);
+        ksort($return['cake']);
+        ksort($return['plugins']);
+        ksort($return['vendor']);
+
+        foreach ($return['plugins'] as &$plugin) {
+            ksort($plugin);
+        }
+
+        foreach ($return as $k => $v) {
+            $return[$k] = Debugger::exportVarAsNodes($v);
+        }
+
+        return $return;
     }
 }

--- a/src/Panel/IncludePanel.php
+++ b/src/Panel/IncludePanel.php
@@ -19,6 +19,7 @@ use Cake\Event\EventInterface;
 use Cake\Utility\Hash;
 use DebugKit\DebugInclude;
 use DebugKit\DebugPanel;
+use function Cake\Core\deprecationWarning;
 
 /**
  * Provides a list of included files for the current request
@@ -38,6 +39,7 @@ class IncludePanel extends DebugPanel
     public function __construct()
     {
         $this->_debug = new DebugInclude();
+        deprecationWarning('5.1.0', 'Include panel is deprecated. Remove it from your panel configuration, and use Environment Panel instead.');
     }
 
     /**

--- a/src/Panel/IncludePanel.php
+++ b/src/Panel/IncludePanel.php
@@ -39,7 +39,10 @@ class IncludePanel extends DebugPanel
     public function __construct()
     {
         $this->_debug = new DebugInclude();
-        deprecationWarning('5.1.0', 'Include panel is deprecated. Remove it from your panel configuration, and use Environment Panel instead.');
+        deprecationWarning(
+            '5.1.0',
+            'Include panel is deprecated. Remove it from your panel configuration, and use Environment Panel instead.'
+        );
     }
 
     /**

--- a/src/Panel/RequestPanel.php
+++ b/src/Panel/RequestPanel.php
@@ -55,6 +55,7 @@ class RequestPanel extends DebugPanel
             'data' => Debugger::exportVarAsNodes($request->getData(), $maxDepth),
             'cookie' => Debugger::exportVarAsNodes($request->getCookieParams(), $maxDepth),
             'get' => Debugger::exportVarAsNodes($_GET, $maxDepth),
+            'session' => Debugger::exportVarAsNodes($request->getSession()->read(), $maxDepth),
             'matchedRoute' => $request->getParam('_matchedRoute'),
             'headers' => [
                 'response' => headers_sent($file, $line),

--- a/src/Panel/SessionPanel.php
+++ b/src/Panel/SessionPanel.php
@@ -18,6 +18,7 @@ use Cake\Core\Configure;
 use Cake\Error\Debugger;
 use Cake\Event\EventInterface;
 use DebugKit\DebugPanel;
+use function Cake\Core\deprecationWarning;
 
 /**
  * Provides debug information on the Session contents.
@@ -32,6 +33,7 @@ class SessionPanel extends DebugPanel
      */
     public function shutdown(EventInterface $event): void
     {
+        deprecationWarning('5.1.0', 'SessionPanel is deprecated. Remove it from your panel list, and use Request panel instead.');
         /** @var \Cake\Controller\Controller $controller */
         $controller = $event->getSubject();
         $request = $controller->getRequest();

--- a/src/Panel/SessionPanel.php
+++ b/src/Panel/SessionPanel.php
@@ -33,7 +33,10 @@ class SessionPanel extends DebugPanel
      */
     public function shutdown(EventInterface $event): void
     {
-        deprecationWarning('5.1.0', 'SessionPanel is deprecated. Remove it from your panel list, and use Request panel instead.');
+        deprecationWarning(
+            '5.1.0',
+            'SessionPanel is deprecated. Remove it from your panel list, and use Request panel instead.'
+        );
         /** @var \Cake\Controller\Controller $controller */
         $controller = $event->getSubject();
         $request = $controller->getRequest();

--- a/src/ToolbarService.php
+++ b/src/ToolbarService.php
@@ -55,7 +55,6 @@ class ToolbarService
     protected array $_defaultConfig = [
         'panels' => [
             'DebugKit.Cache' => true,
-            'DebugKit.Session' => true,
             'DebugKit.Request' => true,
             'DebugKit.SqlLog' => true,
             'DebugKit.Timer' => true,

--- a/src/ToolbarService.php
+++ b/src/ToolbarService.php
@@ -61,7 +61,6 @@ class ToolbarService
             'DebugKit.Log' => true,
             'DebugKit.Variables' => true,
             'DebugKit.Environment' => true,
-            'DebugKit.Include' => true,
             'DebugKit.History' => true,
             'DebugKit.Routes' => true,
             'DebugKit.Packages' => true,

--- a/templates/element/environment_panel.php
+++ b/templates/element/environment_panel.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * Environment Panel Element
  *
@@ -15,17 +17,19 @@
  * @license       https://www.opensource.org/licenses/mit-license.php MIT License
  */
 use Cake\Error\Debugger;
+use function Cake\Core\h;
 
 /**
  * @var \DebugKit\View\AjaxView $this
  * @var array $app
  * @var array $cake
  * @var array $php
+ * @var array $includedFiles
+ * @var array $includePaths
+ * @var \DebugKit\View\Helper\ToolbarHelper $this->Toolbar
+ * @var \DebugKit\View\Helper\CredentialsHelper $this->Credentials
  */
-
-use function Cake\Core\h;
 ?>
-
 <div class="c-environment-panel">
     <h2>Application Constants</h2>
 
@@ -126,4 +130,12 @@ use function Cake\Core\h;
             PHP environment unavailable.
         </div>
     <?php endif; ?>
+
+    <h2>Included Files</h2>
+
+    <h4>Include Paths</h4>
+    <?= $this->Toolbar->dumpNodes($includePaths) ?>
+
+    <h4>Included Files</h4>
+    <?= $this->Toolbar->dumpNodes($includedFiles) ?>
 </div>

--- a/templates/element/request_panel.php
+++ b/templates/element/request_panel.php
@@ -56,7 +56,7 @@ use Cake\Error\Debugger;
         <code><?php echo h($routePath); ?></code>
     </div>
     <p>
-        <i>[Plugin].[Prefix]/[Controller]::[action]</i>
+        <i class="o-help">Route path grammar: [Plugin].[Prefix]/[Controller]::[action]</i>
     </p>
 
     <h4>Attributes</h4>
@@ -91,6 +91,13 @@ use Cake\Error\Debugger;
         <?= $this->Toolbar->dumpNode($cookie) ?>
     <?php else : ?>
         <p class="c-flash c-flash--info">No Cookie data.</p>
+    <?php endif; ?>
+
+    <h4>Session</h4>
+    <?php if (isset($session)) : ?>
+        <?= $this->Toolbar->dumpNode($session) ?>
+    <?php else : ?>
+        <p class="c-flash c-flash--info">No Session data.</p>
     <?php endif; ?>
 
     <?php if (!empty($matchedRoute)) : ?>

--- a/tests/TestCase/Middleware/DebugKitMiddlewareTest.php
+++ b/tests/TestCase/Middleware/DebugKitMiddlewareTest.php
@@ -126,10 +126,10 @@ class DebugKitMiddlewareTest extends TestCase
         $this->assertSame(200, $result->status_code);
         $this->assertGreaterThan(1, $result->panels);
 
-        $this->assertSame('SqlLog', $result->panels[11]->panel);
-        $this->assertSame('DebugKit.sql_log_panel', $result->panels[11]->element);
+        $this->assertSame('Timer', $result->panels[11]->panel);
+        $this->assertSame('DebugKit.timer_panel', $result->panels[11]->element);
         $this->assertNotNull($result->panels[11]->summary);
-        $this->assertSame('Sql Log', $result->panels[11]->title);
+        $this->assertSame('Timer', $result->panels[11]->title);
 
         $timeStamp = filectime(Plugin::path('DebugKit') . 'webroot' . DS . 'js' . DS . 'inject-iframe.js');
 

--- a/tests/TestCase/Middleware/DebugKitMiddlewareTest.php
+++ b/tests/TestCase/Middleware/DebugKitMiddlewareTest.php
@@ -126,10 +126,10 @@ class DebugKitMiddlewareTest extends TestCase
         $this->assertSame(200, $result->status_code);
         $this->assertGreaterThan(1, $result->panels);
 
-        $this->assertSame('Timer', $result->panels[11]->panel);
-        $this->assertSame('DebugKit.timer_panel', $result->panels[11]->element);
-        $this->assertNotNull($result->panels[11]->summary);
-        $this->assertSame('Timer', $result->panels[11]->title);
+        $this->assertSame('Timer', $result->panels[10]->panel);
+        $this->assertSame('DebugKit.timer_panel', $result->panels[10]->element);
+        $this->assertNotNull($result->panels[10]->summary);
+        $this->assertSame('Timer', $result->panels[10]->title);
 
         $timeStamp = filectime(Plugin::path('DebugKit') . 'webroot' . DS . 'js' . DS . 'inject-iframe.js');
 

--- a/tests/TestCase/Panel/EnvironmentPanelTest.php
+++ b/tests/TestCase/Panel/EnvironmentPanelTest.php
@@ -65,7 +65,7 @@ class EnvironmentPanelTest extends TestCase
         $this->panel->shutdown($event);
         $output = $this->panel->data();
         $this->assertIsArray($output);
-        $this->assertSame(['php', 'ini', 'cake', 'app'], array_keys($output));
+        $this->assertSame(['php', 'ini', 'cake', 'app', 'includePaths', 'includedFiles'], array_keys($output));
         $this->assertSame('mysql://user:password@localhost/my_db', $output['php']['TEST_URL_1']);
     }
 }

--- a/tests/TestCase/Panel/RequestPanelTest.php
+++ b/tests/TestCase/Panel/RequestPanelTest.php
@@ -64,6 +64,10 @@ class RequestPanelTest extends TestCase
 
         $data = $this->panel->data();
         $this->assertArrayHasKey('attributes', $data);
+        $this->assertArrayHasKey('session', $data);
+        $this->assertArrayHasKey('params', $data);
+        $this->assertArrayHasKey('data', $data);
+        $this->assertArrayHasKey('cookie', $data);
         $this->assertEquals('string', $data['attributes']['ok']->getType());
         $this->assertStringContainsString('Could not serialize `closure`', $data['attributes']['closure']->getValue());
     }

--- a/tests/TestCase/ToolbarServiceTest.php
+++ b/tests/TestCase/ToolbarServiceTest.php
@@ -256,13 +256,13 @@ class ToolbarServiceTest extends TestCase
         $this->assertSame(200, $result->status_code);
         $this->assertGreaterThan(1, $result->panels);
 
-        $this->assertSame('Timer', $result->panels[11]->panel);
-        $this->assertSame('DebugKit.timer_panel', $result->panels[11]->element);
+        $this->assertSame('Timer', $result->panels[10]->panel);
+        $this->assertSame('DebugKit.timer_panel', $result->panels[10]->element);
         $this->assertMatchesRegularExpression(
             '/\d+\.\d+\s[ms]+\s+\/\s+\d+\.\d+\s+[mbMB]+/',
-            $result->panels[11]->summary
+            $result->panels[10]->summary
         );
-        $this->assertSame('Timer', $result->panels[11]->title);
+        $this->assertSame('Timer', $result->panels[10]->title);
     }
 
     /**

--- a/tests/TestCase/ToolbarServiceTest.php
+++ b/tests/TestCase/ToolbarServiceTest.php
@@ -256,10 +256,13 @@ class ToolbarServiceTest extends TestCase
         $this->assertSame(200, $result->status_code);
         $this->assertGreaterThan(1, $result->panels);
 
-        $this->assertSame('SqlLog', $result->panels[11]->panel);
-        $this->assertSame('DebugKit.sql_log_panel', $result->panels[11]->element);
-        $this->assertSame('0', $result->panels[11]->summary);
-        $this->assertSame('Sql Log', $result->panels[11]->title);
+        $this->assertSame('Timer', $result->panels[11]->panel);
+        $this->assertSame('DebugKit.timer_panel', $result->panels[11]->element);
+        $this->assertMatchesRegularExpression(
+            '/\d+\.\d+\s[ms]+\s+\/\s+\d+\.\d+\s+[mbMB]+/',
+            $result->panels[11]->summary
+        );
+        $this->assertSame('Timer', $result->panels[11]->title);
     }
 
     /**

--- a/webroot/css/style.css
+++ b/webroot/css/style.css
@@ -238,6 +238,10 @@ strong {
     -webkit-animation: spin 4s linear infinite;
     animation: spin 4s linear infinite;
 }
+.o-help {
+  color: var(--checkbox-label);
+  font-size: 14px;
+}
 
 @-webkit-keyframes spin {
     100% {


### PR DESCRIPTION
I find that there are too many panels in debugkit and that we could benefit from collapsing some panels. I'm also considering merging `Deprecations` and `Log` panel together as deprecation warnings are a form of logs.

I've left the panels in the source as userland configuration could have `Session => true` and I don't want to break that. One open question I have is whether or not `Environment` panel should have configuration to turn off saving include path data. Skipping include path data can help keep debugkit data size down.