### PR TITLE
Fix benchmark command option parser error

### DIFF
--- a/src/Command/BenchmarkCommand.php
+++ b/src/Command/BenchmarkCommand.php
@@ -169,11 +169,11 @@ class BenchmarkCommand extends Command
             'required' => true,
         ])
         ->addOption('n', [
-            'default' => 10,
+            'default' => '10',
             'help' => 'Number of iterations to perform.',
         ])
         ->addOption('t', [
-            'default' => 100,
+            'default' => '100',
             'help' =>
                 'Maximum total time for all iterations, in seconds. ' .
                 'If a single iteration takes more than the timeout, only one request will be made',


### PR DESCRIPTION
Currently calling `bin/cake benchmark` gives error 
```
[TypeError] Cake\Console\ConsoleInputOption::__construct(): Argument #5 ($default) must be of type string|bool|null, int given, called in <app>/vendor/cakephp/cakephp/src/Console/ConsoleOptionParser.php on lin
e 382 in <app>/vendor/cakephp/cakephp/src/Console/ConsoleInputOption.php on line 107

Stack Trace:

Cake\Console\ConsoleInputOption->__construct() - CORE/src/Console/ConsoleOptionParser.php, line 382
Cake\Console\ConsoleOptionParser->addOption() - ROOT/vendor/cakephp/debug_kit/src/Command/BenchmarkCommand.php, line 178
DebugKit\Command\BenchmarkCommand->buildOptionParser() - CORE/src/Console/BaseCommand.php, line 129
Cake\Console\BaseCommand->getOptionParser() - CORE/src/Console/BaseCommand.php, line 165
Cake\Console\BaseCommand->run() - CORE/src/Console/CommandRunner.php, line 327
Cake\Console\CommandRunner->runCommand() - CORE/src/Console/CommandRunner.php, line 168
Cake\Console\CommandRunner->run() - ROOT/bin/cake.php, line 10
[main] - [main], line 0 
```

This PR changes the default options parser options to strings from integers