### PR TITLE
Constrain classes further in MailPreview controller (#1078)

### DIFF
--- a/src/Controller/MailPreviewController.php
+++ b/src/Controller/MailPreviewController.php
@@ -22,6 +22,7 @@ use Cake\Http\Exception\NotFoundException;
 use Cake\Routing\Router;
 use Cake\Utility\Inflector;
 use DebugKit\Mailer\AbstractResult;
+use DebugKit\Mailer\MailPreview;
 use DebugKit\Mailer\PreviewResult;
 use DebugKit\Mailer\SentMailResult;
 
@@ -255,7 +256,7 @@ class MailPreviewController extends DebugKitController
      *
      * @param string $previewName The Mailer name
      * @param string $emailName The mailer preview method
-     * @param string $plugin The plugin where the mailer preview should be found
+     * @param null|string $plugin The plugin where the mailer preview should be found
      * @return \DebugKit\Mailer\PreviewResult The result of the email preview
      * @throws \Cake\Http\Exception\NotFoundException
      */
@@ -264,9 +265,12 @@ class MailPreviewController extends DebugKitController
         if ($plugin) {
             $plugin = "$plugin.";
         }
+        if (str_contains($previewName, '\\')) {
+            throw new NotFoundException("Mailer preview $previewName not found");
+        }
 
         $realClass = App::className($plugin . $previewName, 'Mailer/Preview');
-        if (!$realClass) {
+        if (!$realClass || !is_subclass_of($realClass, MailPreview::class, true)) {
             throw new NotFoundException("Mailer preview ${previewName} not found");
         }
         $mailPreview = new $realClass();

--- a/tests/TestCase/Controller/MailPreviewControllerTest.php
+++ b/tests/TestCase/Controller/MailPreviewControllerTest.php
@@ -54,6 +54,20 @@ class MailPreviewControllerTest extends TestCase
         $this->assertResponseContains('src="?part=html&plugin=DebugkitTestPlugin');
     }
 
+    /**
+     * Test that invalid classnames are rejected
+     *
+     * @return void
+     */
+    public function testEmailRejectInvalidClassName()
+    {
+        $this->get('/debug-kit/mail-preview/preview/Cake\Utility\Inflector/slug');
+        $this->assertResponseCode(404);
+
+        $this->get('/debug-kit/mail-preview/preview/Invalid/hello');
+        $this->assertResponseCode(404);
+    }
+
     /** Test email template content
      *
      * @return void

--- a/tests/test_app/Mailer/Preview/Invalid.php
+++ b/tests/test_app/Mailer/Preview/Invalid.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace DebugKit\TestApp\Mailer\Preview;
+
+/**
+ * Stub class that is not a valid mailer preview.
+ */
+class Invalid
+{
+    public function hello(): string
+    {
+        return 'hello';
+    }
+}


### PR DESCRIPTION
This controller should not attempt to load classes with `\` in the name, nor should it attempt to load classes that do not extedn `MailPreview`.

Thanks to Volker Dusch and the PHP Ecosystem security team for reporting this.

Backport from 5.x