### PR TITLE
fix environment panel not working with CakePHP 5.1

### DIFF
--- a/src/Panel/EnvironmentPanel.php
+++ b/src/Panel/EnvironmentPanel.php
@@ -90,8 +90,13 @@ class EnvironmentPanel extends DebugPanel
         $var = get_defined_constants(true);
         $return['app'] = array_diff_key($var['user'], $return['cake'], $hiddenCakeConstants);
 
+        $includePaths = $this->_debug->includePaths();
+        foreach ($includePaths as $k => $v) {
+            $includePaths[$k] = Debugger::exportVarAsNodes($v);
+        }
+
         // Included files data
-        $return['includePaths'] = $this->_debug->includePaths();
+        $return['includePaths'] = $includePaths;
         $return['includedFiles'] = $this->prepareIncludedFiles();
 
         return $return;

--- a/webroot/css/style.css
+++ b/webroot/css/style.css
@@ -281,10 +281,6 @@ strong {
     text-align: left;
 }
 
-/* Override styles in cake's default css */
-.c-debug-table .cake-debug-string {
-    margin-right: 48px;
-}
 /* correct height to fit with environment panel */
 .c-debug-table .cake-debug-copy {
     padding: 5px 6px;


### PR DESCRIPTION
Fixes #1025 

The `$includePaths` didn't get converted to Nodes, therefore putting a simple string into an `ArrayItemNode`didn't work.

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/441e8080-1af7-45b7-9b90-3bdc74775cca">
