### PR TITLE
Fix deprecations panel empty check, escape variables panel error, reset $data in serialize loop

### DIFF
--- a/src/ToolbarService.php
+++ b/src/ToolbarService.php
@@ -290,6 +290,7 @@ class ToolbarService
 
         foreach ($this->registry->loaded() as $name) {
             $panel = $this->registry->{$name};
+            $data = null;
             try {
                 $data = $panel->data();
 

--- a/templates/element/deprecations_panel.php
+++ b/templates/element/deprecations_panel.php
@@ -23,7 +23,7 @@
 
 use function Cake\Core\h;
 
-$hasAny = count($app) + count($plugins) + count($cake) + count($vendor);
+$hasAny = count($app) + count($plugins) + count($cake) + count($vendor) + count($other);
 
 $printer = function ($section, $data) {
 ?>
@@ -41,7 +41,7 @@ $printer = function ($section, $data) {
 }
 ?>
 <div class="c-deprecations-panel">
-    <?php if ($hasAny) : ?>
+    <?php if (!$hasAny) : ?>
         <p class="c-flash c-flash--info">No deprecations</p>
         <?php
     endif;

--- a/templates/element/variables_panel.php
+++ b/templates/element/variables_panel.php
@@ -18,11 +18,14 @@
  * @var array $variables
  * @var array $errors
  */
+
+use function Cake\Core\h;
+
 ?>
 <div class="c-variables-panel">
     <?php
     if (isset($error)) :
-        printf('<p class="c-flash c-flash--warning">%s</p>', $error);
+        printf('<p class="c-flash c-flash--warning">%s</p>', h($error));
     endif;
 
     if (isset($varsMaxDepth)) {

--- a/tests/TestCase/Controller/PanelsControllerTest.php
+++ b/tests/TestCase/Controller/PanelsControllerTest.php
@@ -99,6 +99,104 @@ class PanelsControllerTest extends TestCase
     }
 
     /**
+     * Deprecations panel renders the "No deprecations" flash only when
+     * every category is empty (including the `other` bucket, which was
+     * previously missing from the check).
+     *
+     * @return void
+     */
+    public function testViewDeprecationsPanelEmpty()
+    {
+        $request = $this->makeRequest();
+        $panel = $this->makePanel(
+            $request,
+            'DebugKit.Deprecations',
+            'Deprecations',
+            'DebugKit.deprecations_panel',
+            ['app' => [], 'cake' => [], 'vendor' => [], 'plugins' => [], 'other' => []],
+        );
+
+        $this->get("/debug-kit/panels/view/{$panel->id}");
+
+        $this->assertResponseOk();
+        $this->assertResponseContains('No deprecations');
+    }
+
+    /**
+     * @return void
+     */
+    public function testViewDeprecationsPanelWithEntries()
+    {
+        $request = $this->makeRequest();
+        $entry = ['niceFile' => 'src/Foo.php', 'line' => 1, 'message' => 'deprecated thing'];
+        $panel = $this->makePanel(
+            $request,
+            'DebugKit.Deprecations',
+            'Deprecations',
+            'DebugKit.deprecations_panel',
+            ['app' => [$entry], 'cake' => [], 'vendor' => [], 'plugins' => [], 'other' => []],
+        );
+
+        $this->get("/debug-kit/panels/view/{$panel->id}");
+
+        $this->assertResponseOk();
+        $this->assertResponseNotContains('No deprecations');
+        $this->assertResponseContains('deprecated thing');
+    }
+
+    /**
+     * Deprecations only present in the `other` bucket should also suppress
+     * the "No deprecations" flash. Guards against a regression of M3 where
+     * `count($other)` was missing from the empty-check sum.
+     *
+     * @return void
+     */
+    public function testViewDeprecationsPanelOtherOnly()
+    {
+        $request = $this->makeRequest();
+        $entry = ['niceFile' => 'src/Bar.php', 'line' => 2, 'message' => 'only-other deprecation'];
+        $panel = $this->makePanel(
+            $request,
+            'DebugKit.Deprecations',
+            'Deprecations',
+            'DebugKit.deprecations_panel',
+            ['app' => [], 'cake' => [], 'vendor' => [], 'plugins' => [], 'other' => [$entry]],
+        );
+
+        $this->get("/debug-kit/panels/view/{$panel->id}");
+
+        $this->assertResponseOk();
+        $this->assertResponseNotContains('No deprecations');
+        $this->assertResponseContains('only-other deprecation');
+    }
+
+    /**
+     * The Variables panel surfaces serialization-error messages from
+     * `ToolbarService`; those messages can echo back attacker-controlled
+     * data (e.g. via `__sleep` exceptions), so the template must escape
+     * them. Guards against a regression of M4.
+     *
+     * @return void
+     */
+    public function testViewVariablesPanelErrorIsEscaped()
+    {
+        $request = $this->makeRequest();
+        $panel = $this->makePanel(
+            $request,
+            'DebugKit.Variables',
+            'Variables',
+            'DebugKit.variables_panel',
+            ['error' => '<script>alert(1)</script>', 'variables' => [], 'errors' => []],
+        );
+
+        $this->get("/debug-kit/panels/view/{$panel->id}");
+
+        $this->assertResponseOk();
+        $this->assertResponseNotContains('<script>alert(1)</script>');
+        $this->assertResponseContains('&lt;script&gt;alert(1)&lt;/script&gt;');
+    }
+
+    /**
      * @return void
      */
     public function testLatestHistory()

--- a/tests/TestCase/ToolbarServiceTest.php
+++ b/tests/TestCase/ToolbarServiceTest.php
@@ -27,6 +27,7 @@ use Cake\TestSuite\TestCase;
 use DebugKit\Model\Entity\Request as RequestEntity;
 use DebugKit\Panel\SqlLogPanel;
 use DebugKit\TestApp\Panel\SimplePanel;
+use DebugKit\TestApp\Panel\ThrowingDataPanel;
 use DebugKit\ToolbarService;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -558,5 +559,53 @@ class ToolbarServiceTest extends TestCase
         $content = unserialize($simplePanel->content);
         $this->assertArrayHasKey('error', $content, 'Should have error key');
         $this->assertStringContainsString('SimplePanel', $content['error'], 'Error should mention panel name');
+    }
+
+    /**
+     * Test that saveData survives a panel whose data() method itself throws,
+     * not just one whose serialize() fails.
+     *
+     * @return void
+     */
+    public function testSaveDataPanelDataThrows()
+    {
+        $request = new Request([
+            'url' => '/articles',
+            'environment' => ['REQUEST_METHOD' => 'GET'],
+        ]);
+        $response = new Response([
+            'statusCode' => 200,
+            'type' => 'text/html',
+            'body' => '<html><title>test</title><body><p>some text</p></body>',
+        ]);
+
+        $bar = new ToolbarService($this->events, []);
+        $bar->loadPanels();
+        $bar->registry()->load('DebugKit.TestApp\Panel\ThrowingDataPanel', [
+            'className' => ThrowingDataPanel::class,
+        ]);
+
+        $row = $bar->saveData($request, $response);
+        $this->assertNotEmpty($row, 'Should save data even when a panel data() throws');
+
+        $requests = $this->getTableLocator()->get('DebugKit.Requests');
+        $result = $requests->find()
+            ->orderBy(['Requests.requested_at' => 'DESC'])
+            ->contain('Panels')
+            ->first();
+
+        $throwingPanel = null;
+        foreach ($result->panels as $p) {
+            if ($p->panel === 'DebugKit.TestApp\Panel\ThrowingDataPanel') {
+                $throwingPanel = $p;
+                break;
+            }
+        }
+
+        $this->assertNotNull($throwingPanel, 'ThrowingDataPanel should be present');
+        $content = unserialize($throwingPanel->content);
+        $this->assertArrayHasKey('error', $content);
+        $this->assertStringContainsString('ThrowingDataPanel', $content['error']);
+        $this->assertStringContainsString('Simulated data() failure', $content['error']);
     }
 }

--- a/tests/test_app/Panel/ThrowingDataPanel.php
+++ b/tests/test_app/Panel/ThrowingDataPanel.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ *
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+namespace DebugKit\TestApp\Panel;
+
+use DebugKit\DebugPanel;
+use RuntimeException;
+
+/**
+ * Test panel whose data() method throws, used to verify that
+ * ToolbarService::saveData() does not crash and produces a clean
+ * diagnostic when a panel's data collection itself fails.
+ */
+class ThrowingDataPanel extends DebugPanel
+{
+    public function data(): array
+    {
+        throw new RuntimeException('Simulated data() failure');
+    }
+}


### PR DESCRIPTION
## Summary

Three small correctness fixes surfaced during a 5.x audit:

* **DeprecationsPanel template** -- the empty-check sum was missing `count($other)`, and the surrounding condition was inverted so the *"No deprecations"* flash showed up exactly when deprecations existed. Adds `$other` to the sum and flips to `if (!$hasAny)`.

* **Variables panel template** -- `$error` came through `printf %s` unescaped. That message can carry serializer-exception text echoing back data from whatever variable failed to serialize, so it's now passed through `h()`. A `use function Cake\Core\h;` was added to match the convention used by sibling templates.

* **ToolbarService::saveData** -- `$data` was declared inside the per-panel `try`. When a panel's `data()` method itself threw (before the inner `serialize()`), the catch block's `gettype($data ?? null)` diagnostic reported the *previous* panel's data type instead of `NULL`. Reset `$data = null;` per loop iteration.

Regression coverage is added in `PanelsControllerTest` (empty / non-empty / `$other`-only deprecations, plus `<script>` escaping in the variables panel) and in `ToolbarServiceTest` (`data()` itself throwing, via a new `tests/test_app/Panel/ThrowingDataPanel.php` fixture).
