### PR TITLE
Add missing cache engine method proxies

### DIFF
--- a/src/Cache/Engine/DebugEngine.php
+++ b/src/Cache/Engine/DebugEngine.php
@@ -155,6 +155,21 @@ class DebugEngine extends CacheEngine
     /**
      * @inheritDoc
      */
+    public function add(string $key, mixed $value): bool
+    {
+        $start = microtime(true);
+        $result = $this->_engine->add($key, $value);
+        $duration = microtime(true) - $start;
+
+        $this->track('set');
+        $this->log('add', $duration, $key);
+
+        return $result;
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function setMultiple($values, $ttl = null): bool
     {
         $start = microtime(true);
@@ -182,6 +197,25 @@ class DebugEngine extends CacheEngine
 
         $this->track("get {$metric}");
         $this->log('get', $duration, $key);
+
+        return $result;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function has(string $key): bool
+    {
+        $start = microtime(true);
+        $result = $this->_engine->has($key);
+        $duration = microtime(true) - $start;
+        $metric = 'hit';
+        if (!$result) {
+            $metric = 'miss';
+        }
+
+        $this->track("get {$metric}");
+        $this->log('has', $duration, $key);
 
         return $result;
     }

--- a/tests/TestCase/Cache/Engine/DebugEngineTest.php
+++ b/tests/TestCase/Cache/Engine/DebugEngineTest.php
@@ -100,17 +100,20 @@ class DebugEngineTest extends TestCase
     public function testProxyMethodsTracksMetrics()
     {
         $this->engine->get('key');
+        $this->engine->has('key');
         $this->engine->set('key', 'value');
         $this->engine->get('key');
+        $this->engine->has('key');
+        $this->engine->add('new-key', 'value');
         $this->engine->delete('key');
         $this->engine->increment('key');
         $this->engine->decrement('key');
 
         $result = $this->engine->metrics();
-        $this->assertSame(3, $result['set']);
+        $this->assertSame(4, $result['set']);
         $this->assertSame(1, $result['delete']);
-        $this->assertSame(1, $result['get miss']);
-        $this->assertSame(1, $result['get hit']);
+        $this->assertSame(2, $result['get miss']);
+        $this->assertSame(2, $result['get hit']);
     }
 
     /**
@@ -121,7 +124,9 @@ class DebugEngineTest extends TestCase
     public function testProxyMethodLogs()
     {
         $this->engine->get('key');
+        $this->engine->has('key');
         $this->engine->set('key', 'value');
+        $this->engine->add('new-key', 'value');
         $this->engine->delete('key');
         $this->engine->increment('key');
         $this->engine->decrement('key');
@@ -131,9 +136,11 @@ class DebugEngineTest extends TestCase
         $this->engine->clearGroup('group');
 
         $logs = $this->logger->read();
-        $this->assertCount(9, $logs);
+        $this->assertCount(11, $logs);
         $this->assertStringStartsWith('info: :test: get `key`', $logs[0]);
-        $this->assertStringStartsWith('info: :test: set `key`', $logs[1]);
+        $this->assertStringStartsWith('info: :test: has `key`', $logs[1]);
+        $this->assertStringStartsWith('info: :test: set `key`', $logs[2]);
+        $this->assertStringStartsWith('info: :test: add `new-key`', $logs[3]);
     }
 
     /**


### PR DESCRIPTION
When the Cache panel is enabled, the engine is wrapped into a DebugEngine, which has an empty configuration. Calling add() or has() on this engine generates a warning on a missing prefix key and overall does nothing.

```
2026-08-13 14:22:44 warning: Undefined array key "prefix" in /Users/michele/fatturaelettronicapa/vendor/cakephp/cakephp/src/Cache/CacheEngine.php on line 373
Trace:
Cake\Error\ErrorTrap->handleError() /Users/michele/fatturaelettronicapa/vendor/cakephp/cakephp/src/Cache/CacheEngine.php, line 373
Cake\Cache\CacheEngine->_key() /Users/michele/fatturaelettronicapa/vendor/cakephp/cakephp/src/Cache/CacheEngine.php, line 304
Cake\Cache\CacheEngine->add() /Users/michele/fatturaelettronicapa/vendor/cakephp/cakephp/src/Cache/Cache.php, line 605
Cake\Cache\Cache::add() /Users/michele/fatturaelettronicapa/vendor/cakephp/queue/src/QueueManager.php, line 296
[...]
``` 

This fixes #1083 