### PR TITLE
Add security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,15 +2,9 @@
 
 ## Supported Versions
 
-We support fixing security issues on the following releases:
-
-| Version | Supported          | Security fixes until
-| ------- | ------------------ | --------------------
-| 5.x     | :white_check_mark: | Currently supported
-| 4.x     | :white_check_mark: | 36 Months after the release of CakePHP 5.0 (09 Sep 2026)
-| 3.x     | :x:                | No longer supported
-| 2.x     | :x:                | No longer supported
-| 1.x     | :x:                | No longer supported
+Security fixes are applied to all active versions listed in the
+[version map](https://github.com/cakephp/debug_kit/wiki#version-map).
+Versions marked as EOL no longer receive fixes.
 
 ## Reporting a Vulnerability
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+We support fixing security issues on the following releases:
+
+| Version | Supported          | Security fixes until
+| ------- | ------------------ | --------------------
+| 5.x     | :white_check_mark: | Currently supported
+| 4.x     | :white_check_mark: | 36 Months after the release of CakePHP 5.0 (09 Sep 2026)
+| 3.x     | :x:                | No longer supported
+| 2.x     | :x:                | No longer supported
+| 1.x     | :x:                | No longer supported
+
+## Reporting a Vulnerability
+
+If you've found a security issue in CakePHP DebugKit, please use the following
+procedure instead of the normal bug reporting system. Instead of using the bug
+tracker, or one of the support forums please send an email to
+security [at] cakephp.org. Emails sent to this address go to the CakePHP core
+team on a private mailing list.
+
+For each report, we try to first confirm the vulnerability. Once confirmed,
+the CakePHP team will take the following actions:
+
+* Acknowledge to the reporter that we've received the issue, and are
+  working on a fix. We ask that the reporter keep the issue confidential until we announce it.
+* Get a fix/patch prepared.
+* Prepare a post describing the vulnerability, and the possible exploits.
+* Release new versions of all affected versions.
+* Prominently feature the problem in the release announcement


### PR DESCRIPTION
## Summary

Add a security policy to document supported versions and the vulnerability reporting process.

## Major Changes

- Added `.github/SECURITY.md` with ~~supported version table~~ reference to version table in wiki and vulnerability reporting instructions

## Minor Changes

None.

## Backwards Compatibility Notes

No breaking changes. This is a documentation-only addition.

## Work Remaining

None.

## Test Plan

N/A - documentation only.