### PR TITLE
Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,6 @@ working correctly. Some common problems are:
 2. Your hostname needs to be added to the `DebugKit.safeTld`. If your local
    domain isn't a known development environment name, DebugKit will disable
    itself to protect a potentially non-development environment.
-3. If you are using the [Authorization Plugin](https://github.com/cakephp/authorization)
-   you need to set `DebugKit.ignoreAuthorization` to `true` in your config.
-   Not needed anymore for DebugKit 5.3.0+.
 
 ## Reporting Issues
 

--- a/config/app.example.php
+++ b/config/app.example.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * DebugKit configuration options.
+ *
+ * Copy this file to your application's config directory and include it
+ * in your bootstrap or application configuration.
+ *
+ * All options shown below use their default values.
+ */
+return [
+    'DebugKit' => [
+        /**
+         * Enable or disable panels for DebugKit. You can disable any of the
+         * standard panels by setting them to false.
+         *
+         * Example: ['DebugKit.Packages' => false]
+         */
+        // 'panels' => [],
+
+        /**
+         * Set to true to enable logging of schema reflection queries.
+         * Disabled by default.
+         */
+        // 'includeSchemaReflection' => false,
+
+        /**
+         * Set an array of whitelisted TLDs for local development.
+         * This can be used to make sure DebugKit displays on hosts
+         * it otherwise determines unsafe.
+         *
+         * Example: ['test', 'local', 'example']
+         */
+        // 'safeTld' => [],
+
+        /**
+         * Force DebugKit to display. Careful with this, it is usually
+         * safer to simply whitelist your local TLDs.
+         *
+         * Can also be set to a callable that returns a boolean.
+         * Example: function() { return $_SERVER['REMOTE_ADDR'] === '192.168.2.182'; }
+         */
+        // 'forceEnable' => false,
+
+        /**
+         * Regex pattern (including delimiter) to ignore paths.
+         * DebugKit won't save data for request URLs that match this regex.
+         *
+         * Example: '/\.(jpg|png|gif)$/'
+         */
+        // 'ignorePathsPattern' => null,
+
+        /**
+         * Defines how many levels of nested data should be shown in general
+         * for debug output.
+         *
+         * WARNING: Increasing the max depth level can lead to an out of memory error.
+         */
+        // 'maxDepth' => 5,
+
+        /**
+         * Defines how many levels of nested data should be shown in the
+         * variables tab.
+         *
+         * WARNING: Increasing the max depth level can lead to an out of memory error.
+         */
+        // 'variablesPanelMaxDepth' => 5,
+
+        /**
+         * Number of requests to keep in history panel.
+         */
+        // 'requestCount' => 20,
+    ],
+];

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -62,9 +62,6 @@ Configuration
     // Ignore image paths
     Configure::write('DebugKit.ignorePathsPattern', '/\.(jpg|png|gif)$/');
 
-* ``DebugKit.ignoreAuthorization`` - Set to true to ignore Cake Authorization plugin for DebugKit requests.
-  Not needed anymore for DebugKit 5.3.0+.
-
 * ``DebugKit.maxDepth`` - Defines how many levels of nested data should be shown in general for debug output. Default is 5.
   WARNING: Increasing the max depth level can lead to an out of memory error.::
 

--- a/docs/fr/index.rst
+++ b/docs/fr/index.rst
@@ -30,11 +30,6 @@ Ensuite, vous devez activer le plugin en exécutant la ligne suivante::
 
     bin/cake plugin load DebugKit
 
-Configuration
-=============
-
-* ``DebugKit.ignoreAuthorization`` - Définie à true pour ignorer le plugin Cake Authorization uniquement pour les requêtes DebugKit. Par défaut à false.
-
 Stockage de DebugKit
 ====================
 

--- a/src/Controller/DebugKitController.php
+++ b/src/Controller/DebugKitController.php
@@ -19,7 +19,6 @@ use Cake\Controller\Controller;
 use Cake\Core\Configure;
 use Cake\Event\EventInterface;
 use Cake\Http\Exception\NotFoundException;
-use Cake\Log\Log;
 
 /**
  * DebugKit Controller.
@@ -39,19 +38,9 @@ class DebugKitController extends Controller
             throw new NotFoundException('Not available without debug mode on.');
         }
 
-        // If CakePHP Authorization\Authorization plugin is enabled,
-        // ignore it, only if `DebugKit.ignoreAuthorization` is set to true
         $authorizationService = $this->getRequest()->getAttribute('authorization');
         if ($authorizationService instanceof AuthorizationService) {
-            if (Configure::read('DebugKit.ignoreAuthorization') !== false) {
-                $authorizationService->skipAuthorization();
-            } else {
-                Log::info(
-                    'Cake Authorization plugin is enabled. If you would like ' .
-                    'to force DebugKit to ignore it, set `DebugKit.ignoreAuthorization` ' .
-                    ' Configure option to true.',
-                );
-            }
+            $authorizationService->skipAuthorization();
         }
     }
 }

--- a/tests/TestCase/Controller/DebugKitControllerTest.php
+++ b/tests/TestCase/Controller/DebugKitControllerTest.php
@@ -26,7 +26,9 @@ use DebugKit\Controller\DebugKitController;
 use DebugKit\TestApp\Application;
 
 /**
- * Composer controller test.
+ * DebugKit controller test.
+ *
+ * @uses \DebugKit\Controller\DebugKitController
  */
 class DebugKitControllerTest extends TestCase
 {
@@ -67,33 +69,17 @@ class DebugKitControllerTest extends TestCase
     }
 
     /**
-     * tests authorization is checked to avoid
-     * AuthorizationRequiredException throwned
+     * Tests authorization is skipped to avoid
+     * AuthorizationRequiredException thrown.
      *
      * @return void
      */
-    public function testIgnoreAuthorization()
+    public function testAuthorizationSkipped(): void
     {
         $controller = $this->_buildController();
         $event = new Event('testing');
         $controller->beforeFilter($event);
 
         $this->assertTrue($controller->getRequest()->getAttribute('authorization')->authorizationChecked());
-    }
-
-    /**
-     * tests authorization is enabled but not ignored
-     *
-     * @return void
-     */
-    public function testDontIgnoreAuthorization()
-    {
-        Configure::write('DebugKit.ignoreAuthorization', false);
-
-        $controller = $this->_buildController();
-        $event = new Event('testing');
-        $controller->beforeFilter($event);
-
-        $this->assertFalse($controller->getRequest()->getAttribute('authorization')->authorizationChecked());
     }
 }


### PR DESCRIPTION
Follow https://github.com/cakephp/debug_kit/pull/1055

it does not serve anything it seems, as without it being off, it wouldnt render anyways. so the current false setting seems also pointless.

Also added a useful app.example.php with possible configs to easier copy and paste.