### PR TITLE
Constrain classes further in MailPreview controller

### DIFF
--- a/src/Controller/MailPreviewController.php
+++ b/src/Controller/MailPreviewController.php
@@ -23,6 +23,7 @@ use Cake\Http\Exception\NotFoundException;
 use Cake\Routing\Router;
 use Cake\Utility\Inflector;
 use DebugKit\Mailer\AbstractResult;
+use DebugKit\Mailer\MailPreview;
 use DebugKit\Mailer\PreviewResult;
 use DebugKit\Mailer\SentMailResult;
 use Psr\Http\Message\ResponseInterface;
@@ -261,18 +262,21 @@ class MailPreviewController extends DebugKitController
      *
      * @param string $previewName The Mailer name
      * @param string $emailName The mailer preview method
-     * @param string $plugin The plugin where the mailer preview should be found
+     * @param ?string $plugin The plugin where the mailer preview should be found
      * @return \DebugKit\Mailer\PreviewResult The result of the email preview
      * @throws \Cake\Http\Exception\NotFoundException
      */
-    protected function findPreview(string $previewName, string $emailName, string $plugin = ''): PreviewResult
+    protected function findPreview(string $previewName, string $emailName, ?string $plugin = ''): PreviewResult
     {
         if ($plugin) {
             $plugin = "$plugin.";
         }
+        if (str_contains($previewName, '\\')) {
+            throw new NotFoundException("Mailer preview $previewName not found");
+        }
 
         $realClass = App::className($plugin . $previewName, 'Mailer/Preview');
-        if (!$realClass) {
+        if (!$realClass || !is_subclass_of($realClass, MailPreview::class, true)) {
             throw new NotFoundException("Mailer preview $previewName not found");
         }
         /** @var \DebugKit\Mailer\MailPreview $mailPreview */

--- a/src/Controller/MailPreviewController.php
+++ b/src/Controller/MailPreviewController.php
@@ -266,7 +266,7 @@ class MailPreviewController extends DebugKitController
      * @return \DebugKit\Mailer\PreviewResult The result of the email preview
      * @throws \Cake\Http\Exception\NotFoundException
      */
-    protected function findPreview(string $previewName, string $emailName, ?string $plugin = ''): PreviewResult
+    protected function findPreview(string $previewName, string $emailName, ?string $plugin = null): PreviewResult
     {
         if ($plugin) {
             $plugin = "$plugin.";

--- a/tests/TestCase/Controller/MailPreviewControllerTest.php
+++ b/tests/TestCase/Controller/MailPreviewControllerTest.php
@@ -40,6 +40,20 @@ class MailPreviewControllerTest extends TestCase
         $this->assertResponseContains('src="?part=html&plugin=DebugkitTestPlugin');
     }
 
+    /**
+     * Test that invalid classnames are rejected
+     *
+     * @return void
+     */
+    public function testEmailRejectInvalidClassName()
+    {
+        $this->get('/debug-kit/mail-preview/preview/Cake\Utility\Inflector/slug');
+        $this->assertResponseCode(404);
+
+        $this->get('/debug-kit/mail-preview/preview/Invalid/hello');
+        $this->assertResponseCode(404);
+    }
+
     /** Test email template content
      *
      * @return void


### PR DESCRIPTION
This controller should not attempt to load classes with `\` in the name, nor should it attempt to load classes that do not extedn `MailPreview`.

Thanks to Volker Dusch and the PHP Ecosystem security team for reporting this.