### PR TITLE
Allow debug mode by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ working correctly. Some common problems are:
    itself to protect a potentially non-development environment.
 3. If you are using the [Authorization Plugin](https://github.com/cakephp/authorization)
    you need to set `DebugKit.ignoreAuthorization` to `true` in your config.
+   Not needed anymore for DebugKit 5.3.0+.
 
 ## Reporting Issues
 

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -62,7 +62,8 @@ Configuration
     // Ignore image paths
     Configure::write('DebugKit.ignorePathsPattern', '/\.(jpg|png|gif)$/');
 
-* ``DebugKit.ignoreAuthorization`` - Set to true to ignore Cake Authorization plugin for DebugKit requests. Disabled by default.
+* ``DebugKit.ignoreAuthorization`` - Set to true to ignore Cake Authorization plugin for DebugKit requests.
+  Not needed anymore for DebugKit 5.3.0+.
 
 * ``DebugKit.maxDepth`` - Defines how many levels of nested data should be shown in general for debug output. Default is 5.
   WARNING: Increasing the max depth level can lead to an out of memory error.::

--- a/src/Controller/DebugKitController.php
+++ b/src/Controller/DebugKitController.php
@@ -43,7 +43,7 @@ class DebugKitController extends Controller
         // ignore it, only if `DebugKit.ignoreAuthorization` is set to true
         $authorizationService = $this->getRequest()->getAttribute('authorization');
         if ($authorizationService instanceof AuthorizationService) {
-            if (Configure::read('DebugKit.ignoreAuthorization') || Configure::read('debug')) {
+            if (Configure::read('DebugKit.ignoreAuthorization') !== false) {
                 $authorizationService->skipAuthorization();
             } else {
                 Log::info(

--- a/src/Controller/DebugKitController.php
+++ b/src/Controller/DebugKitController.php
@@ -43,7 +43,7 @@ class DebugKitController extends Controller
         // ignore it, only if `DebugKit.ignoreAuthorization` is set to true
         $authorizationService = $this->getRequest()->getAttribute('authorization');
         if ($authorizationService instanceof AuthorizationService) {
-            if (Configure::read('DebugKit.ignoreAuthorization')) {
+            if (Configure::read('DebugKit.ignoreAuthorization') || Configure::read('debug')) {
                 $authorizationService->skipAuthorization();
             } else {
                 Log::info(

--- a/tests/TestCase/Controller/DebugKitControllerTest.php
+++ b/tests/TestCase/Controller/DebugKitControllerTest.php
@@ -74,12 +74,26 @@ class DebugKitControllerTest extends TestCase
      */
     public function testIgnoreAuthorization()
     {
-        Configure::write('DebugKit.ignoreAuthorization', true);
-
         $controller = $this->_buildController();
         $event = new Event('testing');
         $controller->beforeFilter($event);
 
         $this->assertTrue($controller->getRequest()->getAttribute('authorization')->authorizationChecked());
+    }
+
+    /**
+     * tests authorization is enabled but not ignored
+     *
+     * @return void
+     */
+    public function testDontIgnoreAuthorization()
+    {
+        Configure::write('DebugKit.ignoreAuthorization', false);
+
+        $controller = $this->_buildController();
+        $event = new Event('testing');
+        $controller->beforeFilter($event);
+
+        $this->assertFalse($controller->getRequest()->getAttribute('authorization')->authorizationChecked());
     }
 }

--- a/tests/TestCase/Controller/DebugKitControllerTest.php
+++ b/tests/TestCase/Controller/DebugKitControllerTest.php
@@ -67,20 +67,6 @@ class DebugKitControllerTest extends TestCase
     }
 
     /**
-     * tests authorization is enabled but not ignored
-     *
-     * @return void
-     */
-    public function testDontIgnoreAuthorization()
-    {
-        $controller = $this->_buildController();
-        $event = new Event('testing');
-        $controller->beforeFilter($event);
-
-        $this->assertFalse($controller->getRequest()->getAttribute('authorization')->authorizationChecked());
-    }
-
-    /**
      * tests authorization is checked to avoid
      * AuthorizationRequiredException throwned
      *


### PR DESCRIPTION
Whats the whole point of this flag if that action is only to be used in debug mode

 > Cake\Http\Exception\NotFoundException: Not available without debug mode o

And debug mode by definition should only be a local dev thing (thus access should be granted).

Having to set this flag for all apps is quite annoying, and I dont really see any security relevant point in it.


For now you can still disable using

    Configure::write('DebugKit.ignoreAuthorization', false);

but I dont quite see the point here for DebugKit and debug mode on (the only way it can actually work and display things anyway).