### PR TITLE
Allow SqlPanel skip drivers with no setLogger method

### DIFF
--- a/src/Panel/SqlLogPanel.php
+++ b/src/Panel/SqlLogPanel.php
@@ -68,6 +68,11 @@ class SqlLogPanel extends DebugPanel
             return;
         }
         $driver = $connection->getDriver();
+
+        if (!method_exists($driver, 'setLogger')) {
+            return;
+        }
+
         $logger = null;
         if ($driver instanceof Driver) {
             $logger = $driver->getLogger();

--- a/tests/TestCase/Panel/SqlLogPanelTest.php
+++ b/tests/TestCase/Panel/SqlLogPanelTest.php
@@ -124,4 +124,21 @@ class SqlLogPanelTest extends TestCase
         $result = $this->panel->summary();
         $this->assertMatchesRegularExpression('/\d+ \\/ \d+(\.\d+)? ms/', $result);
     }
+
+    /**
+     * Testing a simple connection (no set/getLogger on driver).
+     *
+     * @return void
+     */
+    public function testWithSimpleConnection()
+    {
+        ConnectionManager::setConfig('simple', [
+            'className' => 'DebugKit\TestApp\Stub\SimpleConnectionStub',
+        ]);
+
+        $this->panel->addConnection('simple'); // should not throw an error
+        $this->assertTrue(true);
+
+        ConnectionManager::drop('simple');
+    }
 }

--- a/tests/test_app/Stub/SimpleConnectionStub.php
+++ b/tests/test_app/Stub/SimpleConnectionStub.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace DebugKit\TestApp\Stub;
+
+use Cake\Cache\Cache;
+use Cake\Datasource\ConnectionInterface;
+use Psr\SimpleCache\CacheInterface;
+use stdClass;
+
+class SimpleConnectionStub implements ConnectionInterface
+{
+    public function getDriver(string $role = self::ROLE_WRITE): object
+    {
+        return new stdClass();
+    }
+
+    public function setCacher(CacheInterface $cacher)
+    {
+        return $this;
+    }
+
+    public function getCacher(): CacheInterface
+    {
+        return Cache::pool('_simple_connection_stub_');
+    }
+
+    public function configName(): string
+    {
+        return 'simple_connection_stub';
+    }
+
+    public function config(): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
This bypasses a potential "Call to undefined method Class::setLogger()" exception when using driver classes that don't implement these methods.

Resolves https://github.com/cakephp/debug_kit/issues/1003