### PR TITLE
Nits + BC correctness fixes from 5.x audit (followup to #1072)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,12 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Method DebugKit\\Mailer\\Transport\\DebugKitTransport\:\:send\(\) should return array\{headers\: string, message\: string\} but returns array\{headers\: non\-empty\-array\<string, string\>, message\: array\{text\: string, html\: string\}\}\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Mailer/Transport/DebugKitTransport.php
-
-		-
 			message: '#^Parameter \#1 \$request of method DebugKit\\ToolbarService\:\:saveData\(\) expects Cake\\Http\\ServerRequest, Psr\\Http\\Message\\ServerRequestInterface given\.$#'
 			identifier: argument.type
 			count: 1

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -11,9 +11,6 @@
     </ImpureMethodCall>
   </file>
   <file src="src/Mailer/Transport/DebugKitTransport.php">
-    <InvalidReturnStatement>
-      <code><![CDATA[$result]]></code>
-    </InvalidReturnStatement>
     <NullArgument>
       <code><![CDATA[$this->emailLog]]></code>
     </NullArgument>

--- a/src/Controller/ToolbarController.php
+++ b/src/Controller/ToolbarController.php
@@ -46,6 +46,9 @@ class ToolbarController extends DebugKitController
         if (!$name) {
             throw new NotFoundException('Invalid cache engine name.');
         }
+        if (!Cache::getConfig($name)) {
+            throw new NotFoundException(sprintf('Unknown cache engine "%s".', $name));
+        }
         $success = Cache::clear($name);
         $message = $success ?
             sprintf('%s cache cleared.', $name) :

--- a/src/Mailer/Transport/DebugKitTransport.php
+++ b/src/Mailer/Transport/DebugKitTransport.php
@@ -7,6 +7,7 @@ use ArrayObject;
 use Cake\Core\App;
 use Cake\Mailer\AbstractTransport;
 use Cake\Mailer\Message;
+use InvalidArgumentException;
 
 /**
  * Debug Transport class, useful for emulating the email sending process and inspecting
@@ -37,6 +38,11 @@ class DebugKitTransport extends AbstractTransport
      */
     public function __construct(array $config = [], ?AbstractTransport $originalTransport = null)
     {
+        if (!isset($config['debugKitLog']) || !$config['debugKitLog'] instanceof ArrayObject) {
+            throw new InvalidArgumentException(
+                'DebugKitTransport requires a `debugKitLog` config entry of type `ArrayObject`.',
+            );
+        }
         $this->emailLog = $config['debugKitLog'];
 
         if ($originalTransport !== null) {
@@ -62,7 +68,17 @@ class DebugKitTransport extends AbstractTransport
     }
 
     /**
-     * @inheritDoc
+     * Capture the message into the in-memory email log and optionally forward
+     * to a wrapped real transport.
+     *
+     * Overrides the parent return shape: DebugKit stores the headers as an
+     * associative array (so the panel can render rows) and splits the body
+     * into text/html parts. Callers that consume this transport's return
+     * value directly must account for this richer shape.
+     *
+     * @param \Cake\Mailer\Message $message The message to capture.
+     * @return array
+     * @phpstan-return array{headers: array<string, string>, message: array{text: string, html: string}}|array<string, mixed>
      */
     public function send(Message $message): array
     {

--- a/src/Panel/RequestPanel.php
+++ b/src/Panel/RequestPanel.php
@@ -54,7 +54,7 @@ class RequestPanel extends DebugPanel
             'query' => Debugger::exportVarAsNodes($request->getQueryParams(), $maxDepth),
             'data' => Debugger::exportVarAsNodes($request->getData(), $maxDepth),
             'cookie' => Debugger::exportVarAsNodes($request->getCookieParams(), $maxDepth),
-            'get' => Debugger::exportVarAsNodes($_GET, $maxDepth),
+            'get' => Debugger::exportVarAsNodes($request->getQueryParams(), $maxDepth),
             'session' => Debugger::exportVarAsNodes($request->getSession()->read(), $maxDepth),
             'matchedRoute' => $request->getParam('_matchedRoute'),
             'headers' => [

--- a/src/ToolbarService.php
+++ b/src/ToolbarService.php
@@ -291,20 +291,22 @@ class ToolbarService
         foreach ($this->registry->loaded() as $name) {
             $panel = $this->registry->{$name};
             $data = null;
+            $handlerInstalled = false;
             try {
                 $data = $panel->data();
 
-                // Set error handler to catch warnings/errors during serialization
-                set_error_handler(function ($errno, $errstr) use ($name): void {
-                    throw new Exception("Serialization error in panel '{$name}': {$errstr}");
-                });
+                // Catch only warnings/notices raised during serialization; fatals
+                // and exceptions in __sleep/__serialize already surface as throws.
+                set_error_handler(
+                    function ($errno, $errstr) use ($name): bool {
+                        throw new Exception("Serialization error in panel '{$name}': {$errstr}");
+                    },
+                    E_WARNING | E_NOTICE | E_USER_WARNING | E_USER_NOTICE,
+                );
+                $handlerInstalled = true;
 
                 $content = serialize($data);
-
-                restore_error_handler();
             } catch (Exception $e) {
-                restore_error_handler();
-
                 $errorMessage = sprintf(
                     'Failed to serialize data for panel "%s": %s',
                     $name,
@@ -312,12 +314,16 @@ class ToolbarService
                 );
 
                 Log::warning($errorMessage);
-                Log::debug('Panel data type: ' . gettype($data ?? null));
+                Log::debug('Panel data type: ' . gettype($data));
 
                 $content = serialize([
                     'error' => $errorMessage,
                     'panel' => $name,
                 ]);
+            } finally {
+                if ($handlerInstalled) {
+                    restore_error_handler();
+                }
             }
             $row->panels[] = $requests->Panels->newEntity([
                 'panel' => $name,

--- a/src/View/Helper/CredentialsHelper.php
+++ b/src/View/Helper/CredentialsHelper.php
@@ -59,7 +59,7 @@ class CredentialsHelper extends Helper
         $link = $this->Html->tag('a', '******', [
             'class' => 'filtered-credentials',
             'title' => h($credentials),
-            'onclick' => 'this.innerHTML = this.title',
+            'onclick' => 'this.textContent = this.title',
         ]);
 
         return h($protocol) . $link . '@' . h($tail);

--- a/templates/element/packages_panel.php
+++ b/templates/element/packages_panel.php
@@ -54,7 +54,11 @@ use function Cake\Core\h;
                         </thead>
                         <tbody>
                         <?php foreach ($packages as $package) : ?>
-                            <?php extract($package); ?>
+                            <?php
+                            $name = (string)($package['name'] ?? '');
+                            $version = (string)($package['version'] ?? '');
+                            $description = (string)($package['description'] ?? '');
+                            ?>
                             <tr>
                                 <td title="<?= h($description) ?>">
                                     <a href="https://packagist.org/packages/<?= h($name) ?>"
@@ -85,7 +89,11 @@ use function Cake\Core\h;
                         </thead>
                         <tbody>
                         <?php foreach ($devPackages as $package) : ?>
-                            <?php extract($package); ?>
+                            <?php
+                            $name = (string)($package['name'] ?? '');
+                            $version = (string)($package['version'] ?? '');
+                            $description = (string)($package['description'] ?? '');
+                            ?>
                             <tr>
                                 <td title="<?= h($description) ?>">
                                     <a href="https://packagist.org/packages/<?= h($name) ?>"

--- a/templates/element/request_panel.php
+++ b/templates/element/request_panel.php
@@ -28,6 +28,7 @@
  */
 
 use Cake\Error\Debugger;
+use function Cake\Core\h;
 
 ?>
 <div class="c-request-panel">
@@ -36,8 +37,8 @@ use Cake\Error\Debugger;
         <p class="c-flash c-flash--warning">
             <?= sprintf(
                 'Headers already sent at file %s and line %d.',
-                $headers['file'],
-                $headers['line']
+                h($headers['file']),
+                (int)$headers['line']
             ) ?>
         </p>
     <?php endif; ?>

--- a/templates/element/routes_panel.php
+++ b/templates/element/routes_panel.php
@@ -45,7 +45,7 @@ foreach (CorePlugin::loaded() as $pluginName) {
             <button type="button" class="o-button js-toggle-plugin-route <?=
                     strpos($pluginName, 'DebugKit') === 0 ? ' is-active' : '' ?>"
                     data-plugin=".c-routes-panel__route-entry--plugin-<?= $parsedName ?>">
-                <?= $pluginName ?>
+                <?= h($pluginName) ?>
             </button>
         <?php endforeach; ?>
     </div>

--- a/templates/element/timer_panel.php
+++ b/templates/element/timer_panel.php
@@ -65,7 +65,7 @@ use function Cake\Core\h;
             <?php
             $rows = [];
             $end = end($timers);
-            $maxTime = $end['end'];
+            $maxTime = $end ? $end['end'] : 0;
 
             $i = 0;
             $values = array_values($timers);

--- a/tests/TestCase/Controller/ToolbarControllerTest.php
+++ b/tests/TestCase/Controller/ToolbarControllerTest.php
@@ -72,6 +72,19 @@ class ToolbarControllerTest extends TestCase
     }
 
     /**
+     * Posting an unknown cache engine name 404s instead of returning a
+     * misleading 200 with `success: false`.
+     *
+     * @return void
+     */
+    public function testClearCacheUnknownEngine()
+    {
+        $this->configRequest(['headers' => ['Accept' => 'application/json']]);
+        $this->post('/debug-kit/toolbar/clear-cache', ['name' => 'does-not-exist']);
+        $this->assertResponseCode(404);
+    }
+
+    /**
      * Test clearing the session.
      *
      * @return void

--- a/tests/TestCase/Mailer/Transport/DebugKitTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/DebugKitTransportTest.php
@@ -19,6 +19,7 @@ use Cake\Mailer\AbstractTransport;
 use Cake\Mailer\Message;
 use Cake\TestSuite\TestCase;
 use DebugKit\Mailer\Transport\DebugKitTransport;
+use InvalidArgumentException;
 
 class DebugKitTransportTest extends TestCase
 {
@@ -65,6 +66,21 @@ class DebugKitTransportTest extends TestCase
     public function testMethodProxy()
     {
         $this->assertSame('bloop', $this->transport->customMethod());
+    }
+
+    public function testConstructorRejectsMissingDebugKitLog()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('debugKitLog');
+
+        new DebugKitTransport([]);
+    }
+
+    public function testConstructorRejectsWrongDebugKitLogType()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new DebugKitTransport(['debugKitLog' => 'not-an-arrayobject']);
     }
 
     public function testEmailCapture()

--- a/tests/TestCase/View/Helper/CredentialsHelperTest.php
+++ b/tests/TestCase/View/Helper/CredentialsHelperTest.php
@@ -84,8 +84,8 @@ class CredentialsHelperTest extends TestCase
             [['value'], ['value']],
             ['http://example.com', 'http://example.com'],
             ['ssh://ssh.example.com', 'ssh://ssh.example.com'],
-            ['http://user@example.com', 'http://<a class="filtered-credentials" title="user" onclick="this.innerHTML = this.title">******</a>@example.com'],
-            ['http://user:pass@example.com', 'http://<a class="filtered-credentials" title="user:pass" onclick="this.innerHTML = this.title">******</a>@example.com'],
+            ['http://user@example.com', 'http://<a class="filtered-credentials" title="user" onclick="this.textContent = this.title">******</a>@example.com'],
+            ['http://user:pass@example.com', 'http://<a class="filtered-credentials" title="user:pass" onclick="this.textContent = this.title">******</a>@example.com'],
         ];
     }
 }


### PR DESCRIPTION
## Summary

Followup to #1072 -- the rest of the small, fully BC items from the same 5.x audit pass, bundled together.

**Nits**

- `CredentialsHelper::filter()` -- click handler swapped from `this.innerHTML = this.title` to `this.textContent = this.title`. A credential URL whose userinfo portion ever decodes to HTML cannot render live markup when the asterisks are revealed.
- `ToolbarController::clearCache()` -- if the posted engine name is not configured, throw `NotFoundException` instead of replying `200 / success: false`. The 200/false combo was the only path where the endpoint silently misreported failure.
- `RequestPanel` -- collect the GET payload via `$request->getQueryParams()` instead of `$_GET` so the panel reflects the request as middleware sees it, consistent with how the `query` key is already collected one line above.
- Templates -- escape `$pluginName` in `routes_panel`, escape the file path in `request_panel`'s "headers already sent" warning, guard `end($timers)` against an empty timers array in `timer_panel`, and replace `extract($package)` in `packages_panel` with explicit destructuring so a future composer.lock schema key cannot clobber template locals.

**BC correctness**

- `DebugKitTransport::send()` -- override the parent return-type docblock with the actual shape (assoc headers array + text/html message split). Runtime return value is unchanged; this just stops static analysis from papering over the LSP gap and lets the PHPStan baseline entry be removed.
- `DebugKitTransport::__construct()` -- reject construction without a valid `debugKitLog` `ArrayObject` up front with `InvalidArgumentException`. Today the missing-key path fatals with a downstream `TypeError` on the property assignment; this gives a clear, actionable message instead.
- `ToolbarService::saveData()` -- move `restore_error_handler()` into a `finally` block (guarded by an `$handlerInstalled` flag so it can't pop a handler that was never installed), and narrow the captured error mask to `E_WARNING | E_NOTICE | E_USER_WARNING | E_USER_NOTICE`. Previously any warning raised during the `serialize()` call, including ones from unrelated userland code touched during serialization, was mis-reported as a panel-serialization failure.

**Baseline**

Removes the now-stale DebugKitTransport return-type entry from `phpstan-baseline.neon`.

Tests added: `CredentialsHelper` data provider updated for the new onclick; `ToolbarControllerTest` gains an unknown-engine 404 case; `DebugKitTransportTest` gains two constructor-rejection cases (missing key, wrong type).
