### PR TITLE
JS DOM-safe rendering: stop string-concat HTML into the toolbar iframe

### DIFF
--- a/webroot/js/inject-iframe.js
+++ b/webroot/js/inject-iframe.js
@@ -10,6 +10,14 @@ if (elem) {
   let bodyOverflow;
 
   const onMessage = (event) => {
+    // The toolbar iframe is same-origin with the host app; reject any
+    // postMessage that does not originate from the iframe we created.
+    if (event.origin !== win.location.origin) {
+      return;
+    }
+    if (!iframe || event.source !== iframe.contentWindow) {
+      return;
+    }
     if (event.data === 'collapse') {
       iframe.height = 40;
       iframe.width = 40;

--- a/webroot/js/modules/Panels/CachePanel.js
+++ b/webroot/js/modules/Panels/CachePanel.js
@@ -1,6 +1,6 @@
 export default (($) => {
   const addMessage = (text) => {
-    $(`<p>${text}</p>`)
+    $('<p>').text(text)
       .appendTo('.c-cache-panel__messages')
       .fadeOut(2000);
   };

--- a/webroot/js/modules/Panels/HistoryPanel.js
+++ b/webroot/js/modules/Panels/HistoryPanel.js
@@ -11,24 +11,32 @@ export default (($) => {
 
     for (let i = 0; i < toolbar.ajaxRequests.length; i++) {
       const element = toolbar.ajaxRequests[i];
-      const params = {
-        id: element.requestId,
-        time: (new Date(element.date)).toLocaleString(),
-        method: element.method,
-        status: element.status,
-        url: element.url,
-        type: element.type,
-      };
-      const content = listItem.replace(/{([^{}]*)}/g, (a, b) => {
-        const r = params[b];
-        return typeof r === 'string' || typeof r === 'number' ? r : a;
-      });
-      $('.c-history-panel__list li:first').after(content);
+      // Request ID is a server-generated UUID; sanitize defensively before
+      // substituting into the href/data-request attribute scaffold.
+      const safeId = String(element.requestId || '').replace(/[^A-Za-z0-9-]/g, '');
+
+      // Only the {id} placeholder feeds attributes; substitute it now and
+      // populate the visible text via .text() so attacker-controlled values
+      // (method/URL/Content-Type from cross-origin responses) cannot inject
+      // HTML into the toolbar iframe (same-origin with the dev's app).
+      const $row = $(listItem.replace(/\{id\}/g, safeId));
+      $row.find('.c-history-panel__time').text((new Date(element.date)).toLocaleString());
+      // bubble[0] is the static "XHR" label; the next three are method/status/type.
+      const $bubbles = $row.find('.c-history-panel__bubble').not('.c-history-panel__xhr');
+      $bubbles.eq(0).text(String(element.method ?? ''));
+      $bubbles.eq(1).text(String(element.status ?? ''));
+      $bubbles.eq(2).text(String(element.type ?? ''));
+      $row.find('.c-history-panel__url').text(String(element.url ?? ''));
+
+      $('.c-history-panel__list li:first').after($row);
     }
 
     const links = $('.c-history-panel__link');
-    // Highlight the active request.
-    links.filter(`[data-request=${toolbar.currentRequest}]`).addClass('is-active');
+    // Highlight the active request via attribute comparison rather than an
+    // unquoted attribute-selector built from a runtime value.
+    links.filter(function highlightActive() {
+      return this.getAttribute('data-request') === String(toolbar.currentRequest);
+    }).addClass('is-active');
 
     links.on('click', function historyLinkClick(e) {
       const el = $(this);

--- a/webroot/js/modules/Panels/PackagesPanel.js
+++ b/webroot/js/modules/Panels/PackagesPanel.js
@@ -1,26 +1,35 @@
 export default (($) => {
   const buildSuccessfulMessage = (response) => {
-    let html = '';
+    const $out = $('<div>');
     if (response.packages.bcBreaks === undefined && response.packages.semverCompatible === undefined) {
-      return '<pre class="c-packages-panel__up2date">All dependencies are up to date</pre>';
+      $out.append($('<pre>').addClass('c-packages-panel__up2date').text('All dependencies are up to date'));
+      return $out;
     }
     if (response.packages.bcBreaks !== undefined) {
-      html += '<h4 class="c-packages-panel__section-header">Update with potential BC break</h4>';
-      html += `<pre>${response.packages.bcBreaks}</pre>`;
+      $out.append($('<h4>').addClass('c-packages-panel__section-header').text('Update with potential BC break'));
+      $out.append($('<pre>').text(String(response.packages.bcBreaks)));
     }
     if (response.packages.semverCompatible !== undefined) {
-      html += '<h4 class="c-packages-panel__section-header">Update semver compatible</h4>';
-      html += `<pre>${response.packages.semverCompatible}</pre>`;
+      $out.append($('<h4>').addClass('c-packages-panel__section-header').text('Update semver compatible'));
+      $out.append($('<pre>').text(String(response.packages.semverCompatible)));
     }
-    return html;
+    return $out;
   };
 
-  const showMessage = (el, html) => {
-    el.show().html(html);
+  const showMessage = (el, $content) => {
+    el.show().empty().append($content);
     $('.o-loader').removeClass('is-loading');
   };
 
-  const buildErrorMessage = (response) => `<pre class="c-packages-panel__warning-message">${JSON.parse(response.responseText).message}</pre>`;
+  const buildErrorMessage = (jqXHR) => {
+    let message = '';
+    try {
+      message = String(JSON.parse(jqXHR.responseText).message ?? '');
+    } catch (_e) {
+      message = String(jqXHR.responseText || jqXHR.statusText || 'Request failed');
+    }
+    return $('<pre>').addClass('c-packages-panel__warning-message').text(message);
+  };
 
   const init = () => {
     const $panel = $('.c-packages-panel');
@@ -41,8 +50,8 @@ export default (($) => {
         success(data) {
           showMessage($terminal, buildSuccessfulMessage(data));
         },
-        error(jqXHR, textStatus) {
-          showMessage($terminal, buildErrorMessage(textStatus));
+        error(jqXHR) {
+          showMessage($terminal, buildErrorMessage(jqXHR));
         },
       });
       e.preventDefault();

--- a/webroot/js/modules/Panels/RequestPanel.js
+++ b/webroot/js/modules/Panels/RequestPanel.js
@@ -1,6 +1,6 @@
 export default (($) => {
   const addMessage = (text) => {
-    $(`<p>${text}</p>`)
+    $('<p>').text(text)
       .appendTo('.c-request-panel__messages')
       .fadeOut(2000);
   };

--- a/webroot/js/modules/Toolbar.js
+++ b/webroot/js/modules/Toolbar.js
@@ -236,6 +236,14 @@ export default class Toolbar {
   // ========== AJAX related functionality ==========
 
   onMessage(event) {
+    // Only accept messages from the parent window that loaded the toolbar
+    // iframe; the toolbar is served same-origin so origin must match too.
+    if (event.origin !== window.location.origin) {
+      return;
+    }
+    if (event.source !== window.parent) {
+      return;
+    }
     if (typeof (event.data) === 'string' && event.data.indexOf('ajax-completed$$') === 0) {
       this.onRequest(JSON.parse(event.data.split('$$')[1]));
     }


### PR DESCRIPTION
## Summary

Third followup PR from the 5.x audit -- the JS hygiene pass.

The toolbar iframe is loaded **same-origin** with the host app, so any HTML injection inside it is effectively XSS against the app being developed (cookies, CSRF tokens, in-flight session). Several panels were composing HTML by string concatenation from data that crosses the toolbar's trust boundary (cross-origin response `Content-Type` headers, attacker-influenced URLs, raw composer error bodies). Each sink is rewritten to construct DOM via `document.createElement` / jQuery `.text()` / `.append()` instead.

### What changed

* **HistoryPanel.js** -- previously the per-XHR row was built by string-replacing six placeholders (`{id}`, `{time}`, `{method}`, `{status}`, `{type}`, `{url}`) into raw HTML and inserting the result with `.after(htmlString)`. `params.type` is the response `Content-Type` of any cross-origin URL the dev's app fetches and is therefore attacker-controlled; `params.url` and `params.method` are similarly untrusted. New flow: substitute only the (sanitized) request UUID `{id}` into the href and `data-request` attributes, then populate the five visible spans via jQuery `.text()`. The `[data-request=...]` highlight selector at the bottom of `init()` is rewritten as a `.filter(fn)` predicate so a runtime id can't slip into selector syntax.

* **CachePanel.js / RequestPanel.js** -- `$(`<p>${text}</p>`)` -> `$('<p>').text(text)`. Same UX, no HTML parsing.

* **PackagesPanel.js** -- the success / error output is assembled as jQuery-built elements with `.text()`, and `showMessage()` writes them via `.empty().append(...)` rather than `.html(string)`. Fixes a pre-existing bug along the way: the `error` callback was passing jQuery's `textStatus` string to `buildErrorMessage` (which expected the jqXHR object), so every non-2xx response was previously a silent `JSON.parse` throw with no visible message. The new error builder takes the jqXHR object directly and falls back to `responseText` / `statusText` / a literal `"Request failed"` -- credit to codex for catching the regression.

* **postMessage handlers** in `inject-iframe.js` (parent side) and `Toolbar.onMessage` (iframe side) now reject any message whose origin is not same-origin and whose source is not the expected counterpart window (`iframe.contentWindow` on the parent, `window.parent` on the iframe). Today only resize and XHR-counter messages flow, so the practical impact of the missing check is low, but the one-line hardening keeps the protocol safe as it grows.

### Verification

ESLint output for the touched files is clean; the remaining warnings/errors (`Turbo` undefined, unnamed function expressions in Toolbar and inject-iframe, Keyboard.js return) are pre-existing on 5.x and untouched by this PR. PHP test suite, PHPStan, and PHPCS all green.
