### PR TITLE
rector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,9 @@
         "stan": "@phpstan",
         "stan-baseline": "tools/phpstan --generate-baseline",
         "stan-setup": "phive install",
+        "rector-setup": "cp composer.json composer.backup && composer require --dev rector/rector:\"~2.3.1\" && mv composer.backup composer.json",
+        "rector-check": "vendor/bin/rector process --dry-run",
+        "rector-fix": "vendor/bin/rector process",
         "test": "phpunit"
     },
     "minimum-stability": "dev",

--- a/config/routes.php
+++ b/config/routes.php
@@ -3,8 +3,8 @@
 use Cake\Routing\Route\DashedRoute;
 use Cake\Routing\RouteBuilder;
 
-return function (RouteBuilder $routes) {
-    $routes->plugin('DebugKit', ['path' => '/debug-kit'], function (RouteBuilder $routes) {
+return function (RouteBuilder $routes): void {
+    $routes->plugin('DebugKit', ['path' => '/debug-kit'], function (RouteBuilder $routes): void {
         $routes->setExtensions('json');
         $routes->setRouteClass(DashedRoute::class);
 
@@ -37,7 +37,7 @@ return function (RouteBuilder $routes) {
         $routes->scope(
             '/mail-preview',
             ['controller' => 'MailPreview'],
-            function (RouteBuilder $routes) {
+            function (RouteBuilder $routes): void {
                 $routes->connect('/', ['action' => 'index']);
                 $routes->connect('/preview', ['action' => 'email']);
                 $routes->connect('/preview/*', ['action' => 'email']);

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+use Rector\Caching\ValueObject\Storage\FileCacheStorage;
+use Rector\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRector;
+use Rector\CodeQuality\Rector\FuncCall\CompactToVariablesRector;
+use Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector;
+use Rector\CodingStyle\Rector\Assign\SplitDoubleAssignRector;
+use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
+use Rector\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector;
+use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
+use Rector\EarlyReturn\Rector\If_\ChangeOrIfContinueToMultiContinueRector;
+use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
+use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+use Rector\Php80\Rector\Class_\StringableForToStringRector;
+use Rector\Set\ValueObject\SetList;
+use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\ParamTypeByMethodCallTypeRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictFluentReturnRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector;
+use Rector\TypeDeclaration\Rector\Function_\AddFunctionVoidReturnTypeWhereNoReturnRector;
+
+$cacheDir = getenv('RECTOR_CACHE_DIR') ?: sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'rector';
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/config',
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+
+    ->withCache(
+        cacheClass: FileCacheStorage::class,
+        cacheDirectory: $cacheDir,
+    )
+
+    ->withPhpSets()
+    ->withAttributesSets()
+
+    ->withSets([
+        SetList::CODE_QUALITY,
+        SetList::CODING_STYLE,
+        SetList::DEAD_CODE,
+        SetList::EARLY_RETURN,
+        SetList::INSTANCEOF,
+        SetList::TYPE_DECLARATION,
+    ])
+
+    ->withSkip([
+        __DIR__ . '/tests/test_app/templates',
+        __DIR__ . '/tests/test_app/Plugin/TestPlugin/templates',
+
+        ClassPropertyAssignToConstructorPromotionRector::class,
+        CatchExceptionNameMatchingTypeRector::class,
+        ClosureToArrowFunctionRector::class,
+        RemoveUselessReturnTagRector::class,
+        ReturnTypeFromStrictFluentReturnRector::class,
+        NewlineAfterStatementRector::class,
+        StringClassNameToClassConstantRector::class,
+        ReturnTypeFromStrictTypedCallRector::class,
+        ParamTypeByMethodCallTypeRector::class,
+        AddFunctionVoidReturnTypeWhereNoReturnRector::class,
+        StringableForToStringRector::class,
+        CompactToVariablesRector::class,
+        SplitDoubleAssignRector::class,
+        ChangeOrIfContinueToMultiContinueRector::class,
+        ExplicitBoolCompareRector::class,
+        NewlineBeforeNewAssignSetRector::class,
+        SimplifyEmptyCheckOnEmptyArrayRector::class,
+        DisallowedEmptyRuleFixerRector::class,
+    ]);

--- a/src/Cache/Engine/DebugEngine.php
+++ b/src/Cache/Engine/DebugEngine.php
@@ -28,19 +28,11 @@ class DebugEngine extends CacheEngine
 {
     /**
      * Proxied engine
-     *
-     * @var \Cake\Cache\CacheEngine
      */
     protected CacheEngine $_engine;
 
-    /**
-     * @var \Psr\Log\LoggerInterface
-     */
     protected LoggerInterface $logger;
 
-    /**
-     * @var string
-     */
     protected string $name;
 
     /**
@@ -132,9 +124,9 @@ class DebugEngine extends CacheEngine
      */
     protected function log(string $operation, float $duration, ?string $key = null): void
     {
-        $key = $key ? " `{$key}`" : '';
+        $key = $key ? sprintf(' `%s`', $key) : '';
         $duration = number_format($duration, 5);
-        $this->logger->log('info', ":{$this->name}: {$operation}{$key} - {$duration}ms");
+        $this->logger->log('info', sprintf(':%s: %s%s - %sms', $this->name, $operation, $key, $duration));
     }
 
     /**
@@ -180,7 +172,7 @@ class DebugEngine extends CacheEngine
             $metric = 'miss';
         }
 
-        $this->track("get {$metric}");
+        $this->track('get ' . $metric);
         $this->log('get', $duration, $key);
 
         return $result;
@@ -336,7 +328,7 @@ class DebugEngine extends CacheEngine
     {
         if (isset($this->_engine)) {
             // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
-            [$ns, $class] = namespaceSplit(get_class($this->_engine));
+            [$ns, $class] = namespaceSplit($this->_engine::class);
 
             return str_replace('Engine', '', $class);
         }

--- a/src/Command/BenchmarkCommand.php
+++ b/src/Command/BenchmarkCommand.php
@@ -41,8 +41,6 @@ class BenchmarkCommand extends Command
 
     /**
      * The console io
-     *
-     * @var \Cake\Console\ConsoleIo
      */
     protected ConsoleIo $io;
 
@@ -144,8 +142,8 @@ class BenchmarkCommand extends Command
         foreach ($times as $time) {
             $n += 1;
             $delta = $time - $mean;
-            $mean = $mean + $delta / $n;
-            $M2 = $M2 + $delta * ($time - $mean);
+            $mean += $delta / $n;
+            $M2 += $delta * ($time - $mean);
         }
 
         if ($sample) {

--- a/src/Controller/ComposerController.php
+++ b/src/Controller/ComposerController.php
@@ -55,10 +55,10 @@ class ComposerController extends DebugKitController
         $dependencies = array_filter(explode("\n", $output->fetch()));
         $packages = [];
         foreach ($dependencies as $dependency) {
-            if (strpos($dependency, 'php_network_getaddresses') !== false) {
+            if (str_contains($dependency, 'php_network_getaddresses')) {
                 throw new RuntimeException('You have to be connected to the internet');
             }
-            if (strpos($dependency, '<highlight>') !== false) {
+            if (str_contains($dependency, '<highlight>')) {
                 $packages['semverCompatible'][] = $dependency;
                 continue;
             }

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -48,7 +48,7 @@ class DashboardController extends DebugKitController
         $requestsModel = $this->fetchTable('DebugKit.Requests');
 
         $data = [
-            'driver' => get_class($requestsModel->getConnection()->getDriver()),
+            'driver' => $requestsModel->getConnection()->getDriver()::class,
             'rows' => $requestsModel->find()->count(),
         ];
 

--- a/src/Controller/MailPreviewController.php
+++ b/src/Controller/MailPreviewController.php
@@ -20,6 +20,7 @@ use Cake\Core\App;
 use Cake\Core\Plugin as CorePlugin;
 use Cake\Event\EventInterface;
 use Cake\Http\Exception\NotFoundException;
+use Cake\Http\ServerRequest;
 use Cake\Routing\Router;
 use Cake\Utility\Inflector;
 use DebugKit\Mailer\AbstractResult;
@@ -120,14 +121,14 @@ class MailPreviewController extends DebugKitController
 
         if ($partType) {
             $result = $this->respondWithPart($email, $partType);
-            if ($restore) {
+            if ($restore instanceof ServerRequest) {
                 Router::setRequest($restore);
             }
 
             return $result;
         }
 
-        $humanName = Inflector::humanize(Inflector::underscore($name) . "_$method");
+        $humanName = Inflector::humanize(Inflector::underscore($name) . '_' . $method);
         /** @var string $part */
         $part = $this->request->getQuery('part');
         $this->set('title', $humanName);
@@ -135,7 +136,7 @@ class MailPreviewController extends DebugKitController
         $this->set('plugin', $plugin);
         $this->set('part', $this->findPreferredPart($email, $part));
 
-        if ($restore) {
+        if ($restore instanceof ServerRequest) {
             Router::setRequest($restore);
         }
 
@@ -184,11 +185,11 @@ class MailPreviewController extends DebugKitController
     protected function getMailPreviewClasses(): CollectionInterface
     {
         $pluginPaths = collection(CorePlugin::loaded())
-            ->reject(function ($plugin) {
+            ->reject(function ($plugin): bool {
                 return $plugin === 'DebugKit';
             })
-            ->map(function ($plugin) {
-                return [[CorePlugin::classPath($plugin) . 'Mailer/Preview/'], "$plugin."];
+            ->map(function (string $plugin): array {
+                return [[CorePlugin::classPath($plugin) . 'Mailer/Preview/'], $plugin . '.'];
             });
 
         $appPaths = [App::classPath('Mailer/Preview'), ''];
@@ -201,7 +202,7 @@ class MailPreviewController extends DebugKitController
                     yield $plugin => $path;
                 }
             })
-            ->unfold(function ($path, $plugin) {
+            ->unfold(function (string $path, string $plugin) {
                 /** @var list<string> $files */
                 $files = glob($path . '*Preview.php');
                 foreach ($files as $file) {
@@ -223,13 +224,7 @@ class MailPreviewController extends DebugKitController
      */
     protected function findPart(AbstractResult $email, string $partType): ?string
     {
-        foreach ($email->getParts() as $part => $content) {
-            if ($part === $partType) {
-                return $content;
-            }
-        }
-
-        return null;
+        return $email->getParts()[$partType] ?? null;
     }
 
     /**
@@ -248,7 +243,7 @@ class MailPreviewController extends DebugKitController
         }
 
         if ($partType === null) {
-            foreach ($email->getParts() as $part => $content) {
+            foreach (array_keys($email->getParts()) as $part) {
                 return $part;
             }
         }
@@ -268,12 +263,12 @@ class MailPreviewController extends DebugKitController
     protected function findPreview(string $previewName, string $emailName, string $plugin = ''): PreviewResult
     {
         if ($plugin) {
-            $plugin = "$plugin.";
+            $plugin .= '.';
         }
 
         $realClass = App::className($plugin . $previewName, 'Mailer/Preview');
         if (!$realClass) {
-            throw new NotFoundException("Mailer preview $previewName not found");
+            throw new NotFoundException(sprintf('Mailer preview %s not found', $previewName));
         }
         /** @var \DebugKit\Mailer\MailPreview $mailPreview */
         $mailPreview = new $realClass();

--- a/src/Database/Log/DebugLog.php
+++ b/src/Database/Log/DebugLog.php
@@ -31,44 +31,32 @@ class DebugLog extends AbstractLogger
 {
     /**
      * Logs from the current request.
-     *
-     * @var array
      */
     protected array $_queries = [];
 
     /**
      * Decorated logger.
-     *
-     * @var \Psr\Log\LoggerInterface|null
      */
     protected ?LoggerInterface $_logger = null;
 
     /**
      * Name of the connection being logged.
-     *
-     * @var string
      */
     protected string $_connectionName;
 
     /**
      * Total time (ms) of all queries
-     *
-     * @var float
      */
     protected float $_totalTime = 0;
 
     /**
      * Set to true to capture schema reflection queries
      * in the SQL log panel.
-     *
-     * @var bool
      */
     protected bool $_includeSchema = false;
 
     /**
      * Whether a transaction is currently open or not.
-     *
-     * @var bool
      */
     protected bool $inTransaction = false;
 
@@ -137,7 +125,7 @@ class DebugLog extends AbstractLogger
         /** @var \Cake\Database\Log\LoggedQuery|object|null $query */
         $query = $context['query'] ?? null;
 
-        if ($this->_logger) {
+        if ($this->_logger instanceof LoggerInterface) {
             $this->_logger->log($level, $message, $context);
         }
 
@@ -206,18 +194,18 @@ class DebugLog extends AbstractLogger
         $querystring = $query->jsonSerialize()['query'];
 
         return // Multiple engines
-            strpos($querystring, 'FROM information_schema') !== false ||
+            str_contains((string)$querystring, 'FROM information_schema') ||
             // Postgres
-            strpos($querystring, 'FROM pg_catalog') !== false ||
+            str_contains((string)$querystring, 'FROM pg_catalog') ||
             // MySQL
-            strpos($querystring, 'SHOW TABLE') === 0 ||
-            strpos($querystring, 'SHOW FULL COLUMNS') === 0 ||
-            strpos($querystring, 'SHOW INDEXES') === 0 ||
+            str_starts_with((string)$querystring, 'SHOW TABLE') ||
+            str_starts_with((string)$querystring, 'SHOW FULL COLUMNS') ||
+            str_starts_with((string)$querystring, 'SHOW INDEXES') ||
             // Sqlite
-            strpos($querystring, 'FROM sqlite_master') !== false ||
-            strpos($querystring, 'PRAGMA') === 0 ||
+            str_contains((string)$querystring, 'FROM sqlite_master') ||
+            str_starts_with((string)$querystring, 'PRAGMA') ||
             // Sqlserver
-            strpos($querystring, 'FROM INFORMATION_SCHEMA') !== false ||
-            strpos($querystring, 'FROM sys.') !== false;
+            str_contains((string)$querystring, 'FROM INFORMATION_SCHEMA') ||
+            str_contains((string)$querystring, 'FROM sys.');
     }
 }

--- a/src/DebugInclude.php
+++ b/src/DebugInclude.php
@@ -39,8 +39,6 @@ class DebugInclude
 
     /**
      * File Types
-     *
-     * @var array
      */
     protected array $_fileTypes = [
         'Auth', 'Cache', 'Collection', 'Config', 'Configure', 'Console', 'Component', 'Controller',
@@ -83,12 +81,8 @@ class DebugInclude
     public function includePaths(): array
     {
         $paths = explode(PATH_SEPARATOR, (string)get_include_path());
-        $paths = array_filter($paths, function ($path) {
-            if ($path === '.' || strlen($path) === 0) {
-                return false;
-            }
-
-            return true;
+        $paths = array_filter($paths, function ($path): bool {
+            return $path !== '.' && strlen($path) !== 0;
         });
 
         return array_values($paths);
@@ -102,7 +96,7 @@ class DebugInclude
      */
     public function isCakeFile(string $file): bool
     {
-        return strpos($file, CAKE) === 0;
+        return str_starts_with($file, CAKE);
     }
 
     /**
@@ -113,7 +107,7 @@ class DebugInclude
      */
     public function isAppFile(string $file): bool
     {
-        return strpos($file, APP) === 0;
+        return str_starts_with($file, APP);
     }
 
     /**
@@ -125,7 +119,7 @@ class DebugInclude
     public function getPluginName(string $file): string|bool
     {
         foreach ($this->_pluginPaths as $plugin => $path) {
-            if (strpos($file, $path) === 0) {
+            if (str_starts_with($file, $path)) {
                 return $plugin;
             }
         }
@@ -142,7 +136,7 @@ class DebugInclude
     public function getComposerPackageName(string $file): string|bool
     {
         foreach ($this->_composerPaths as $package => $path) {
-            if (strpos($file, $path) === 0) {
+            if (str_starts_with($file, $path)) {
                 return $package;
             }
         }
@@ -160,24 +154,14 @@ class DebugInclude
      */
     public function niceFileName(string $file, string $type, ?string $name = null): string
     {
-        switch ($type) {
-            case 'app':
-                return str_replace(APP, 'APP' . DIRECTORY_SEPARATOR, $file);
-
-            case 'cake':
-                return str_replace(CAKE, 'CAKE' . DIRECTORY_SEPARATOR, $file);
-
-            case 'root':
-                return str_replace(ROOT, 'ROOT', $file);
-
-            case 'plugin':
-                return str_replace($this->_pluginPaths[$name], $name . DIRECTORY_SEPARATOR, $file);
-
-            case 'vendor':
-                return str_replace($this->_composerPaths[$name], '', $file);
-        }
-
-        throw new InvalidArgumentException("Type `{$type}` is not supported.");
+        return match ($type) {
+            'app' => str_replace(APP, 'APP' . DIRECTORY_SEPARATOR, $file),
+            'cake' => str_replace(CAKE, 'CAKE' . DIRECTORY_SEPARATOR, $file),
+            'root' => str_replace(ROOT, 'ROOT', $file),
+            'plugin' => str_replace($this->_pluginPaths[$name], $name . DIRECTORY_SEPARATOR, $file),
+            'vendor' => str_replace($this->_composerPaths[$name], '', $file),
+            default => throw new InvalidArgumentException(sprintf('Type `%s` is not supported.', $type)),
+        };
     }
 
     /**

--- a/src/DebugKitPlugin.php
+++ b/src/DebugKitPlugin.php
@@ -32,9 +32,6 @@ use DebugKit\Panel\DeprecationsPanel;
  */
 class DebugKitPlugin extends BasePlugin
 {
-    /**
-     * @var \DebugKit\ToolbarService|null
-     */
     protected ?ToolbarService $service = null;
 
     /**
@@ -67,7 +64,7 @@ class DebugKitPlugin extends BasePlugin
     public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
     {
         // Only insert middleware if Toolbar Service is available (not in phpunit run)
-        if ($this->service) {
+        if ($this->service instanceof ToolbarService) {
             $middlewareQueue->insertAt(0, new DebugKitMiddleware($this->service));
         }
 

--- a/src/DebugMemory.php
+++ b/src/DebugMemory.php
@@ -24,8 +24,6 @@ class DebugMemory
 {
     /**
      * An array of recorded memory use points.
-     *
-     * @var array
      */
     protected static array $_points = [];
 

--- a/src/DebugPanel.php
+++ b/src/DebugPanel.php
@@ -29,15 +29,11 @@ class DebugPanel implements EventListenerInterface
 {
     /**
      * Defines which plugin this panel is from so the element can be located.
-     *
-     * @var string
      */
     public string $plugin = 'DebugKit';
 
     /**
      * The data collected about a given request.
-     *
-     * @var array
      */
     protected array $_data = [];
 

--- a/src/DebugSql.php
+++ b/src/DebugSql.php
@@ -30,8 +30,6 @@ class DebugSql
 {
     /**
      * Template used for HTML output.
-     *
-     * @var string
      */
     private static string $templateHtml = <<<HTML
 <div class="cake-debug-output">
@@ -44,8 +42,6 @@ HTML;
 
     /**
      * Template used for CLI and text output.
-     *
-     * @var string
      */
     private static string $templateText = <<<TEXT
 %s
@@ -190,7 +186,7 @@ TEXT;
      */
     private static function interpolate(string $sql, array $bindings): string
     {
-        $params = array_map(function ($binding) {
+        $params = array_map(function (array $binding) {
             $p = $binding['value'];
 
             if ($p === null) {
@@ -209,7 +205,7 @@ TEXT;
 
                 $p = strtr($p, $replacements);
 
-                return "'$p'";
+                return sprintf("'%s'", $p);
             }
 
             return $p;
@@ -217,8 +213,8 @@ TEXT;
 
         $keys = [];
         $limit = is_int(key($params)) ? 1 : -1;
-        foreach ($params as $key => $param) {
-            $keys[] = is_string($key) ? "/$key\b/" : '/[?]/';
+        foreach (array_keys($params) as $key) {
+            $keys[] = is_string($key) ? sprintf('/%s\b/', $key) : '/[?]/';
         }
 
         return (string)preg_replace($keys, $params, $sql, $limit);

--- a/src/DebugTimer.php
+++ b/src/DebugTimer.php
@@ -25,8 +25,6 @@ class DebugTimer
 {
     /**
      * Internal timers array
-     *
-     * @var array
      */
     protected static array $_timers = [];
 

--- a/src/Log/Engine/DebugKitLog.php
+++ b/src/Log/Engine/DebugKitLog.php
@@ -24,8 +24,6 @@ class DebugKitLog extends BaseLog
 {
     /**
      * logs
-     *
-     * @var array
      */
     protected array $_logs = [];
 
@@ -62,7 +60,7 @@ class DebugKitLog extends BaseLog
      */
     public function count(): int
     {
-        return array_reduce($this->_logs, function ($sum, $v) {
+        return array_reduce($this->_logs, function (int|float $sum, $v): int {
             return $sum + count($v);
         }, 0);
     }
@@ -74,6 +72,6 @@ class DebugKitLog extends BaseLog
      */
     public function noLogs(): bool
     {
-        return empty($this->_logs);
+        return $this->_logs === [];
     }
 }

--- a/src/Mailer/AbstractResult.php
+++ b/src/Mailer/AbstractResult.php
@@ -21,15 +21,11 @@ abstract class AbstractResult
 {
     /**
      * The list of headers included in the email
-     *
-     * @var array
      */
     protected array $headers = [];
 
     /**
      * The rendered parts of the email (for example text and html)
-     *
-     * @var array
      */
     protected array $parts = [];
 

--- a/src/Mailer/MailPreview.php
+++ b/src/Mailer/MailPreview.php
@@ -95,7 +95,7 @@ class MailPreview
 
         try {
             $method = new ReflectionMethod($this, $email);
-        } catch (ReflectionException $e) {
+        } catch (ReflectionException) {
             return false;
         }
 

--- a/src/Mailer/Transport/DebugKitTransport.php
+++ b/src/Mailer/Transport/DebugKitTransport.php
@@ -16,16 +16,12 @@ class DebugKitTransport extends AbstractTransport
 {
     /**
      * The transport object this class is decorating
-     *
-     * @var \Cake\Mailer\AbstractTransport|null
      */
     protected ?AbstractTransport $originalTransport = null;
 
     /**
      * A reference to the object were emails will be pushed to
      * for logging.
-     *
-     * @var \ArrayObject
      */
     protected ArrayObject $emailLog;
 
@@ -39,7 +35,7 @@ class DebugKitTransport extends AbstractTransport
     {
         $this->emailLog = $config['debugKitLog'];
 
-        if ($originalTransport !== null) {
+        if ($originalTransport instanceof AbstractTransport) {
             $this->originalTransport = $originalTransport;
 
             return;
@@ -76,7 +72,7 @@ class DebugKitTransport extends AbstractTransport
         $result = ['headers' => $headers, 'message' => $parts];
         $this->emailLog[] = $result;
 
-        if ($this->originalTransport !== null) {
+        if ($this->originalTransport instanceof AbstractTransport) {
             return $this->originalTransport->send($message);
         }
 

--- a/src/Middleware/DebugKitMiddleware.php
+++ b/src/Middleware/DebugKitMiddleware.php
@@ -26,9 +26,6 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 class DebugKitMiddleware implements MiddlewareInterface
 {
-    /**
-     * @var \DebugKit\ToolbarService
-     */
     protected ToolbarService $service;
 
     /**

--- a/src/Model/Table/LazyTableTrait.php
+++ b/src/Model/Table/LazyTableTrait.php
@@ -47,7 +47,7 @@ trait LazyTableTrait
             $existing = $schema->listTables();
         } catch (PDOException $e) {
             // Handle errors when SQLite blows up if the schema has changed.
-            if (strpos($e->getMessage(), 'schema has changed') !== false) {
+            if (str_contains($e->getMessage(), 'schema has changed')) {
                 $existing = $schema->listTables();
             } else {
                 throw $e;
@@ -55,7 +55,7 @@ trait LazyTableTrait
         }
 
         try {
-            $config = require dirname(dirname(__DIR__)) . '/schema.php';
+            $config = require dirname(__DIR__, 2) . '/schema.php';
             $driver = $connection->getDriver();
             foreach ($config as $table) {
                 if (in_array($table['table'], $existing, true)) {
@@ -80,6 +80,8 @@ trait LazyTableTrait
                 throw new RuntimeException(
                     'Could not create a SQLite database. ' .
                     'Ensure that your webserver has write access to the database file and folder it is in.',
+                    $e->getCode(),
+                    $e,
                 );
             }
             throw $e;

--- a/src/Model/Table/RequestsTable.php
+++ b/src/Model/Table/RequestsTable.php
@@ -87,7 +87,7 @@ class RequestsTable extends Table
      */
     protected function shouldGc(): bool
     {
-        return rand(1, 10) === 10;
+        return random_int(1, 10) === 10;
     }
 
     /**
@@ -97,7 +97,7 @@ class RequestsTable extends Table
      */
     protected function shouldGcVacuum(): bool
     {
-        return rand(1, 10) === 10;
+        return random_int(1, 10) === 10;
     }
 
     /**

--- a/src/Model/Table/SqlTraceTrait.php
+++ b/src/Model/Table/SqlTraceTrait.php
@@ -68,7 +68,7 @@ trait SqlTraceTrait
         int $start = 1,
         bool $debugOnly = true,
     ): SelectQuery|UpdateQuery|DeleteQuery {
-        if (!Configure::read('debug') && $debugOnly === true) {
+        if (!Configure::read('debug') && $debugOnly) {
             return $query;
         }
 
@@ -84,7 +84,7 @@ trait SqlTraceTrait
                 if ($path === '[internal]') {
                     continue;
                 }
-                if (defined('CAKE_CORE_INCLUDE_PATH') && strpos($path, CAKE_CORE_INCLUDE_PATH) !== 0) {
+                if (defined('CAKE_CORE_INCLUDE_PATH') && !str_starts_with((string)$path, CAKE_CORE_INCLUDE_PATH)) {
                     break;
                 }
             }

--- a/src/Panel/CachePanel.php
+++ b/src/Panel/CachePanel.php
@@ -24,9 +24,6 @@ use DebugKit\DebugPanel;
  */
 class CachePanel extends DebugPanel
 {
-    /**
-     * @var \Cake\Log\Engine\ArrayLog
-     */
     protected ArrayLog $logger;
 
     /**

--- a/src/Panel/DeprecationsPanel.php
+++ b/src/Panel/DeprecationsPanel.php
@@ -26,15 +26,11 @@ class DeprecationsPanel extends DebugPanel
 {
     /**
      * The list of depreated errors.
-     *
-     * @var array
      */
     protected static array $deprecatedErrors = [];
 
     /**
      * instance of DebugInclude
-     *
-     * @var \DebugKit\DebugInclude
      */
     protected DebugInclude $_debug;
 
@@ -135,7 +131,7 @@ class DeprecationsPanel extends DebugPanel
                 return $carry;
             }
             // app, cake, or other groups
-            if (Hash::dimensions($item) == 2) {
+            if (Hash::dimensions($item) === 2) {
                 return $carry + count($item);
             }
 

--- a/src/Panel/EnvironmentPanel.php
+++ b/src/Panel/EnvironmentPanel.php
@@ -26,8 +26,6 @@ class EnvironmentPanel extends DebugPanel
 {
     /**
      * instance of DebugInclude
-     *
-     * @var \DebugKit\DebugInclude
      */
     protected DebugInclude $_debug;
 

--- a/src/Panel/IncludePanel.php
+++ b/src/Panel/IncludePanel.php
@@ -28,8 +28,6 @@ class IncludePanel extends DebugPanel
 {
     /**
      * instance of DebugInclude
-     *
-     * @var \DebugKit\DebugInclude
      */
     protected DebugInclude $_debug;
 
@@ -111,7 +109,7 @@ class IncludePanel extends DebugPanel
         }
 
         unset($data['paths']);
-        $data = array_filter($data, function ($v, $k) {
+        $data = array_filter($data, function ($v, $k): bool {
             return !empty($v);
         }, ARRAY_FILTER_USE_BOTH);
 

--- a/src/Panel/MailPanel.php
+++ b/src/Panel/MailPanel.php
@@ -28,8 +28,6 @@ class MailPanel extends DebugPanel
 {
     /**
      * The list of emails produced during the request
-     *
-     * @var \ArrayObject|null
      */
     protected ?ArrayObject $emailLog = null;
 
@@ -77,7 +75,7 @@ class MailPanel extends DebugPanel
     public function data(): array
     {
         return [
-            'emails' => isset($this->emailLog) ? $this->emailLog->getArrayCopy() : [],
+            'emails' => $this->emailLog instanceof ArrayObject ? $this->emailLog->getArrayCopy() : [],
         ];
     }
 
@@ -88,7 +86,7 @@ class MailPanel extends DebugPanel
      */
     public function summary(): string
     {
-        if (empty($this->emailLog)) {
+        if (!$this->emailLog instanceof ArrayObject) {
             return '';
         }
 

--- a/src/Panel/PanelRegistry.php
+++ b/src/Panel/PanelRegistry.php
@@ -86,11 +86,7 @@ class PanelRegistry extends ObjectRegistry implements EventDispatcherInterface
      */
     protected function _create(object|string $class, string $alias, array $config): DebugPanel
     {
-        if (is_string($class)) {
-            $instance = new $class();
-        } else {
-            $instance = $class;
-        }
+        $instance = is_string($class) ? new $class() : $class;
 
         $this->getEventManager()->on($instance);
 

--- a/src/Panel/RequestPanel.php
+++ b/src/Panel/RequestPanel.php
@@ -43,7 +43,7 @@ class RequestPanel extends DebugPanel
             try {
                 serialize($value);
             } catch (Exception $e) {
-                $value = "Could not serialize `{$attr}`. It failed with {$e->getMessage()}";
+                $value = sprintf('Could not serialize `%s`. It failed with %s', $attr, $e->getMessage());
             }
             $attributes[$attr] = Debugger::exportVarAsNodes($value, $maxDepth);
         }

--- a/src/Panel/RoutesPanel.php
+++ b/src/Panel/RoutesPanel.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace DebugKit\Panel;
 
 use Cake\Event\EventInterface;
+use Cake\Routing\Route\Route;
 use Cake\Routing\Router;
 use DebugKit\DebugPanel;
 
@@ -30,7 +31,7 @@ class RoutesPanel extends DebugPanel
      */
     public function summary(): string
     {
-        $routes = array_filter(Router::routes(), function ($route) {
+        $routes = array_filter(Router::routes(), function (Route $route): bool {
             return !isset($route->defaults['plugin']) || $route->defaults['plugin'] !== 'DebugKit';
         });
 

--- a/src/Panel/SqlLogPanel.php
+++ b/src/Panel/SqlLogPanel.php
@@ -31,8 +31,6 @@ class SqlLogPanel extends DebugPanel
 
     /**
      * Loggers connected
-     *
-     * @var array
      */
     protected static array $_loggers = [];
 
@@ -103,7 +101,7 @@ class SqlLogPanel extends DebugPanel
     public function data(): array
     {
         return [
-            'tables' => array_map(function (Table $table) {
+            'tables' => array_map(function (Table $table): string {
                 return $table->getAlias();
             }, $this->getTableLocator()->genericInstances()),
             'loggers' => static::$_loggers,
@@ -126,6 +124,6 @@ class SqlLogPanel extends DebugPanel
             return '0';
         }
 
-        return "$count / $time ms";
+        return sprintf('%d / %s ms', $count, $time);
     }
 }

--- a/src/Panel/TimerPanel.php
+++ b/src/Panel/TimerPanel.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace DebugKit\Panel;
 
 use Cake\I18n\Number;
+use Closure;
 use DebugKit\DebugMemory;
 use DebugKit\DebugPanel;
 use DebugKit\DebugTimer;
@@ -31,17 +32,17 @@ class TimerPanel extends DebugPanel
      */
     public function implementedEvents(): array
     {
-        $before = function ($name) {
+        $before = function ($name): Closure {
             return function () use ($name): void {
                 DebugTimer::start($name);
             };
         };
-        $after = function ($name) {
+        $after = function ($name): Closure {
             return function () use ($name): void {
                 DebugTimer::stop($name);
             };
         };
-        $both = function ($name) use ($before, $after) {
+        $both = function (string $name) use ($before, $after): array {
             return [
                 ['priority' => 0, 'callable' => $before('Event: ' . $name)],
                 ['priority' => 999, 'callable' => $after('Event: ' . $name)],
@@ -80,12 +81,12 @@ class TimerPanel extends DebugPanel
             'View.beforeLayout' => $both('View.beforeLayout'),
             'View.afterLayout' => $both('View.afterLayout'),
             'View.beforeRenderFile' => [
-                ['priority' => 0, 'callable' => function ($event, $filename): void {
+                ['priority' => 0, 'callable' => function ($event, string $filename): void {
                     DebugTimer::start('Render File: ' . $filename);
                 }],
             ],
             'View.afterRenderFile' => [
-                ['priority' => 0, 'callable' => function ($event, $filename): void {
+                ['priority' => 0, 'callable' => function ($event, string $filename): void {
                     DebugTimer::stop('Render File: ' . $filename);
                 }],
             ],
@@ -125,6 +126,6 @@ class TimerPanel extends DebugPanel
         $time = Number::precision(DebugTimer::requestTime(), 2) . ' s';
         $memory = Number::toReadableSize(DebugMemory::getPeak());
 
-        return "$time / $memory";
+        return sprintf('%s / %s', $time, $memory);
     }
 }

--- a/src/Panel/VariablesPanel.php
+++ b/src/Panel/VariablesPanel.php
@@ -70,7 +70,7 @@ class VariablesPanel extends DebugPanel
         } catch (Exception $exception) {
             return sprintf(
                 'Could not retrieve debug info - %s. Error: %s in %s, line %d',
-                get_class($item),
+                $item::class,
                 $exception->getMessage(),
                 $exception->getFile(),
                 $exception->getLine(),

--- a/src/ToolbarService.php
+++ b/src/ToolbarService.php
@@ -42,15 +42,11 @@ class ToolbarService
 
     /**
      * The panel registry.
-     *
-     * @var \DebugKit\Panel\PanelRegistry
      */
     protected PanelRegistry $registry;
 
     /**
      * Default configuration.
-     *
-     * @var array
      */
     protected array $_defaultConfig = [
         'panels' => [
@@ -113,7 +109,7 @@ class ToolbarService
         }
         $enabled = (bool)Configure::read('debug')
                 && !$this->isSuspiciouslyProduction()
-                && php_sapi_name() !== 'phpdbg';
+                && PHP_SAPI !== 'phpdbg';
 
         if ($enabled) {
             return true;
@@ -159,7 +155,7 @@ class ToolbarService
 
         // So it's not an IP address. It must be a domain name.
         $parts = explode('.', $host);
-        if (count($parts) == 1) {
+        if (count($parts) === 1) {
             return false;
         }
 
@@ -176,8 +172,8 @@ class ToolbarService
         if (!$this->getConfig('forceEnable')) {
             $safeList = implode(', ', $safeTlds);
             Log::warning(
-                "DebugKit is disabling itself as your host `{$host}` " .
-                "is not in the known safe list of top-level-domains ({$safeList}). " .
+                sprintf('DebugKit is disabling itself as your host `%s` ', $host) .
+                sprintf('is not in the known safe list of top-level-domains (%s). ', $safeList) .
                 'If you would like to force DebugKit on use the `DebugKit.forceEnable` Configure option.',
             );
         }
@@ -244,8 +240,8 @@ class ToolbarService
     {
         $path = $request->getUri()->getPath();
         $dashboardUrl = '/debug-kit';
-        if (strpos($path, 'debug_kit') !== false || strpos($path, 'debug-kit') !== false) {
-            if (!($path === $dashboardUrl || $path === $dashboardUrl . '/')) {
+        if (str_contains($path, 'debug_kit') || str_contains($path, 'debug-kit')) {
+            if ($path !== $dashboardUrl && $path !== $dashboardUrl . '/') {
                 // internal debug-kit request
                 return false;
             }
@@ -295,7 +291,7 @@ class ToolbarService
 
                 // Set error handler to catch warnings/errors during serialization
                 set_error_handler(function ($errno, $errstr) use ($name): void {
-                    throw new Exception("Serialization error in panel '{$name}': {$errstr}");
+                    throw new Exception(sprintf("Serialization error in panel '%s': %s", $name, $errstr));
                 });
 
                 $content = serialize($data);
@@ -372,7 +368,7 @@ class ToolbarService
     public function injectScripts(Request $row, ResponseInterface $response): ResponseInterface
     {
         $response = $response->withHeader('X-DEBUGKIT-ID', (string)$row->id);
-        if (strpos($response->getHeaderLine('Content-Type'), 'html') === false) {
+        if (!str_contains($response->getHeaderLine('Content-Type'), 'html')) {
             return $response;
         }
         $body = $response->getBody();
@@ -390,7 +386,7 @@ class ToolbarService
         // state after other middleware have been applied.
         $request = Router::getRequest();
         $nonce = '';
-        if ($request && $request->getAttribute('cspScriptNonce')) {
+        if ($request instanceof ServerRequest && $request->getAttribute('cspScriptNonce')) {
             $nonce = sprintf(' nonce="%s"', $request->getAttribute('cspScriptNonce'));
         }
 

--- a/src/View/Helper/CredentialsHelper.php
+++ b/src/View/Helper/CredentialsHelper.php
@@ -31,8 +31,6 @@ class CredentialsHelper extends Helper
 {
     /**
      * Helpers property
-     *
-     * @var array
      */
     public array $helpers = ['Html', 'DebugKit.Toolbar'];
 

--- a/src/View/Helper/SimpleGraphHelper.php
+++ b/src/View/Helper/SimpleGraphHelper.php
@@ -35,8 +35,6 @@ class SimpleGraphHelper extends Helper
      * - width => (int)
      * - valueType => string (value, percentage)
      * - style => array
-     *
-     * @var array
      */
     protected array $_defaultSettings = [
         'max' => 100,
@@ -71,9 +69,9 @@ class SimpleGraphHelper extends Helper
 
         return sprintf(
             '<div class="c-graph-bar" style="%s"><div class="c-graph-bar__value" style="%s" title="%s"> </div></div>',
-            "width: {$width}px",
-            "margin-left: {$graphOffset}px; width: {$graphValue}px",
-            "Starting {$offset}ms into the request, taking {$value}ms",
+            sprintf('width: %spx', $width),
+            sprintf('margin-left: %spx; width: %spx', $graphOffset, $graphValue),
+            sprintf('Starting %sms into the request, taking %sms', $offset, $value),
         );
     }
 }

--- a/src/View/Helper/ToolbarHelper.php
+++ b/src/View/Helper/ToolbarHelper.php
@@ -34,15 +34,11 @@ class ToolbarHelper extends Helper
 {
     /**
      * helpers property
-     *
-     * @var array
      */
     public array $helpers = ['Html', 'Form', 'Url'];
 
     /**
      * Whether or not the top level keys should be sorted.
-     *
-     * @var bool
      */
     protected bool $sort = false;
 
@@ -76,7 +72,7 @@ class ToolbarHelper extends Helper
         }
         $root = new ArrayNode($items);
 
-        return implode([
+        return implode('', [
             '<div class="cake-debug-output" style="direction:ltr">',
             $formatter->dump($root),
             '</div>',
@@ -93,7 +89,7 @@ class ToolbarHelper extends Helper
     {
         $formatter = new HtmlFormatter();
 
-        return implode([
+        return implode('', [
             '<div class="cake-debug-output" style="direction:ltr">',
             $formatter->dump($node),
             '</div>',

--- a/tests/Fixture/PanelsFixture.php
+++ b/tests/Fixture/PanelsFixture.php
@@ -25,15 +25,11 @@ class PanelsFixture extends TestFixture
      * table property
      *
      * This is necessary to prevent userland inflections from causing issues.
-     *
-     * @var string
      */
     public string $table = 'panels';
 
     /**
      * Records
-     *
-     * @var array
      */
     public array $records = [];
 }

--- a/tests/Fixture/RequestsFixture.php
+++ b/tests/Fixture/RequestsFixture.php
@@ -25,15 +25,11 @@ class RequestsFixture extends TestFixture
      * table property
      *
      * This is necessary to prevent userland inflections from causing issues.
-     *
-     * @var string
      */
     public string $table = 'requests';
 
     /**
      * Records
-     *
-     * @var array
      */
     public array $records = [];
 }

--- a/tests/TestCase/Cache/Engine/DebugEngineTest.php
+++ b/tests/TestCase/Cache/Engine/DebugEngineTest.php
@@ -32,22 +32,16 @@ class DebugEngineTest extends TestCase
      */
     protected $engine;
 
-    /**
-     * @var \Cake\Cache\Engine\ArrayEngine
-     */
-    private $wrapped;
+    private ArrayEngine $wrapped;
 
-    /**
-     * @var \Cake\Log\Engine\ArrayLog
-     */
-    private $logger;
+    private ArrayLog $logger;
 
     /**
      * setup
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->wrapped = new ArrayEngine();
@@ -65,7 +59,7 @@ class DebugEngineTest extends TestCase
      *
      * @return void
      */
-    public function testInitEngineBasedOnConfig()
+    public function testInitEngineBasedOnConfig(): void
     {
         $engine = new DebugEngine([
             'className' => 'File',
@@ -81,7 +75,7 @@ class DebugEngineTest extends TestCase
      *
      * @return void
      */
-    public function testInitErrorOnInvalidConfig()
+    public function testInitErrorOnInvalidConfig(): void
     {
         $this->expectException(BadMethodCallException::class);
         $engine = new DebugEngine([
@@ -97,7 +91,7 @@ class DebugEngineTest extends TestCase
      *
      * @return void
      */
-    public function testProxyMethodsTracksMetrics()
+    public function testProxyMethodsTracksMetrics(): void
     {
         $this->engine->get('key');
         $this->engine->set('key', 'value');
@@ -118,7 +112,7 @@ class DebugEngineTest extends TestCase
      *
      * @return void
      */
-    public function testProxyMethodLogs()
+    public function testProxyMethodLogs(): void
     {
         $this->engine->get('key');
         $this->engine->set('key', 'value');
@@ -141,7 +135,7 @@ class DebugEngineTest extends TestCase
      *
      * @return void
      */
-    public function testGroupsProxies()
+    public function testGroupsProxies(): void
     {
         $engine = new DebugEngine([
             'className' => 'File',
@@ -159,7 +153,7 @@ class DebugEngineTest extends TestCase
      *
      * @return void
      */
-    public function testConfigProxies()
+    public function testConfigProxies(): void
     {
         $engine = new DebugEngine([
             'className' => 'File',
@@ -178,7 +172,7 @@ class DebugEngineTest extends TestCase
      *
      * @return void
      */
-    public function testToString()
+    public function testToString(): void
     {
         $engine = new DebugEngine([
             'className' => 'File',

--- a/tests/TestCase/Controller/ComposerControllerTest.php
+++ b/tests/TestCase/Controller/ComposerControllerTest.php
@@ -31,7 +31,7 @@ class ComposerControllerTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->configApplication(Application::class, []);
@@ -42,7 +42,7 @@ class ComposerControllerTest extends TestCase
      *
      * @return void
      */
-    public function testCheckDependencies()
+    public function testCheckDependencies(): void
     {
         $this->configRequest([
             'headers' => [

--- a/tests/TestCase/Controller/DashboardControllerTest.php
+++ b/tests/TestCase/Controller/DashboardControllerTest.php
@@ -43,13 +43,13 @@ class DashboardControllerTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->configApplication(Application::class, []);
     }
 
-    public function testIndexNoRequests()
+    public function testIndexNoRequests(): void
     {
         $requests = $this->fetchTable('DebugKit.Requests');
         $requests->Panels->deleteAll('1=1');
@@ -62,7 +62,7 @@ class DashboardControllerTest extends TestCase
         $this->assertResponseNotContains('Reset database');
     }
 
-    public function testIndexWithRequests()
+    public function testIndexWithRequests(): void
     {
         $request = $this->makeRequest();
         $this->makePanel($request);
@@ -74,7 +74,7 @@ class DashboardControllerTest extends TestCase
         $this->assertResponseContains('Reset database');
     }
 
-    public function testReset()
+    public function testReset(): void
     {
         $request = $this->makeRequest();
         $this->makePanel($request);

--- a/tests/TestCase/Controller/DebugKitControllerTest.php
+++ b/tests/TestCase/Controller/DebugKitControllerTest.php
@@ -24,12 +24,12 @@ use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 use DebugKit\Controller\DebugKitController;
 use DebugKit\TestApp\Application;
+use PHPUnit\Framework\Attributes\UsesClass;
 
 /**
  * DebugKit controller test.
- *
- * @uses \DebugKit\Controller\DebugKitController
  */
+#[UsesClass('\DebugKit\Controller\DebugKitController')]
 class DebugKitControllerTest extends TestCase
 {
     use IntegrationTestTrait;
@@ -39,7 +39,7 @@ class DebugKitControllerTest extends TestCase
      *
      * @return void
      */
-    public function testDebugDisabled()
+    public function testDebugDisabled(): void
     {
         Configure::write('debug', false);
 
@@ -56,7 +56,7 @@ class DebugKitControllerTest extends TestCase
      *
      * @return DebugKit\Controller\DebugKitController
      */
-    private function _buildController()
+    private function _buildController(): DebugKitController
     {
         $request = new ServerRequest(['url' => '/debug-kit/']);
 

--- a/tests/TestCase/Controller/MailPreviewControllerTest.php
+++ b/tests/TestCase/Controller/MailPreviewControllerTest.php
@@ -32,7 +32,7 @@ class MailPreviewControllerTest extends TestCase
      *
      * @return void
      */
-    public function testEmailPluginPassedToView()
+    public function testEmailPluginPassedToView(): void
     {
         $this->get('/debug-kit/mail-preview/preview/TestMailerPreview/test_email?plugin=DebugkitTestPlugin');
 
@@ -44,7 +44,7 @@ class MailPreviewControllerTest extends TestCase
      *
      * @return void
      */
-    public function testEmailPartTextContent()
+    public function testEmailPartTextContent(): void
     {
         $this->get('/debug-kit/mail-preview/preview/TestMailerPreview/test_email?part=text&plugin=DebugkitTestPlugin');
 
@@ -58,7 +58,7 @@ class MailPreviewControllerTest extends TestCase
      *
      * @return void
      */
-    public function testOnChangeJsPluginPassedToview()
+    public function testOnChangeJsPluginPassedToview(): void
     {
         $this->get('/debug-kit/mail-preview/preview/TestMailerPreview/test_email?plugin=DebugkitTestPlugin');
 
@@ -70,7 +70,7 @@ class MailPreviewControllerTest extends TestCase
      *
      * @return void
      */
-    public function testSentInvalidData()
+    public function testSentInvalidData(): void
     {
         $this->get('/debug-kit/mail-preview/sent/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/0');
         $this->assertResponseCode(404);
@@ -81,7 +81,7 @@ class MailPreviewControllerTest extends TestCase
      *
      * @return void
      */
-    public function testSentValidData()
+    public function testSentValidData(): void
     {
         $panels = $this->fetchTable('DebugKit.Panels');
         $request = $this->makeRequest();
@@ -97,7 +97,7 @@ class MailPreviewControllerTest extends TestCase
         $panel->content = serialize($data);
         $panels->save($panel);
 
-        $this->get("/debug-kit/mail-preview/sent/{$panel->id}/0");
+        $this->get(sprintf('/debug-kit/mail-preview/sent/%s/0', $panel->id));
         $this->assertResponseCode(200);
         $this->assertResponseContains('test@example.com');
         $this->assertResponseContains('<iframe');
@@ -108,7 +108,7 @@ class MailPreviewControllerTest extends TestCase
      *
      * @return void
      */
-    public function testSentValidDataRenderPart()
+    public function testSentValidDataRenderPart(): void
     {
         $panels = $this->fetchTable('DebugKit.Panels');
         $request = $this->makeRequest();
@@ -124,7 +124,7 @@ class MailPreviewControllerTest extends TestCase
         $panel->content = serialize($data);
         $panels->save($panel);
 
-        $this->get("/debug-kit/mail-preview/sent/{$panel->id}/0?part=html");
+        $this->get(sprintf('/debug-kit/mail-preview/sent/%s/0?part=html', $panel->id));
         $this->assertResponseCode(200);
         $this->assertResponseContains('<h1>Hi</h1>');
     }

--- a/tests/TestCase/Controller/PanelsControllerTest.php
+++ b/tests/TestCase/Controller/PanelsControllerTest.php
@@ -43,7 +43,7 @@ class PanelsControllerTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->configApplication(Application::class, []);
@@ -54,7 +54,7 @@ class PanelsControllerTest extends TestCase
      *
      * @return void
      */
-    public function testIndex()
+    public function testIndex(): void
     {
         $this->configRequest([
             'headers' => [
@@ -63,7 +63,7 @@ class PanelsControllerTest extends TestCase
         ]);
         $request = $this->makeRequest();
         $this->makePanel($request);
-        $this->get("/debug-kit/panels/{$request->id}");
+        $this->get('/debug-kit/panels/' . $request->id);
 
         $this->assertResponseOk();
         $this->assertContentType('application/json');
@@ -74,12 +74,12 @@ class PanelsControllerTest extends TestCase
      *
      * @return void
      */
-    public function testView()
+    public function testView(): void
     {
         $request = $this->makeRequest();
         $panel = $this->makePanel($request);
 
-        $this->get("/debug-kit/panels/view/{$panel->id}");
+        $this->get('/debug-kit/panels/view/' . $panel->id);
 
         $this->assertResponseOk();
         $this->assertResponseContains('Request</h2>');
@@ -91,7 +91,7 @@ class PanelsControllerTest extends TestCase
      *
      * @return void
      */
-    public function testViewNotExists()
+    public function testViewNotExists(): void
     {
         $this->get('/debug-kit/panels/view/aaaaaaaa-ffff-ffff-ffff-aaaaaaaaaaaa');
         $this->assertResponseError();
@@ -101,7 +101,7 @@ class PanelsControllerTest extends TestCase
     /**
      * @return void
      */
-    public function testLatestHistory()
+    public function testLatestHistory(): void
     {
         $request = $this->fetchTable('DebugKit.Requests')->find('recent')->first();
         if (!$request) {

--- a/tests/TestCase/Controller/RequestsControllerTest.php
+++ b/tests/TestCase/Controller/RequestsControllerTest.php
@@ -43,7 +43,7 @@ class RequestsControllerTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->configApplication(Application::class, []);
@@ -54,13 +54,13 @@ class RequestsControllerTest extends TestCase
      *
      * @return void
      */
-    public function testView()
+    public function testView(): void
     {
         $request = $this->makeRequest();
         $this->makePanel($request);
 
         $this->configRequest(['headers' => ['Accept' => 'application/json']]);
-        $this->get("/debug-kit/toolbar/{$request->id}");
+        $this->get('/debug-kit/toolbar/' . $request->id);
 
         $this->assertResponseOk();
         $this->assertResponseContains('Request', 'Has a panel button');
@@ -72,7 +72,7 @@ class RequestsControllerTest extends TestCase
      *
      * @return void
      */
-    public function testViewNotExists()
+    public function testViewNotExists(): void
     {
         $this->configRequest(['headers' => ['Accept' => 'application/json']]);
         $this->get('/debug-kit/toolbar/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb');

--- a/tests/TestCase/Controller/ToolbarControllerTest.php
+++ b/tests/TestCase/Controller/ToolbarControllerTest.php
@@ -32,7 +32,7 @@ class ToolbarControllerTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->configApplication(Application::class, []);
@@ -43,7 +43,7 @@ class ToolbarControllerTest extends TestCase
      *
      * @return void
      */
-    public function testClearCacheNoGet()
+    public function testClearCacheNoGet(): void
     {
         $this->get('/debug-kit/toolbar/clear-cache?name=testing');
         $this->assertResponseCode(405);
@@ -54,7 +54,7 @@ class ToolbarControllerTest extends TestCase
      *
      * @return void
      */
-    public function testClearCache()
+    public function testClearCache(): void
     {
         $mock = $this->getMockBuilder('Cake\Cache\CacheEngine')->getMock();
         $mock->expects($this->once())

--- a/tests/TestCase/Database/Log/DebugLogTest.php
+++ b/tests/TestCase/Database/Log/DebugLogTest.php
@@ -36,7 +36,7 @@ class DebugLogTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->logger = new DebugLog(null, 'test');
@@ -47,7 +47,7 @@ class DebugLogTest extends TestCase
      *
      * @return void
      */
-    public function testLog()
+    public function testLog(): void
     {
         $query = new LoggedQuery();
         $query->setContext([
@@ -72,7 +72,7 @@ class DebugLogTest extends TestCase
      *
      * @return void
      */
-    public function testLogElastic()
+    public function testLogElastic(): void
     {
         $this->assertCount(0, $this->logger->queries());
 
@@ -114,7 +114,7 @@ class DebugLogTest extends TestCase
      * @return void
      */
     #[DataProvider('schemaQueryProvider')]
-    public function testLogIgnoreReflection($sql)
+    public function testLogIgnoreReflection(string $sql): void
     {
         $query = new LoggedQuery();
         $query->setContext([
@@ -135,7 +135,7 @@ class DebugLogTest extends TestCase
      * @return void
      */
     #[DataProvider('schemaQueryProvider')]
-    public function testLogIgnoreReflectionDisabled($sql)
+    public function testLogIgnoreReflectionDisabled(string $sql): void
     {
         $query = new LoggedQuery();
         $query->setContext([
@@ -151,7 +151,7 @@ class DebugLogTest extends TestCase
         $this->assertCount(1, $logger->queries());
     }
 
-    public static function schemaQueryProvider()
+    public static function schemaQueryProvider(): array
     {
         return [
             // MySQL
@@ -173,7 +173,7 @@ class DebugLogTest extends TestCase
      *
      * @return void
      */
-    public function testLogDecorates()
+    public function testLogDecorates(): void
     {
         $orig = $this->getMockBuilder(LoggerInterface::class)->getMock();
         $orig->expects($this->once())

--- a/tests/TestCase/DebugIncludeTest.php
+++ b/tests/TestCase/DebugIncludeTest.php
@@ -22,7 +22,7 @@ use DebugKit\DebugInclude;
  */
 class DebugIncludeTest extends TestCase
 {
-    public function testIncludePaths()
+    public function testIncludePaths(): void
     {
         $include = new DebugInclude();
         $result = $include->includePaths();
@@ -30,7 +30,7 @@ class DebugIncludeTest extends TestCase
         $this->assertStringContainsString($result[0], get_include_path());
     }
 
-    public function testIsCakeFile()
+    public function testIsCakeFile(): void
     {
         $include = new DebugInclude();
 
@@ -41,7 +41,7 @@ class DebugIncludeTest extends TestCase
         $this->assertFalse($include->isCakeFile(TMP));
     }
 
-    public function testIsAppFile()
+    public function testIsAppFile(): void
     {
         $include = new DebugInclude();
 
@@ -52,7 +52,7 @@ class DebugIncludeTest extends TestCase
         $this->assertFalse($include->isAppFile(TMP));
     }
 
-    public function testGetPluginName()
+    public function testGetPluginName(): void
     {
         $include = new DebugInclude();
 
@@ -60,7 +60,7 @@ class DebugIncludeTest extends TestCase
         $this->assertFalse($include->getPluginName(TMP));
     }
 
-    public function testGetComposerPackageName()
+    public function testGetComposerPackageName(): void
     {
         $include = new DebugInclude();
 
@@ -68,7 +68,7 @@ class DebugIncludeTest extends TestCase
         $this->assertSame('cakephp/cakephp', $include->getComposerPackageName($path));
     }
 
-    public function testNiceFileName()
+    public function testNiceFileName(): void
     {
         $include = new DebugInclude();
 
@@ -98,7 +98,7 @@ class DebugIncludeTest extends TestCase
         );
     }
 
-    public function testGetFileType()
+    public function testGetFileType(): void
     {
         $include = new DebugInclude();
 

--- a/tests/TestCase/DebugKitPluginTest.php
+++ b/tests/TestCase/DebugKitPluginTest.php
@@ -34,7 +34,7 @@ class DebugKitPluginTest extends TestCase
      *
      * @return void
      */
-    public function testSetDeprecationHandler()
+    public function testSetDeprecationHandler(): void
     {
         DeprecationsPanel::clearDeprecatedErrors();
         $service = new ToolbarService(new EventManager(), []);
@@ -86,7 +86,7 @@ TEXT;
      *
      * @return void
      */
-    public function testMiddlewareNotLoadedInTests()
+    public function testMiddlewareNotLoadedInTests(): void
     {
         $baseApp = new Application(dirname(__DIR__) . '/config');
         $baseApp->pluginBootstrap();

--- a/tests/TestCase/DebugMemoryTest.php
+++ b/tests/TestCase/DebugMemoryTest.php
@@ -27,7 +27,7 @@ class DebugMemoryTest extends TestCase
      *
      * @return void
      */
-    public function testMemoryUsage()
+    public function testMemoryUsage(): void
     {
         $result = DebugMemory::getCurrent();
         $this->assertIsInt($result);
@@ -41,7 +41,7 @@ class DebugMemoryTest extends TestCase
      *
      * @return void
      */
-    public function testRecordNoKey()
+    public function testRecordNoKey(): void
     {
         DebugMemory::clear();
         DebugMemory::record();
@@ -55,7 +55,7 @@ class DebugMemoryTest extends TestCase
      *
      * @return void
      */
-    public function testMemorySettingAndGetting()
+    public function testMemorySettingAndGetting(): void
     {
         DebugMemory::clear();
         $result = DebugMemory::record('test marker');

--- a/tests/TestCase/DebugPanelTest.php
+++ b/tests/TestCase/DebugPanelTest.php
@@ -28,18 +28,18 @@ class DebugPanelTest extends TestCase
      */
     protected $panel;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->panel = new SimplePanel();
     }
 
-    public function testTitle()
+    public function testTitle(): void
     {
         $this->assertSame('Simple', $this->panel->title());
     }
 
-    public function testElementName()
+    public function testElementName(): void
     {
         $this->assertSame('DebugKit.simple_panel', $this->panel->elementName());
 

--- a/tests/TestCase/DebugSqlTest.php
+++ b/tests/TestCase/DebugSqlTest.php
@@ -34,7 +34,7 @@ class DebugSqlTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
@@ -44,7 +44,7 @@ class DebugSqlTest extends TestCase
      * Tests that a SQL string is outputted in a formatted and
      * highlighted fashion in a CLI environment.
      */
-    public function testSqlCli()
+    public function testSqlCli(): void
     {
         $query = $this->newQuery()->select(['panels.id']);
 
@@ -65,7 +65,7 @@ EXPECTED;
      * Tests that a SQL string is outputted as HTML in a CLI
      * environment.
      */
-    public function testSqlHtmlOnCli()
+    public function testSqlHtmlOnCli(): void
     {
         $query = $this->newQuery()->select(['panels.id']);
 
@@ -84,7 +84,7 @@ EXPECTED;
      * Tests that a SQL string is outputted as HTML in a non-CLI
      * environment.
      */
-    public function testSqlHtml()
+    public function testSqlHtml(): void
     {
         $query = $this->newQuery()->select(['panels.id']);
 
@@ -108,7 +108,7 @@ EXPECTED;
      * Tests that a SQL string is outputted as plain text in a non-CLI
      * environment.
      */
-    public function testSqlPlain()
+    public function testSqlPlain(): void
     {
         $query = $this->newQuery()->select(['panels.id']);
 

--- a/tests/TestCase/DebugTimerTest.php
+++ b/tests/TestCase/DebugTimerTest.php
@@ -29,7 +29,7 @@ class DebugTimerTest extends TestCase
      *
      * @return void
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         DebugTimer::clear();
     }
@@ -39,7 +39,7 @@ class DebugTimerTest extends TestCase
      *
      * @return void
      */
-    public function testTimers()
+    public function testTimers(): void
     {
         $this->assertTrue(DebugTimer::start('test1', 'this is my first test'));
         usleep(5000);
@@ -64,7 +64,7 @@ class DebugTimerTest extends TestCase
      *
      * @return void
      */
-    public function testAnonymousTimers()
+    public function testAnonymousTimers(): void
     {
         $this->assertTrue(DebugTimer::start());
         usleep(2000);
@@ -72,9 +72,8 @@ class DebugTimerTest extends TestCase
         $timers = DebugTimer::getAll();
 
         $this->assertCount(2, $timers);
-        end($timers);
-        $key = key($timers);
-        $lineNo = __LINE__ - 8;
+        $key = array_key_last($timers);
+        $lineNo = __LINE__ - 7;
 
         $file = Debugger::trimPath(__FILE__);
         $expected = $file . ' line ' . $lineNo;
@@ -90,7 +89,7 @@ class DebugTimerTest extends TestCase
      *
      * @return void
      */
-    public function testNestedAnonymousTimers()
+    public function testNestedAnonymousTimers(): void
     {
         $this->assertTrue(DebugTimer::start());
         usleep(100);
@@ -119,7 +118,7 @@ class DebugTimerTest extends TestCase
      *
      * @return void
      */
-    public function testRepeatTimers()
+    public function testRepeatTimers(): void
     {
         DebugTimer::start('my timer', 'This is the first call');
         usleep(100);
@@ -145,7 +144,7 @@ class DebugTimerTest extends TestCase
      *
      * @return void
      */
-    public function testRequestTime()
+    public function testRequestTime(): void
     {
         $result1 = DebugTimer::requestTime();
         usleep(50);
@@ -158,7 +157,7 @@ class DebugTimerTest extends TestCase
      *
      * @return void
      */
-    public function testGetTimersWithClear()
+    public function testGetTimersWithClear(): void
     {
         DebugTimer::start('test1', 'this is my first test');
         DebugTimer::stop('test1');
@@ -173,7 +172,7 @@ class DebugTimerTest extends TestCase
      *
      * @return void
      */
-    public function testGetTimers()
+    public function testGetTimers(): void
     {
         DebugTimer::start('test1', 'this is my first test');
         DebugTimer::stop('test1');

--- a/tests/TestCase/Mailer/Transport/DebugKitTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/DebugKitTransportTest.php
@@ -28,7 +28,7 @@ class DebugKitTransportTest extends TestCase
 
     protected $wrapped;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->log = new ArrayObject();
         $this->wrapped = new class extends AbstractTransport {
@@ -50,7 +50,7 @@ class DebugKitTransportTest extends TestCase
         );
     }
 
-    public function testPropertyProxies()
+    public function testPropertyProxies(): void
     {
         $this->wrapped->property = 'value';
         $this->assertTrue(isset($this->transport->property));
@@ -62,12 +62,12 @@ class DebugKitTransportTest extends TestCase
         $this->assertFalse(isset($this->wrapped->property));
     }
 
-    public function testMethodProxy()
+    public function testMethodProxy(): void
     {
         $this->assertSame('bloop', $this->transport->customMethod());
     }
 
-    public function testEmailCapture()
+    public function testEmailCapture(): void
     {
         $message = new Message();
         $message->setSubject('Testing 123')

--- a/tests/TestCase/Middleware/DebugKitMiddlewareTest.php
+++ b/tests/TestCase/Middleware/DebugKitMiddlewareTest.php
@@ -24,6 +24,7 @@ use Cake\Http\ServerRequest;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use DebugKit\Middleware\DebugKitMiddleware;
+use Psr\Http\Message\MessageInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use ReflectionProperty;
 
@@ -44,9 +45,6 @@ class DebugKitMiddlewareTest extends TestCase
 
     protected ?array $oldConfig = null;
 
-    /**
-     * @var bool
-     */
     protected bool $restore = false;
 
     /**
@@ -54,7 +52,7 @@ class DebugKitMiddlewareTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -70,7 +68,7 @@ class DebugKitMiddlewareTest extends TestCase
      *
      * @return void
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 
@@ -80,11 +78,9 @@ class DebugKitMiddlewareTest extends TestCase
 
     protected function handler()
     {
-        $handler = $this->getMockBuilder(RequestHandlerInterface::class)
+        return $this->getMockBuilder(RequestHandlerInterface::class)
             ->onlyMethods(['handle'])
             ->getMock();
-
-        return $handler;
     }
 
     /**
@@ -92,7 +88,7 @@ class DebugKitMiddlewareTest extends TestCase
      *
      * @return void
      */
-    public function testInvokeSaveData()
+    public function testInvokeSaveData(): void
     {
         $request = new ServerRequest([
             'url' => '/articles',
@@ -146,7 +142,7 @@ class DebugKitMiddlewareTest extends TestCase
      *
      * @return void
      */
-    public function testInvokeInjectCspNonce()
+    public function testInvokeInjectCspNonce(): void
     {
         $request = new ServerRequest([
             'url' => '/articles',
@@ -179,7 +175,7 @@ class DebugKitMiddlewareTest extends TestCase
      *
      * @return void
      */
-    public function testInvokeNoModifyBinaryResponse()
+    public function testInvokeNoModifyBinaryResponse(): void
     {
         $request = new ServerRequest([
             'url' => '/articles',
@@ -193,8 +189,8 @@ class DebugKitMiddlewareTest extends TestCase
         $handler = $this->handler();
         $handler->expects($this->once())
             ->method('handle')
-            ->willReturnCallback(function ($req) use ($response) {
-                $stream = new CallbackStream(function () {
+            ->willReturnCallback(function ($req) use ($response): MessageInterface {
+                $stream = new CallbackStream(function (): string {
                     return 'hi!';
                 });
 
@@ -218,7 +214,7 @@ class DebugKitMiddlewareTest extends TestCase
      *
      * @return void
      */
-    public function testInvokeNoModifyNonHtmlResponse()
+    public function testInvokeNoModifyNonHtmlResponse(): void
     {
         $request = new ServerRequest([
             'url' => '/articles',
@@ -251,13 +247,12 @@ class DebugKitMiddlewareTest extends TestCase
      *
      * @return void
      */
-    public function testConfigIsPassed()
+    public function testConfigIsPassed(): void
     {
         $config = ['foo' => 'bar'];
         Configure::write('DebugKit', $config);
         $layer = new DebugKitMiddleware();
         $prop = new ReflectionProperty(DebugKitMiddleware::class, 'service');
-        $prop->setAccessible(true);
         $service = $prop->getValue($layer);
         $this->assertSame('bar', $service->getConfig('foo'));
     }

--- a/tests/TestCase/Model/Behavior/TimedBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TimedBehaviorTest.php
@@ -33,7 +33,7 @@ class TimedBehaviorTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->Article = $this->fetchTable('Articles');
@@ -45,7 +45,7 @@ class TimedBehaviorTest extends TestCase
      *
      * @return void
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         unset($this->Article);
@@ -57,7 +57,7 @@ class TimedBehaviorTest extends TestCase
      *
      * @return void
      */
-    public function testFindTimers()
+    public function testFindTimers(): void
     {
         $timers = DebugTimer::getAll();
         $this->assertCount(1, $timers);
@@ -76,7 +76,7 @@ class TimedBehaviorTest extends TestCase
      *
      * @return void
      */
-    public function testSaveTimers()
+    public function testSaveTimers(): void
     {
         $timers = DebugTimer::getAll();
         $this->assertCount(1, $timers);

--- a/tests/TestCase/Model/Table/RequestTableTest.php
+++ b/tests/TestCase/Model/Table/RequestTableTest.php
@@ -32,7 +32,7 @@ class RequestTableTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $connection = ConnectionManager::get('test');
@@ -44,7 +44,7 @@ class RequestTableTest extends TestCase
      *
      * @return void
      */
-    public function testInitializeCreatesSchema()
+    public function testInitializeCreatesSchema(): void
     {
         $connection = ConnectionManager::get('test');
         $stmt = $connection->execute('DROP TABLE IF EXISTS panels');
@@ -66,7 +66,7 @@ class RequestTableTest extends TestCase
      *
      * @return void
      */
-    public function testFindRecent()
+    public function testFindRecent(): void
     {
         $table = $this->fetchTable('DebugKit.Requests');
         $query = $table->find('recent');
@@ -79,7 +79,7 @@ class RequestTableTest extends TestCase
      *
      * @return void
      */
-    public function testGc()
+    public function testGc(): void
     {
         /** @var \PHPUnit\Framework\MockObject\MockObject&\DebugKit\Model\Table\RequestsTable $requestsTableMock */
         $requestsTableMock = $this->getMockForModel('DebugKit.Requests', ['shouldGc']);

--- a/tests/TestCase/Model/Table/SqlTraceTraitTest.php
+++ b/tests/TestCase/Model/Table/SqlTraceTraitTest.php
@@ -50,7 +50,7 @@ class SqlTraceTraitTest extends TestCase
         $this->debug = Configure::read('App.debug', true);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         Configure::write('App.debug', $this->debug);
@@ -59,7 +59,7 @@ class SqlTraceTraitTest extends TestCase
     /**
      * Verify file name when calling find()
      */
-    public function testFind()
+    public function testFind(): void
     {
         foreach ($this->tables as $table) {
             $table = $this->fetchTable($table);
@@ -71,7 +71,7 @@ class SqlTraceTraitTest extends TestCase
     /**
      * Verify file name when calling query()/select()
      */
-    public function testQuery()
+    public function testQuery(): void
     {
         foreach ($this->tables as $table) {
             $table = $this->fetchTable($table);
@@ -83,7 +83,7 @@ class SqlTraceTraitTest extends TestCase
     /**
      * Verify file name when calling update()
      */
-    public function testUpdate()
+    public function testUpdate(): void
     {
         foreach ($this->tables as $table) {
             $table = $this->fetchTable($table);
@@ -95,7 +95,7 @@ class SqlTraceTraitTest extends TestCase
     /**
      * Verify file name when calling delete()
      */
-    public function testDelete()
+    public function testDelete(): void
     {
         foreach ($this->tables as $table) {
             $table = $this->fetchTable($table);

--- a/tests/TestCase/Panel/CachePanelTest.php
+++ b/tests/TestCase/Panel/CachePanelTest.php
@@ -33,7 +33,7 @@ class CachePanelTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->panel = new CachePanel();
@@ -45,7 +45,7 @@ class CachePanelTest extends TestCase
      *
      * @return void
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         Cache::drop('debug_kit_test');
@@ -57,7 +57,7 @@ class CachePanelTest extends TestCase
      *
      * @return void
      */
-    public function testInitialize()
+    public function testInitialize(): void
     {
         $this->panel->initialize();
 
@@ -71,7 +71,7 @@ class CachePanelTest extends TestCase
      *
      * @return void
      */
-    public function testInitializeNoProxyIncompleteConfig()
+    public function testInitializeNoProxyIncompleteConfig(): void
     {
         $data = ['duration' => '+2 seconds'];
         Cache::setConfig('incomplete', $data);
@@ -86,7 +86,7 @@ class CachePanelTest extends TestCase
      *
      * @return void
      */
-    public function testInitializeIncompleteData()
+    public function testInitializeIncompleteData(): void
     {
         Cache::setConfig('incomplete', ['duration' => '+2 seconds']);
         $this->panel->initialize();
@@ -100,7 +100,7 @@ class CachePanelTest extends TestCase
      *
      * @return void
      */
-    public function testInitializeTwiceNoDoubleProxy()
+    public function testInitializeTwiceNoDoubleProxy(): void
     {
         $this->panel->initialize();
         $result = Cache::pool('debug_kit_test');
@@ -111,7 +111,7 @@ class CachePanelTest extends TestCase
         $this->assertSame($result2, $result);
     }
 
-    public function testInitializePreserveGlobalConfig()
+    public function testInitializePreserveGlobalConfig(): void
     {
         $this->panel->initialize();
         $result = Cache::getConfig('debug_kit_test');

--- a/tests/TestCase/Panel/DeprecationsPanelTest.php
+++ b/tests/TestCase/Panel/DeprecationsPanelTest.php
@@ -35,7 +35,7 @@ class DeprecationsPanelTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         DeprecationsPanel::clearDeprecatedErrors();
@@ -43,7 +43,7 @@ class DeprecationsPanelTest extends TestCase
         $this->loadPlugins(['DebugKit']);
         $this->panel = new DeprecationsPanel();
 
-        set_error_handler(function ($code, $message, $file, $line, $context = null) {
+        set_error_handler(function ($code, $message, $file, $line, $context = null): void {
             DeprecationsPanel::addDeprecatedError(compact('code', 'message', 'file', 'line', 'context'));
         });
         try {
@@ -56,7 +56,7 @@ class DeprecationsPanelTest extends TestCase
     }
 
     #[WithoutErrorHandler]
-    public function testShutdown()
+    public function testShutdown(): void
     {
         $event = new Event('Panel.shutdown');
         $this->panel->shutdown($event);
@@ -75,7 +75,7 @@ class DeprecationsPanelTest extends TestCase
         $this->assertArrayHasKey('line', $error);
     }
 
-    public function testSummary()
+    public function testSummary(): void
     {
         $this->assertSame('1', $this->panel->summary());
     }

--- a/tests/TestCase/Panel/EnvironmentPanelTest.php
+++ b/tests/TestCase/Panel/EnvironmentPanelTest.php
@@ -34,7 +34,7 @@ class EnvironmentPanelTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->panel = new EnvironmentPanel();
@@ -45,7 +45,7 @@ class EnvironmentPanelTest extends TestCase
      *
      * @return void
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         unset($this->panel);
@@ -56,7 +56,7 @@ class EnvironmentPanelTest extends TestCase
      *
      * @return void
      */
-    public function testShutdown()
+    public function testShutdown(): void
     {
         $controller = new stdClass();
         $event = new Event('Controller.shutdown', $controller);

--- a/tests/TestCase/Panel/IncludePanelTest.php
+++ b/tests/TestCase/Panel/IncludePanelTest.php
@@ -34,10 +34,10 @@ class IncludePanelTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $this->panel = new IncludePanel();
         });
     }
@@ -48,7 +48,7 @@ class IncludePanelTest extends TestCase
      * @return void
      */
     #[WithoutErrorHandler]
-    public function testShutdown()
+    public function testShutdown(): void
     {
         $this->panel->shutdown(new Event('Controller.shutdown'));
 
@@ -66,7 +66,7 @@ class IncludePanelTest extends TestCase
      * @return void
      */
     #[WithoutErrorHandler]
-    public function testSummary()
+    public function testSummary(): void
     {
         $total = $this->panel->summary();
         $this->assertEquals(5, $total);

--- a/tests/TestCase/Panel/LogPanelTest.php
+++ b/tests/TestCase/Panel/LogPanelTest.php
@@ -34,7 +34,7 @@ class LogPanelTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->panel = new LogPanel();
@@ -45,7 +45,7 @@ class LogPanelTest extends TestCase
      *
      * @return void
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         Log::drop('debug_kit_log_panel');
@@ -56,7 +56,7 @@ class LogPanelTest extends TestCase
      *
      * @return void
      */
-    public function testInitialize()
+    public function testInitialize(): void
     {
         $this->panel->initialize();
 
@@ -70,7 +70,7 @@ class LogPanelTest extends TestCase
      *
      * @return void
      */
-    public function testData()
+    public function testData(): void
     {
         $this->panel->initialize();
         Log::write('error', 'Test');
@@ -90,7 +90,7 @@ class LogPanelTest extends TestCase
      *
      * @return void
      */
-    public function testSummary()
+    public function testSummary(): void
     {
         $this->panel->initialize();
 

--- a/tests/TestCase/Panel/PackagesPanelTest.php
+++ b/tests/TestCase/Panel/PackagesPanelTest.php
@@ -34,7 +34,7 @@ class PackagesPanelTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->panel = new PackagesPanel();
@@ -45,7 +45,7 @@ class PackagesPanelTest extends TestCase
      *
      * @return array
      */
-    public static function packagesProvider()
+    public static function packagesProvider(): array
     {
         return [
             'requirements' => ['packages'],
@@ -59,7 +59,7 @@ class PackagesPanelTest extends TestCase
      * @return void
      */
     #[DataProvider('packagesProvider')]
-    public function testData($package)
+    public function testData(string $package): void
     {
         $data = $this->panel->data();
         $this->assertArrayHasKey($package, $data);

--- a/tests/TestCase/Panel/RequestPanelTest.php
+++ b/tests/TestCase/Panel/RequestPanelTest.php
@@ -35,7 +35,7 @@ class RequestPanelTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->panel = new RequestPanel();
@@ -46,7 +46,7 @@ class RequestPanelTest extends TestCase
      *
      * @return void
      */
-    public function testShutdownSkipAttributes()
+    public function testShutdownSkipAttributes(): void
     {
         $request = new ServerRequest([
             'url' => '/',
@@ -55,7 +55,7 @@ class RequestPanelTest extends TestCase
         ]);
         $request = $request
             ->withAttribute('ok', 'string')
-            ->withAttribute('closure', function () {
+            ->withAttribute('closure', function (): void {
             });
 
         $controller = new Controller($request);

--- a/tests/TestCase/Panel/RoutesPanelTest.php
+++ b/tests/TestCase/Panel/RoutesPanelTest.php
@@ -33,7 +33,7 @@ class RoutesPanelTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -54,7 +54,7 @@ class RoutesPanelTest extends TestCase
      *
      * @return void
      */
-    public function testSummary()
+    public function testSummary(): void
     {
         $this->panel->initialize();
         $this->assertSame('4', $this->panel->summary());

--- a/tests/TestCase/Panel/SessionPanelTest.php
+++ b/tests/TestCase/Panel/SessionPanelTest.php
@@ -37,7 +37,7 @@ class SessionPanelTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->panel = new SessionPanel();
@@ -49,7 +49,7 @@ class SessionPanelTest extends TestCase
      * @return void
      */
     #[WithoutErrorHandler]
-    public function testShutdownSkipAttributes()
+    public function testShutdownSkipAttributes(): void
     {
         $session = new Session();
         $session->write('test', 123);
@@ -59,7 +59,7 @@ class SessionPanelTest extends TestCase
 
         $controller = new Controller($request);
         $event = new Event('Controller.shutdown', $controller);
-        $this->deprecated(function () use ($event) {
+        $this->deprecated(function () use ($event): void {
             $this->panel->shutdown($event);
         });
 

--- a/tests/TestCase/Panel/SqlLogPanelTest.php
+++ b/tests/TestCase/Panel/SqlLogPanelTest.php
@@ -40,14 +40,14 @@ class SqlLogPanelTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->panel = new SqlLogPanel();
         $this->logger = ConnectionManager::get('test')->getDriver()->getLogger();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 
@@ -61,7 +61,7 @@ class SqlLogPanelTest extends TestCase
      *
      * @return void
      */
-    public function testInitializeTwiceNoDoubleProxy()
+    public function testInitializeTwiceNoDoubleProxy(): void
     {
         $this->panel->initialize();
         $db = ConnectionManager::get('test');
@@ -78,7 +78,7 @@ class SqlLogPanelTest extends TestCase
      *
      * @return void
      */
-    public function testInitializePassesIncludeSchema()
+    public function testInitializePassesIncludeSchema(): void
     {
         Configure::write('DebugKit.includeSchemaReflection', true);
         $this->panel->initialize();
@@ -87,7 +87,6 @@ class SqlLogPanelTest extends TestCase
         $this->assertInstanceOf('DebugKit\Database\Log\DebugLog', $logger);
 
         $property = new ReflectionProperty($logger, '_includeSchema');
-        $property->setAccessible(true);
         $this->assertTrue($property->getValue($logger));
     }
 
@@ -96,7 +95,7 @@ class SqlLogPanelTest extends TestCase
      *
      * @return void
      */
-    public function testData()
+    public function testData(): void
     {
         $this->panel->initialize();
 
@@ -113,7 +112,7 @@ class SqlLogPanelTest extends TestCase
      *
      * @return void
      */
-    public function testSummary()
+    public function testSummary(): void
     {
         $this->panel->initialize();
 
@@ -130,7 +129,7 @@ class SqlLogPanelTest extends TestCase
      *
      * @return void
      */
-    public function testWithSimpleConnection()
+    public function testWithSimpleConnection(): void
     {
         ConnectionManager::setConfig('simple', [
             'className' => 'DebugKit\TestApp\Stub\SimpleConnectionStub',

--- a/tests/TestCase/Panel/VariablesPanelTest.php
+++ b/tests/TestCase/Panel/VariablesPanelTest.php
@@ -37,7 +37,7 @@ class VariablesPanelTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->panel = new VariablesPanel();
@@ -48,7 +48,7 @@ class VariablesPanelTest extends TestCase
      *
      * @return void
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         unset($this->panel);
@@ -59,7 +59,7 @@ class VariablesPanelTest extends TestCase
      *
      * @return void
      */
-    public function testShutdown()
+    public function testShutdown(): void
     {
         $requests = $this->getTableLocator()->get('Requests');
         $query = $requests->find('all');

--- a/tests/TestCase/ToolbarServiceTest.php
+++ b/tests/TestCase/ToolbarServiceTest.php
@@ -45,9 +45,6 @@ class ToolbarServiceTest extends TestCase
         'plugin.DebugKit.Panels',
     ];
 
-    /**
-     * @var bool
-     */
     protected bool $restore = false;
 
     /**
@@ -60,7 +57,7 @@ class ToolbarServiceTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->events = new EventManager();
@@ -76,7 +73,7 @@ class ToolbarServiceTest extends TestCase
      *
      * @return void
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         putenv('HTTP_HOST=');
@@ -88,7 +85,7 @@ class ToolbarServiceTest extends TestCase
      *
      * @return void
      */
-    public function testLoadPanels()
+    public function testLoadPanels(): void
     {
         $bar = new ToolbarService($this->events, []);
         $bar->loadPanels();
@@ -103,7 +100,7 @@ class ToolbarServiceTest extends TestCase
      *
      * @return void
      */
-    public function testDisablePanels()
+    public function testDisablePanels(): void
     {
         $bar = new ToolbarService($this->events, ['panels' => [
             'DebugKit.SqlLog' => false,
@@ -122,7 +119,7 @@ class ToolbarServiceTest extends TestCase
      *
      * @return void
      */
-    public function testInitializePanels()
+    public function testInitializePanels(): void
     {
         Log::drop('debug_kit_log_panel');
         $bar = new ToolbarService($this->events, []);
@@ -139,7 +136,7 @@ class ToolbarServiceTest extends TestCase
      *
      * @return void
      */
-    public function testSaveDataIgnoreDebugKit()
+    public function testSaveDataIgnoreDebugKit(): void
     {
         $request = new Request([
             'url' => '/debug_kit/panel/abc123',
@@ -160,7 +157,7 @@ class ToolbarServiceTest extends TestCase
      *
      * @return void
      */
-    public function testSaveDataIgnoreDebugKitDashedUrl()
+    public function testSaveDataIgnoreDebugKitDashedUrl(): void
     {
         $request = new Request([
             'url' => '/debug-kit/panel/abc123',
@@ -194,7 +191,7 @@ class ToolbarServiceTest extends TestCase
      *
      * @return void
      */
-    public function testSaveDataIgnorePaths()
+    public function testSaveDataIgnorePaths(): void
     {
         $request = new Request([
             'url' => '/foo.jpg',
@@ -228,7 +225,7 @@ class ToolbarServiceTest extends TestCase
      *
      * @return void
      */
-    public function testSaveData()
+    public function testSaveData(): void
     {
         $request = new Request([
             'url' => '/articles',
@@ -272,7 +269,7 @@ class ToolbarServiceTest extends TestCase
      *
      * @return void
      */
-    public function testSaveDataMissingConnection()
+    public function testSaveDataMissingConnection(): void
     {
         $restore = ConnectionManager::getConfig('test_debug_kit');
         ConnectionManager::drop('test_debug_kit');
@@ -300,7 +297,7 @@ class ToolbarServiceTest extends TestCase
      *
      * @return void
      */
-    public function testInjectScriptsLastBodyTag()
+    public function testInjectScriptsLastBodyTag(): void
     {
         $request = new Request([
             'url' => '/articles',
@@ -335,7 +332,7 @@ class ToolbarServiceTest extends TestCase
      *
      * @return void
      */
-    public function testInjectScriptsFileBodies()
+    public function testInjectScriptsFileBodies(): void
     {
         $response = new Response([
             'statusCode' => 200,
@@ -357,7 +354,7 @@ class ToolbarServiceTest extends TestCase
      *
      * @return void
      */
-    public function testInjectScriptsStreamBodies()
+    public function testInjectScriptsStreamBodies(): void
     {
         $response = new Response([
             'statusCode' => 200,
@@ -378,7 +375,7 @@ class ToolbarServiceTest extends TestCase
      *
      * @return void
      */
-    public function testInjectScriptsNoModifyResponse()
+    public function testInjectScriptsNoModifyResponse(): void
     {
         $request = new Request([
             'url' => '/articles/view/123',
@@ -406,7 +403,7 @@ class ToolbarServiceTest extends TestCase
      *
      * @return void
      */
-    public function testIsEnabled()
+    public function testIsEnabled(): void
     {
         Configure::write('debug', true);
         $bar = new ToolbarService($this->events, []);
@@ -425,10 +422,10 @@ class ToolbarServiceTest extends TestCase
      * @return void
      */
     #[DataProvider('domainsProvider')]
-    public function testIsEnabledProductionEnv(string $domain, bool $isEnabled)
+    public function testIsEnabledProductionEnv(string $domain, bool $isEnabled): void
     {
         Configure::write('debug', true);
-        putenv("HTTP_HOST=$domain");
+        putenv('HTTP_HOST=' . $domain);
         $bar = new ToolbarService($this->events, []);
         $this->assertSame($isEnabled, $bar->isEnabled());
 
@@ -467,12 +464,12 @@ class ToolbarServiceTest extends TestCase
      *
      * @return void
      */
-    public function testIsEnabledProductionEnvCustomTld()
+    public function testIsEnabledProductionEnvCustomTld(): void
     {
         $domain = 'myapp.foobar';
         Configure::write('debug', true);
 
-        putenv("HTTP_HOST=$domain");
+        putenv('HTTP_HOST=' . $domain);
         $bar = new ToolbarService($this->events, []);
         $this->assertFalse($bar->isEnabled());
 
@@ -485,7 +482,7 @@ class ToolbarServiceTest extends TestCase
      *
      * @return void
      */
-    public function testIsEnabledForceEnable()
+    public function testIsEnabledForceEnable(): void
     {
         Configure::write('debug', false);
         $bar = new ToolbarService($this->events, ['forceEnable' => true]);
@@ -497,11 +494,11 @@ class ToolbarServiceTest extends TestCase
      *
      * @return void
      */
-    public function testIsEnabledForceEnableCallable()
+    public function testIsEnabledForceEnableCallable(): void
     {
         Configure::write('debug', false);
         $bar = new ToolbarService($this->events, [
-            'forceEnable' => function () {
+            'forceEnable' => function (): bool {
                 return true;
             },
         ]);
@@ -513,7 +510,7 @@ class ToolbarServiceTest extends TestCase
      *
      * @return void
      */
-    public function testSaveDataSerializationError()
+    public function testSaveDataSerializationError(): void
     {
         $request = new Request([
             'url' => '/articles',
@@ -534,7 +531,7 @@ class ToolbarServiceTest extends TestCase
             'className' => SimplePanel::class,
         ]);
         // Mock the data() method to return something problematic
-        $panel->setData(['closure' => fn() => 'test']);
+        $panel->setData(['closure' => fn(): string => 'test']);
 
         $row = $bar->saveData($request, $response);
         $this->assertNotEmpty($row, 'Should save data even with serialization errors');

--- a/tests/TestCase/View/Helper/CredentialsHelperTest.php
+++ b/tests/TestCase/View/Helper/CredentialsHelperTest.php
@@ -41,7 +41,7 @@ class CredentialsHelperTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -56,18 +56,17 @@ class CredentialsHelperTest extends TestCase
      *
      * @return void
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         unset($this->Helper);
     }
 
     /**
-     * @dataProvider credentialsProvider
      * @return void
      */
     #[DataProvider('credentialsProvider')]
-    public function testFilter($in, $out)
+    public function testFilter(string|array|null $in, string|array|null $out): void
     {
         $this->assertSame($out, $this->Helper->filter($in));
     }
@@ -77,7 +76,7 @@ class CredentialsHelperTest extends TestCase
      *
      * @return array input, expected output
      */
-    public static function credentialsProvider()
+    public static function credentialsProvider(): array
     {
         return [
             [null, null],

--- a/tests/TestCase/View/Helper/SimpleGraphHelperTest.php
+++ b/tests/TestCase/View/Helper/SimpleGraphHelperTest.php
@@ -41,7 +41,7 @@ class SimpleGraphHelperTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         Router::createRouteBuilder('/')->connect('/{controller}/{action}');
@@ -58,7 +58,7 @@ class SimpleGraphHelperTest extends TestCase
      *
      * @return void
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         unset($this->Graph);
@@ -69,7 +69,7 @@ class SimpleGraphHelperTest extends TestCase
      *
      * @return void
      */
-    public function testBar()
+    public function testBar(): void
     {
         $output = $this->Graph->bar(10, 0);
         $expected = [
@@ -94,7 +94,7 @@ class SimpleGraphHelperTest extends TestCase
      *
      * @return void
      */
-    public function testBarOffset()
+    public function testBarOffset(): void
     {
         $output = $this->Graph->bar(10, 10);
         $expected = [
@@ -119,7 +119,7 @@ class SimpleGraphHelperTest extends TestCase
      *
      * @return void
      */
-    public function testBarWithFloat()
+    public function testBarWithFloat(): void
     {
         $output = $this->Graph->bar(10.5, 10.5);
         $expected = [

--- a/tests/TestCase/View/Helper/ToolbarHelperTest.php
+++ b/tests/TestCase/View/Helper/ToolbarHelperTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
  */
 namespace DebugKit\Test\TestCase\View\Helper;
 
+use Cake\Error\Debug\NodeInterface;
 use Cake\Error\Debugger;
 use Cake\Http\ServerRequest as Request;
 use Cake\Routing\Router;
@@ -44,7 +45,7 @@ class ToolbarHelperTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         Router::createRouteBuilder('/')->connect('/{controller}/{action}');
@@ -61,17 +62,17 @@ class ToolbarHelperTest extends TestCase
      *
      * @return void
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         unset($this->Toolbar);
     }
 
-    public function testDumpNodesSorted()
+    public function testDumpNodesSorted(): void
     {
         $path = '//*[@class="cake-debug-array-item"]/*[@class="cake-debug-string"]';
         $data = ['z' => 1, 'a' => 99, 'm' => 123];
-        $nodes = array_map(function ($v) {
+        $nodes = array_map(function (int $v): NodeInterface {
             return Debugger::exportVarAsNodes($v);
         }, $data);
         $result = $this->Toolbar->dumpNodes($nodes);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -22,7 +22,7 @@ use Cake\TestSuite\Fixture\SchemaLoader;
 use DebugKit\DebugKitPlugin;
 use function Cake\Core\env;
 
-require_once 'vendor/autoload.php';
+require_once dirname(__DIR__) . '/vendor/autoload.php';
 
 // Path constants to a few helpful things.
 if (!defined('DS')) {

--- a/tests/test_app/Application.php
+++ b/tests/test_app/Application.php
@@ -41,7 +41,6 @@ class Application extends BaseApplication
     }
 
     /**
-     * @param \Cake\Routing\RouteBuilder $routes
      * @return void
      */
     public function routes(RouteBuilder $routes): void

--- a/tests/test_app/Controller/DebugKitTestController.php
+++ b/tests/test_app/Controller/DebugKitTestController.php
@@ -54,7 +54,7 @@ class DebugKitTestController extends Controller
      *
      * @return string
      */
-    public function request_action_return()
+    public function request_action_return(): string
     {
         $this->autoRender = false;
 
@@ -64,7 +64,7 @@ class DebugKitTestController extends Controller
     /**
      * Render Request Action
      */
-    public function request_action_render()
+    public function request_action_render(): void
     {
         $this->set('test', 'I have been rendered.');
     }

--- a/tests/test_app/Form/TestForm.php
+++ b/tests/test_app/Form/TestForm.php
@@ -36,7 +36,7 @@ class TestForm extends Form
         return $validator
             ->requirePresence('accept')
             ->add('accept', 'accept', [
-                'rule' => function ($value) {
+                'rule' => function ($value): string {
                     return 'always fail validation';
                 },
             ]);

--- a/tests/test_app/Panel/TestPanel.php
+++ b/tests/test_app/Panel/TestPanel.php
@@ -31,10 +31,8 @@ class TestPanel extends DebugPanel
 {
     /**
      * Startup
-     *
-     * @param Controller $controller
      */
-    public function startup(Controller $controller)
+    public function startup(Controller $controller): void
     {
         $controller->testPanel = true;
     }


### PR DESCRIPTION
This would be changed by rector if we added it to debug_kit. Would love to see this across all our plugins to get more consistency.

Woud be cool if we could somehow unify the rector config across repositories though.

The shared CI workflow also needs to be adjusted to execute rector (if its present)