### PR TITLE
fix styling for environment panel

### DIFF
--- a/webroot/css/style.css
+++ b/webroot/css/style.css
@@ -281,9 +281,9 @@ strong {
     text-align: left;
 }
 
-/* correct height to fit with environment panel */
 .c-debug-table .cake-debug-copy {
-    padding: 5px 6px;
+    position: static;
+    margin-left: 10px;
 }
 
 .c-debug-table .duplicate-route td {


### PR DESCRIPTION
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/5a5c799c-894a-4b0a-a59d-c5906b67e690">
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/28820c5b-ca56-4405-a509-57ad592d48d4">

thanks @markstory for pointing into the right direction 😉 
this of course is just a debug_kit specific CSS problem, not a debugger general problem