### PR TITLE
Add missing command description for benchmark

### DIFF
--- a/src/Command/BenchmarkCommand.php
+++ b/src/Command/BenchmarkCommand.php
@@ -32,6 +32,14 @@ use Cake\Utility\Text;
 class BenchmarkCommand extends Command
 {
     /**
+     * @return string
+     */
+    public static function getDescription(): string
+    {
+        return 'Benchmark a fully qualified URL.';
+    }
+
+    /**
      * The console io
      *
      * @var \Cake\Console\ConsoleIo


### PR DESCRIPTION
## Summary
- Adds `getDescription()` for the `benchmark` command so it appears in the CLI command listing.